### PR TITLE
Keep  keep original feature IDs intact

### DIFF
--- a/org.eclipse.draw2d-feature/feature.xml
+++ b/org.eclipse.draw2d-feature/feature.xml
@@ -10,7 +10,7 @@
         IBM Corporation - initial API and implementation
  -->
 <feature
-      id="org.eclipse.draw2d-feature"
+      id="org.eclipse.draw2d"
       label="%featureName"
       version="3.13.0.qualifier"
       provider-name="%providerName"

--- a/org.eclipse.draw2d.sdk-feature/feature.xml
+++ b/org.eclipse.draw2d.sdk-feature/feature.xml
@@ -10,7 +10,7 @@
         IBM Corporation - initial API and implementation
  -->
 <feature
-      id="org.eclipse.draw2d.sdk-feature"
+      id="org.eclipse.draw2d.sdk"
       label="%featureName"
       version="3.13.0.qualifier"
       provider-name="%providerName"
@@ -36,7 +36,7 @@
    </url>
 
    <includes
-         id="org.eclipse.draw2d-feature"
+         id="org.eclipse.draw2d"
          version="0.0.0"/>
 
    <plugin

--- a/org.eclipse.gef-feature/feature.xml
+++ b/org.eclipse.gef-feature/feature.xml
@@ -10,7 +10,7 @@
         IBM Corporation - initial API and implementation
  -->
 <feature
-      id="org.eclipse.gef-feature"
+      id="org.eclipse.gef"
       label="%featureName"
       version="3.13.0.qualifier"
       provider-name="%providerName"
@@ -36,7 +36,7 @@
    </url>
 
    <includes
-         id="org.eclipse.draw2d-feature"
+         id="org.eclipse.draw2d"
          version="0.0.0"/>
 
    <requires>

--- a/org.eclipse.gef.repository/category.xml
+++ b/org.eclipse.gef.repository/category.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.gef-feature">
+   <feature id="org.eclipse.gef">
       <category name="gef"/>
    </feature>
-   <feature id="org.eclipse.gef-feature.source">
+   <feature id="org.eclipse.gef.source">
       <category name="gef"/>
    </feature>
-   <feature id="org.eclipse.draw2d-feature">
+   <feature id="org.eclipse.draw2d">
       <category name="draw2d"/>
    </feature>
-   <feature id="org.eclipse.draw2d-feature.source">
+   <feature id="org.eclipse.draw2d.source">
       <category name="draw2d"/>
    </feature>
-   <feature id="org.eclipse.zest-feature">
+   <feature id="org.eclipse.zest">
       <category name="zest"/>
    </feature>
-   <feature id="org.eclipse.zest-feature.source">
+   <feature id="org.eclipse.zest.source">
       <category name="zest"/>
    </feature>
-   <feature id="org.eclipse.zest.sdk-feature">
+   <feature id="org.eclipse.zest.sdk">
       <category name="zest"/>
    </feature>
-   <feature id="org.eclipse.gef.sdk-feature">
+   <feature id="org.eclipse.gef.sdk">
       <category name="gef"/>
    </feature>
    <feature id="org.eclipse.gef.examples">
@@ -29,6 +29,9 @@
    </feature>
    <feature id="org.eclipse.gef.examples.source">
       <category name="gef"/>
+   </feature>
+   <feature id="org.eclipse.draw2d.sdk">
+      <category name="draw2d"/>
    </feature>
    <bundle id="org.eclipse.zest.examples">
       <category name="zest"/>

--- a/org.eclipse.gef.sdk-feature/feature.xml
+++ b/org.eclipse.gef.sdk-feature/feature.xml
@@ -10,7 +10,7 @@
         IBM Corporation - initial API and implementation
  -->
 <feature
-      id="org.eclipse.gef.sdk-feature"
+      id="org.eclipse.gef.sdk"
       label="%featureName"
       version="3.13.0.qualifier"
       provider-name="%providerName"
@@ -36,11 +36,11 @@
    </url>
 
    <includes
-         id="org.eclipse.gef-feature"
+         id="org.eclipse.gef"
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.draw2d-feature"
+         id="org.eclipse.draw2d"
          version="0.0.0"/>
 
    <plugin

--- a/org.eclipse.zest-feature/feature.xml
+++ b/org.eclipse.zest-feature/feature.xml
@@ -10,7 +10,7 @@
         IBM Corporation - initial API and implementation
  -->
 <feature
-      id="org.eclipse.zest-feature"
+      id="org.eclipse.zest"
       label="%featureName"
       version="3.13.0.qualifier"
       provider-name="%providerName"
@@ -36,7 +36,7 @@
    </url>
 
    <includes
-         id="org.eclipse.draw2d-feature"
+         id="org.eclipse.draw2d"
          version="0.0.0"/>
 
    <requires>

--- a/org.eclipse.zest.sdk-feature/feature.xml
+++ b/org.eclipse.zest.sdk-feature/feature.xml
@@ -10,7 +10,7 @@
         IBM Corporation - initial API and implementation
  -->
 <feature
-      id="org.eclipse.zest.sdk-feature"
+      id="org.eclipse.zest.sdk"
       label="%featureName"
       version="3.13.0.qualifier"
       provider-name="%providerName"
@@ -36,11 +36,11 @@
    </url>
 
    <includes
-         id="org.eclipse.zest-feature"
+         id="org.eclipse.zest"
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.draw2d-feature"
+         id="org.eclipse.draw2d"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
Also add the org.eclipse.draw2d.sdk to the category.xml

https://github.com/eclipse/gef-classic/issues/70