### PR TITLE
Add api baseline target for 3.14.0 release

### DIFF
--- a/org.eclipse.gef.baseline/API-baseline-3.14.0/gef-classic-3.14.0.target
+++ b/org.eclipse.gef.baseline/API-baseline-3.14.0/gef-classic-3.14.0.target
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="GEF Classic 3.14.0 Base Line Target" sequenceNumber="1">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+<repository location="https://download.eclipse.org/releases/latest"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.zest.sdk.feature.group" version="3.14.0.202206170857"/>
+<unit id="org.eclipse.draw2d.sdk.feature.group" version="3.14.0.202206170857"/>
+<unit id="org.eclipse.gef.sdk.feature.group" version="3.14.0.202206170857"/>
+<unit id="org.eclipse.gef.examples.feature.group" version="3.14.0.202206170857"/>
+<repository location="https://download.eclipse.org/tools/gef/classic/releases/3.14.0"/>
+	<unit id="org.eclipse.draw2d.examples" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.draw2d.examples.source" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.draw2d.feature.group" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.draw2d.source.feature.group" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.gef.examples.source.feature.group" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.gef.feature.group" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.gef.source.feature.group" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.zest.examples" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.zest.examples.source" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.zest.feature.group" version="3.14.0.202206170857"/>
+	<unit id="org.eclipse.zest.source.feature.group" version="3.14.0.202206170857"/>
+</location>
+</locations>
+</target>


### PR DESCRIPTION
Added a target platform with the 3.14 release for use as api base line in pde tools.