### PR TITLE
More version alignments for the 3.13.0 release

### DIFF
--- a/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.examples
-Bundle-Version: 3.11.100.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.draw2d;bundle-version="[3.2.0,4.0.0)"
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.gef.examples-feature/feature.xml
+++ b/org.eclipse.gef.examples-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gef.examples"
       label="%featureName"
-      version="3.12.100.qualifier"
+      version="3.13.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef.examples.logic"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.repository/category.xml
+++ b/org.eclipse.gef.repository/category.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.gef.examples_3.12.100.qualifier.jar" id="org.eclipse.gef.examples" version="3.12.100.qualifier">
-      <category name="gef"/>
-   </feature>
    <feature id="org.eclipse.gef-feature">
       <category name="gef"/>
    </feature>
@@ -16,6 +13,9 @@
       <category name="zest"/>
    </feature>
    <feature id="org.eclipse.gef.sdk-feature">
+      <category name="gef"/>
+   </feature>
+   <feature id="org.eclipse.gef.examples">
       <category name="gef"/>
    </feature>
    <bundle id="org.eclipse.zest.examples">

--- a/org.eclipse.zest.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.examples
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 3.13.0.qualifier
+Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.pde,

--- a/org.eclipse.zest.examples/build.properties
+++ b/org.eclipse.zest.examples/build.properties
@@ -10,7 +10,8 @@
 ###############################################################################
 bin.includes = plugin.*,\
                .,\
-               META-INF/
+               META-INF/,\
+               plugin.properties
 jars.compile.order = .
 source.. = src/
 output.. = bin/


### PR DESCRIPTION
Examples versions are aligned with feature and release number
gef-example feature number has been changed to 3.13
Missing build.properties entry added