### PR TITLE
Adding missing plug-ins and GEF SDK feature to update site

### DIFF
--- a/org.eclipse.gef.repository/category.xml
+++ b/org.eclipse.gef.repository/category.xml
@@ -15,6 +15,15 @@
    <feature id="org.eclipse.draw2d-feature">
       <category name="GEF"/>
    </feature>
+   <feature id="org.eclipse.gef.sdk">
+      <category name="GEF"/>
+   </feature>
+   <bundle id="org.eclipse.zest.examples">
+      <category name="GEF"/>
+   </bundle>
+   <bundle id="org.eclipse.draw2d.examples">
+      <category name="GEF"/>
+   </bundle>
    <category-def name="GEF" label="GEF (Graphical Editing Framework) Classic">
       <description>
          Draw2d, GEF (MVC), and Zest runtime, SDK, examples, and sources

--- a/pom.xml
+++ b/pom.xml
@@ -347,13 +347,14 @@
 		<module>org.eclipse.gef.tests</module>
 		
 		<!--examples-->
-		
+		<module>org.eclipse.draw2d.examples</module>
 		<module>org.eclipse.gef.examples.flow</module>
 		<module>org.eclipse.gef.examples.logic</module>
 		<module>org.eclipse.gef.examples.shapes</module>
 		<module>org.eclipse.gef.examples.text</module>
 		<module>org.eclipse.gef.examples.ui.capabilities</module>
 		<module>org.eclipse.gef.examples.ui.pde</module>
+		<module>org.eclipse.zest.examples</module>
 		
 	
 	<!--features-->


### PR DESCRIPTION
This commits adds the following to the update:

gef-sdk feature
zest.examples plugin
draw2d.examples plugin

Fixes #9