### PR TITLE
[Modernize Code] Turn Editpart children into typed List

### DIFF
--- a/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/parts/SequentialActivityPart.java
+++ b/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/parts/SequentialActivityPart.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.flow.parts;
 
-import java.util.List;
 import java.util.Map;
 
 import org.eclipse.draw2d.IFigure;
@@ -38,12 +37,10 @@ public class SequentialActivityPart extends StructuredActivityPart {
 	 */
 	public void contributeEdgesToGraph(CompoundDirectedGraph graph, Map map) {
 		super.contributeEdgesToGraph(graph, map);
-		Node node, prev = null;
-		EditPart a;
-		List members = getChildren();
-		for (int n = 0; n < members.size(); n++) {
-			a = (EditPart) members.get(n);
-			node = (Node) map.get(a);
+		Node prev = null;
+
+		for (EditPart a : getChildren()) {
+			Node node = (Node) map.get(a);
 			if (prev != null) {
 				Edge e = new Edge(prev, node);
 				e.weight = 50;

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicFlowEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicFlowEditPolicy.java
@@ -28,8 +28,8 @@ import org.eclipse.gef.examples.logicdesigner.model.commands.CloneCommand;
 import org.eclipse.gef.examples.logicdesigner.model.commands.CreateCommand;
 import org.eclipse.gef.examples.logicdesigner.model.commands.ReorderPartCommand;
 
-public class LogicFlowEditPolicy extends
-		org.eclipse.gef.editpolicies.FlowLayoutEditPolicy {
+public class LogicFlowEditPolicy
+		extends org.eclipse.gef.editpolicies.FlowLayoutEditPolicy {
 
 	/**
 	 * Override to return the <code>Command</code> to perform an

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.edit;
 
-import java.util.Iterator;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.RectangleFigure;
@@ -79,10 +77,8 @@ public class LogicResizableEditPolicy extends ResizableEditPolicy {
 
 		child.setBounds(childBounds);
 
-		Iterator i = part.getChildren().iterator();
-
-		while (i.hasNext())
-			createFigure((GraphicalEditPart) i.next(), child);
+		part.getChildren()
+				.forEach(ep -> createFigure((GraphicalEditPart) ep, child));
 
 		return child;
 	}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeContainerEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeContainerEditPolicy.java
@@ -63,8 +63,8 @@ public class LogicTreeContainerEditPolicy extends TreeContainerEditPolicy {
 				LogicSubpart childModel = (LogicSubpart) child.getModel();
 				command.add(createCreateCommand(childModel,
 						new Rectangle(new org.eclipse.draw2d.geometry.Point(),
-								childModel.getSize()), index,
-						"Reparent LogicSubpart"));//$NON-NLS-1$
+								childModel.getSize()),
+						index, "Reparent LogicSubpart"));//$NON-NLS-1$
 			}
 		}
 		return command;
@@ -79,7 +79,7 @@ public class LogicTreeContainerEditPolicy extends TreeContainerEditPolicy {
 	protected Command getMoveChildrenCommand(ChangeBoundsRequest request) {
 		CompoundCommand command = new CompoundCommand();
 		List editparts = request.getEditParts();
-		List children = getHost().getChildren();
+		List<EditPart> children = getHost().getChildren();
 		int newIndex = findIndexOfTreeItemAt(request.getLocation());
 
 		for (int i = 0; i < editparts.size(); i++) {

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/SelectionRange.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/SelectionRange.java
@@ -65,12 +65,13 @@ public class SelectionRange {
 	 * @param end
 	 * @param forward
 	 */
-	public SelectionRange(TextLocation begin, TextLocation end, boolean forward) {
+	public SelectionRange(TextLocation begin, TextLocation end,
+			boolean forward) {
 		this(begin, end, forward, true);
 	}
 
-	public SelectionRange(TextLocation begin, TextLocation end,
-			boolean forward, boolean trailing) {
+	public SelectionRange(TextLocation begin, TextLocation end, boolean forward,
+			boolean trailing) {
 		Assert.isNotNull(begin);
 		Assert.isNotNull(end);
 		this.begin = begin;
@@ -83,7 +84,8 @@ public class SelectionRange {
 		this(new TextLocation(part, offset));
 	}
 
-	public SelectionRange(TextEditPart begin, int bo, TextEditPart end, int eo) {
+	public SelectionRange(TextEditPart begin, int bo, TextEditPart end,
+			int eo) {
 		this(new TextLocation(begin, bo), new TextLocation(end, eo));
 	}
 
@@ -92,8 +94,7 @@ public class SelectionRange {
 			result.add(part);
 		else
 			for (int i = 0; i < part.getChildren().size(); i++)
-				depthFirstTraversal((EditPart) part.getChildren().get(i),
-						result);
+				depthFirstTraversal(part.getChildren().get(i), result);
 	}
 
 	public boolean equals(Object obj) {
@@ -105,28 +106,29 @@ public class SelectionRange {
 		return false;
 	}
 
-	private List findLeavesBetweenInclusive(EditPart left, EditPart right) {
+	private List<EditPart> findLeavesBetweenInclusive(EditPart left,
+			EditPart right) {
 		if (left == right)
 			return Collections.singletonList(left);
 		EditPart commonAncestor = ToolUtilities.findCommonAncestor(left, right);
 
 		EditPart nextLeft = left.getParent();
-		List children;
+		List<EditPart> children;
 
-		ArrayList result = new ArrayList();
+		ArrayList<EditPart> result = new ArrayList<>();
 
 		if (nextLeft == commonAncestor)
 			result.add(left);
 		while (nextLeft != commonAncestor) {
 			children = nextLeft.getChildren();
 			for (int i = children.indexOf(left); i < children.size(); i++)
-				depthFirstTraversal((EditPart) children.get(i), result);
+				depthFirstTraversal(children.get(i), result);
 
 			left = nextLeft;
 			nextLeft = nextLeft.getParent();
 		}
 
-		ArrayList rightSide = new ArrayList();
+		ArrayList<EditPart> rightSide = new ArrayList<>();
 		EditPart nextRight = right.getParent();
 		if (nextRight == commonAncestor)
 			rightSide.add(right);
@@ -134,7 +136,7 @@ public class SelectionRange {
 			children = nextRight.getChildren();
 			int end = children.indexOf(right);
 			for (int i = 0; i <= end; i++)
-				depthFirstTraversal((EditPart) children.get(i), rightSide);
+				depthFirstTraversal(children.get(i), rightSide);
 
 			right = nextRight;
 			nextRight = nextRight.getParent();
@@ -144,21 +146,22 @@ public class SelectionRange {
 		int start = children.indexOf(left) + 1;
 		int end = children.indexOf(right);
 		for (int i = start; i < end; i++)
-			depthFirstTraversal((EditPart) children.get(i), result);
+			depthFirstTraversal(children.get(i), result);
 
 		result.addAll(rightSide);
 		return result;
 	}
 
-	private List findNodesBetweenInclusive(EditPart left, EditPart right) {
+	private List<EditPart> findNodesBetweenInclusive(EditPart left,
+			EditPart right) {
 		if (left == right)
 			return Collections.singletonList(left);
 		EditPart commonAncestor = ToolUtilities.findCommonAncestor(left, right);
 
 		EditPart nextLeft = left.getParent();
-		List children;
+		List<EditPart> children;
 
-		ArrayList result = new ArrayList();
+		ArrayList<EditPart> result = new ArrayList<>();
 
 		// if (nextLeft == commonAncestor)
 		result.add(left);
@@ -171,7 +174,7 @@ public class SelectionRange {
 			nextLeft = nextLeft.getParent();
 		}
 
-		ArrayList rightSide = new ArrayList();
+		ArrayList<EditPart> rightSide = new ArrayList<>();
 		EditPart nextRight = right.getParent();
 		rightSide.add(right);
 		while (nextRight != commonAncestor) {
@@ -195,7 +198,8 @@ public class SelectionRange {
 
 	public List getLeafParts() {
 		if (leafParts == null) {
-			List list = findLeavesBetweenInclusive(begin.part, end.part);
+			List<EditPart> list = findLeavesBetweenInclusive(begin.part,
+					end.part);
 			leafParts = Collections.unmodifiableList(list);
 		}
 		return leafParts;
@@ -207,7 +211,8 @@ public class SelectionRange {
 	 */
 	public List getSelectedParts() {
 		if (selectedParts == null) {
-			List list = findNodesBetweenInclusive(begin.part, end.part);
+			List<EditPart> list = findNodesBetweenInclusive(begin.part,
+					end.part);
 			selectedParts = Collections.unmodifiableList(list);
 		}
 		return selectedParts;

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/edit/CompoundTextPart.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/edit/CompoundTextPart.java
@@ -22,6 +22,7 @@ import org.eclipse.draw2d.text.BlockFlow;
 import org.eclipse.draw2d.text.CaretInfo;
 import org.eclipse.draw2d.text.FlowPage;
 import org.eclipse.draw2d.text.InlineFlow;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.examples.text.TextLocation;
 import org.eclipse.gef.examples.text.figures.CommentPage;
 import org.eclipse.gef.examples.text.model.Container;
@@ -38,7 +39,8 @@ public abstract class CompoundTextPart extends AbstractTextPart {
 	}
 
 	public boolean acceptsCaret() {
-		for (Iterator iter = getChildren().iterator(); iter.hasNext();) {
+		for (Iterator<EditPart> iter = getChildren().iterator(); iter
+				.hasNext();) {
 			TextEditPart part = (TextEditPart) iter.next();
 			if (part.acceptsCaret())
 				return true;
@@ -152,8 +154,8 @@ public abstract class CompoundTextPart extends AbstractTextPart {
 	}
 
 	protected void searchForward(CaretRequest search, SearchResult result) {
-		int childIndex = search.isRecursive ? 0 : getChildren().indexOf(
-				search.where.part) + 1;
+		int childIndex = search.isRecursive ? 0
+				: getChildren().indexOf(search.where.part) + 1;
 		int childCount = getChildren().size();
 		boolean wasRecursive = search.isRecursive;
 		search.setRecursive(true);
@@ -203,8 +205,8 @@ public abstract class CompoundTextPart extends AbstractTextPart {
 		int childCount = getChildren().size();
 		search.setRecursive(true);
 		while (childIndex < childCount) {
-			TextEditPart newPart = (TextEditPart) getChildren().get(
-					childIndex++);
+			TextEditPart newPart = (TextEditPart) getChildren()
+					.get(childIndex++);
 			newPart.getTextLocation(search, result);
 			if (result.location != null)
 				return;

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPart.java
@@ -151,7 +151,7 @@ public interface EditPart extends IAdaptable {
 	 * 
 	 * @return a <code>List</code> of children
 	 */
-	List getChildren();
+	List<EditPart> getChildren();
 
 	/**
 	 * Returns the {@link Command} to perform the specified Request or
@@ -217,9 +217,9 @@ public interface EditPart extends IAdaptable {
 	 * 
 	 * @return one of:
 	 *         <UL>
-	 *         <LI> {@link #SELECTED}
-	 *         <LI> {@link #SELECTED_NONE}
-	 *         <LI> {@link #SELECTED_PRIMARY}
+	 *         <LI>{@link #SELECTED}
+	 *         <LI>{@link #SELECTED_NONE}
+	 *         <LI>{@link #SELECTED_PRIMARY}
 	 *         </UL>
 	 */
 	int getSelected();

--- a/org.eclipse.gef/src/org/eclipse/gef/SnapToGeometry.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SnapToGeometry.java
@@ -211,12 +211,12 @@ public class SnapToGeometry extends SnapToHelper {
 	 */
 	protected List generateSnapPartsList(List exclusions) {
 		// Don't snap to any figure that is being dragged
-		List children = new ArrayList(container.getChildren());
+		List<EditPart> children = new ArrayList<>(container.getChildren());
 		children.removeAll(exclusions);
 
 		// Don't snap to hidden figures
-		List hiddenChildren = new ArrayList();
-		for (Iterator iter = children.iterator(); iter.hasNext();) {
+		List<EditPart> hiddenChildren = new ArrayList<>();
+		for (Iterator<EditPart> iter = children.iterator(); iter.hasNext();) {
 			GraphicalEditPart child = (GraphicalEditPart) iter.next();
 			if (!child.getFigure().isVisible())
 				hiddenChildren.add(child);
@@ -254,8 +254,8 @@ public class SnapToGeometry extends SnapToHelper {
 		// populateRowsAndCols() does by using int precision).
 		if ((int) (near - far) % 2 != 0)
 			total -= 1.0;
-		double result = getCorrectionFor(entries, extendedData, vert,
-				total / 2, 0);
+		double result = getCorrectionFor(entries, extendedData, vert, total / 2,
+				0);
 		if (result == getThreshold())
 			result = getCorrectionFor(entries, extendedData, vert, near, -1);
 		if (result == getThreshold())
@@ -406,8 +406,8 @@ public class SnapToGeometry extends SnapToHelper {
 					baseRect.preciseRight() - 1, 1);
 			if (rightCorrection != getThreshold()) {
 				snapOrientation &= ~EAST;
-				correction.setPreciseWidth(correction.preciseWidth()
-						+ rightCorrection);
+				correction.setPreciseWidth(
+						correction.preciseWidth() + rightCorrection);
 			}
 		}
 
@@ -416,8 +416,8 @@ public class SnapToGeometry extends SnapToHelper {
 					request.getExtendedData(), true, baseRect.preciseX(), -1);
 			if (leftCorrection != getThreshold()) {
 				snapOrientation &= ~WEST;
-				correction.setPreciseWidth(correction.preciseWidth()
-						- leftCorrection);
+				correction.setPreciseWidth(
+						correction.preciseWidth() - leftCorrection);
 				correction.setPreciseX(correction.preciseX() + leftCorrection);
 			}
 		}
@@ -437,8 +437,8 @@ public class SnapToGeometry extends SnapToHelper {
 					request.getExtendedData(), false, baseRect.preciseY(), -1);
 			if (topCorrection != getThreshold()) {
 				snapOrientation &= ~NORTH;
-				correction.setPreciseHeight(correction.preciseHeight()
-						- topCorrection);
+				correction.setPreciseHeight(
+						correction.preciseHeight() - topCorrection);
 				correction.setPreciseY(correction.preciseY() + topCorrection);
 			}
 		}
@@ -446,10 +446,10 @@ public class SnapToGeometry extends SnapToHelper {
 		makeAbsolute(container.getContentPane(), correction);
 		result.setPreciseX(result.preciseX() + correction.preciseX());
 		result.setPreciseY(result.preciseY() + correction.preciseY());
-		result.setPreciseWidth(result.preciseWidth()
-				+ correction.preciseWidth());
-		result.setPreciseHeight(result.preciseHeight()
-				+ correction.preciseHeight());
+		result.setPreciseWidth(
+				result.preciseWidth() + correction.preciseWidth());
+		result.setPreciseHeight(
+				result.preciseHeight() + correction.preciseHeight());
 		return snapOrientation;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
@@ -51,8 +51,8 @@ import org.eclipse.gef.editpolicies.SelectionEditPolicy;
  * AbstractEditPart provides support for children. All AbstractEditPart's can
  * potentially be containers for other EditParts.
  */
-public abstract class AbstractEditPart implements EditPart, RequestConstants,
-		IAdaptable {
+public abstract class AbstractEditPart
+		implements EditPart, RequestConstants, IAdaptable {
 
 	/**
 	 * This flag is set during {@link #activate()}, and reset on
@@ -81,7 +81,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	/**
 	 * The List of children EditParts
 	 */
-	protected List children;
+	protected List<EditPart> children;
 
 	/**
 	 * call getEventListeners(Class) instead.
@@ -155,9 +155,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 
 		activateEditPolicies();
 
-		List c = getChildren();
-		for (int i = 0; i < c.size(); i++)
-			((EditPart) c.get(i)).activate();
+		getChildren().forEach(EditPart::activate);
 
 		fireActivated();
 	}
@@ -204,7 +202,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 		if (index == -1)
 			index = getChildren().size();
 		if (children == null)
-			children = new ArrayList(2);
+			children = new ArrayList<>(2);
 
 		children.add(index, child);
 		child.setParent(this);
@@ -247,9 +245,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	public void addNotify() {
 		register();
 		createEditPolicies();
-		List children = getChildren();
-		for (int i = 0; i < children.size(); i++)
-			((EditPart) children.get(i)).addNotify();
+		getChildren().forEach(EditPart::addNotify);
 		refresh();
 	}
 
@@ -288,9 +284,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	 * @see #activate()
 	 */
 	public void deactivate() {
-		List c = getChildren();
-		for (int i = 0; i < c.size(); i++)
-			((EditPart) c.get(i)).deactivate();
+		getChildren().forEach(EditPart::deactivate);
 
 		deactivateEditPolicies();
 
@@ -467,9 +461,9 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	/**
 	 * @see org.eclipse.gef.EditPart#getChildren()
 	 */
-	public List getChildren() {
+	public List<EditPart> getChildren() {
 		if (children == null)
-			return Collections.EMPTY_LIST;
+			return Collections.emptyList();
 		return children;
 	}
 
@@ -748,13 +742,13 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 		EditPart editPart;
 		Object model;
 
-		List children = getChildren();
+		List<EditPart> children = getChildren();
 		int size = children.size();
 		Map modelToEditPart = Collections.EMPTY_MAP;
 		if (size > 0) {
 			modelToEditPart = new HashMap(size);
 			for (i = 0; i < size; i++) {
-				editPart = (EditPart) children.get(i);
+				editPart = children.get(i);
 				modelToEditPart.put(editPart.getModel(), editPart);
 			}
 		}
@@ -764,8 +758,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 			model = modelObjects.get(i);
 
 			// Do a quick check to see if editPart[i] == model[i]
-			if (i < children.size()
-					&& ((EditPart) children.get(i)).getModel() == model)
+			if (i < children.size() && children.get(i).getModel() == model)
 				continue;
 
 			// Look to see if the EditPart is already around but in the
@@ -785,13 +778,10 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 		// remove the remaining EditParts
 		size = children.size();
 		if (i < size) {
-			List trash = new ArrayList(size - i);
+			List<EditPart> trash = new ArrayList<>(size - i);
 			for (; i < size; i++)
 				trash.add(children.get(i));
-			for (i = 0; i < trash.size(); i++) {
-				EditPart ep = (EditPart) trash.get(i);
-				removeChild(ep);
-			}
+			trash.forEach(this::removeChild);
 		}
 	}
 
@@ -943,9 +933,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 		if (hasFocus())
 			getViewer().setFocus(null);
 
-		List children = getChildren();
-		for (int i = 0; i < children.size(); i++)
-			((EditPart) children.get(i)).removeNotify();
+		getChildren().forEach(EditPart::removeNotify);
 		unregister();
 	}
 
@@ -960,9 +948,8 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	 */
 	protected void reorderChild(EditPart editpart, int index) {
 		removeChildVisual(editpart);
-		List children = getChildren();
-		children.remove(editpart);
-		children.add(index, editpart);
+		getChildren().remove(editpart);
+		getChildren().add(index, editpart);
 		addChildVisual(editpart, index);
 	}
 
@@ -1002,8 +989,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	 */
 	public void setFocus(boolean value) {
 		// only selectable edit parts may obtain focus
-		Assert.isLegal(
-				isSelectable() || !value,
+		Assert.isLegal(isSelectable() || !value,
 				"An EditPart has to be selectable (isSelectable() == true) in order to obtain focus."); //$NON-NLS-1$
 
 		if (hasFocus() == value)
@@ -1057,8 +1043,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	 */
 	public void setSelected(int value) {
 		// only selectable edit parts may get selected.
-		Assert.isLegal(
-				isSelectable() || value == SELECTED_NONE,
+		Assert.isLegal(isSelectable() || value == SELECTED_NONE,
 				"An EditPart has to be selectable (isSelectable() == true) in order to get selected."); //$NON-NLS-1$
 
 		if (selected == value)

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
@@ -71,8 +71,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * 
 	 * @since 2.0
 	 */
-	protected abstract class AccessibleGraphicalEditPart extends
-			AccessibleEditPart {
+	protected abstract class AccessibleGraphicalEditPart
+			extends AccessibleEditPart {
 		/**
 		 * @see AccessibleEditPart#getChildCount(AccessibleControlEvent)
 		 */
@@ -84,15 +84,15 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 		 * @see AccessibleEditPart#getChildren(AccessibleControlEvent)
 		 */
 		public void getChildren(AccessibleControlEvent e) {
-			List list = AbstractGraphicalEditPart.this.getChildren();
-			Object children[] = new Object[list.size()];
+			List<EditPart> list = AbstractGraphicalEditPart.this.getChildren();
+			Integer[] children = new Integer[list.size()];
 			for (int i = 0; i < list.size(); i++) {
-				EditPart part = (EditPart) list.get(i);
-				AccessibleEditPart access = (AccessibleEditPart) part
+				EditPart part = list.get(i);
+				AccessibleEditPart access = part
 						.getAdapter(AccessibleEditPart.class);
 				if (access == null)
 					return; // fail if any children aren't accessible.
-				children[i] = new Integer(access.getAccessibleID());
+				children[i] = Integer.valueOf(access.getAccessibleID());
 			}
 			e.children = children;
 		}
@@ -119,7 +119,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 			e.detail = ACC.STATE_SELECTABLE | ACC.STATE_FOCUSABLE;
 			if (getSelected() != EditPart.SELECTED_NONE)
 				e.detail |= ACC.STATE_SELECTED;
-			if (getViewer().getFocusEditPart() == AbstractGraphicalEditPart.this)
+			if (getViewer()
+					.getFocusEditPart() == AbstractGraphicalEditPart.this)
 				e.detail |= ACC.STATE_FOCUSED;
 		}
 
@@ -138,8 +139,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * 
 	 * @since 2.0
 	 */
-	protected class DefaultAccessibleAnchorProvider implements
-			AccessibleAnchorProvider {
+	protected class DefaultAccessibleAnchorProvider
+			implements AccessibleAnchorProvider {
 		private List getDefaultLocations() {
 			List list = new ArrayList();
 			Rectangle r = getFigure().getBounds();
@@ -250,7 +251,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * @param index
 	 *            Index where it is being added
 	 */
-	protected void addSourceConnection(ConnectionEditPart connection, int index) {
+	protected void addSourceConnection(ConnectionEditPart connection,
+			int index) {
 		primAddSourceConnection(connection, index);
 
 		GraphicalEditPart source = (GraphicalEditPart) connection.getSource();
@@ -281,7 +283,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * @param index
 	 *            Index where it is being added
 	 */
-	protected void addTargetConnection(ConnectionEditPart connection, int index) {
+	protected void addTargetConnection(ConnectionEditPart connection,
+			int index) {
 		primAddTargetConnection(connection, index);
 
 		GraphicalEditPart target = (GraphicalEditPart) connection.getTarget();
@@ -686,7 +689,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 			model = modelObjects.get(i);
 
 			if (i < sourceConnections.size()
-					&& ((EditPart) sourceConnections.get(i)).getModel() == model)
+					&& ((EditPart) sourceConnections.get(i))
+							.getModel() == model)
 				continue;
 
 			editPart = (ConnectionEditPart) modelToEditPart.get(model);
@@ -749,7 +753,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 			model = modelObjects.get(i);
 
 			if (i < targetConnections.size()
-					&& ((EditPart) targetConnections.get(i)).getModel() == model)
+					&& ((EditPart) targetConnections.get(i))
+							.getModel() == model)
 				continue;
 
 			editPart = (ConnectionEditPart) modelToEditPart.get(model);
@@ -833,8 +838,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 *            Connection being removed
 	 */
 	protected void removeSourceConnection(ConnectionEditPart connection) {
-		fireRemovingSourceConnection(connection, getSourceConnections()
-				.indexOf(connection));
+		fireRemovingSourceConnection(connection,
+				getSourceConnections().indexOf(connection));
 		if (connection.getSource() == this) {
 			connection.deactivate();
 			connection.setSource(null);
@@ -852,8 +857,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 *            Connection being removed
 	 */
 	protected void removeTargetConnection(ConnectionEditPart connection) {
-		fireRemovingTargetConnection(connection, getTargetConnections()
-				.indexOf(connection));
+		fireRemovingTargetConnection(connection,
+				getTargetConnections().indexOf(connection));
 		if (connection.getTarget() == this)
 			connection.setTarget(null);
 		primRemoveTargetConnection(connection);

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractTreeEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractTreeEditPart.java
@@ -33,8 +33,8 @@ import org.eclipse.gef.TreeEditPart;
  * <em>subclassing</em> this class. Callers of public API should refer to the
  * interface's documentation.
  */
-public abstract class AbstractTreeEditPart extends AbstractEditPart implements
-		TreeEditPart {
+public abstract class AbstractTreeEditPart extends AbstractEditPart
+		implements TreeEditPart {
 
 	/**
 	 * Either a Tree or TreeItem
@@ -60,9 +60,8 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements
 	}
 
 	/**
-	 * Implemented to assign the child its
-	 * {@link TreeEditPart#setWidget(Widget) widget}. Subclasses should not call
-	 * or override this method.
+	 * Implemented to assign the child its {@link TreeEditPart#setWidget(Widget)
+	 * widget}. Subclasses should not call or override this method.
 	 * 
 	 * @see AbstractEditPart#addChildVisual(EditPart, int)
 	 */
@@ -84,7 +83,8 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements
 	 *         not disposed
 	 */
 	protected final boolean checkTreeItem() {
-		return !(widget == null || widget.isDisposed() || widget instanceof Tree);
+		return !(widget == null || widget.isDisposed()
+				|| widget instanceof Tree);
 	}
 
 	/**
@@ -173,7 +173,7 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements
 	 * @see org.eclipse.gef.TreeEditPart#setWidget(Widget)
 	 */
 	public void setWidget(Widget widget) {
-		List children = getChildren();
+		List<EditPart> children = getChildren();
 		if (widget != null) {
 			widget.setData(this);
 			if (widget instanceof TreeItem) {
@@ -197,7 +197,7 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements
 			if (widget instanceof TreeItem)
 				((TreeItem) widget).setExpanded(expanded);
 		} else {
-			Iterator iter = getChildren().iterator();
+			Iterator<EditPart> iter = getChildren().iterator();
 			while (iter.hasNext())
 				((TreeEditPart) iter.next()).setWidget(null);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/FlowLayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/FlowLayoutEditPolicy.java
@@ -57,7 +57,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	 * @return the index for the insertion reference
 	 */
 	protected int getFeedbackIndexFor(Request request) {
-		List children = getHost().getChildren();
+		List<EditPart> children = getHost().getChildren();
 		if (children.isEmpty())
 			return -1;
 
@@ -70,7 +70,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 		int rowBottom = Integer.MIN_VALUE;
 		int candidate = -1;
 		for (int i = 0; i < children.size(); i++) {
-			EditPart child = (EditPart) children.get(i);
+			EditPart child = children.get(i);
 			Rectangle rect = transposer
 					.t(getAbsoluteBounds(((GraphicalEditPart) child)));
 			if (rect.y > rowBottom) {
@@ -119,20 +119,20 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	 * @see OrderedLayoutEditPolicy#getInsertionReference(Request)
 	 */
 	protected EditPart getInsertionReference(Request request) {
-		List children = getHost().getChildren();
+		List<EditPart> children = getHost().getChildren();
 
 		if (request.getType().equals(RequestConstants.REQ_CREATE)) {
 			int i = getFeedbackIndexFor(request);
 			if (i == -1)
 				return null;
-			return (EditPart) children.get(i);
+			return children.get(i);
 		}
 
 		int index = getFeedbackIndexFor(request);
 		if (index != -1) {
 			List selection = getHost().getViewer().getSelectedEditParts();
 			do {
-				EditPart editpart = (EditPart) children.get(index);
+				EditPart editpart = children.get(index);
 				if (!selection.contains(editpart))
 					return editpart;
 			} while (++index < children.size());
@@ -176,7 +176,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	 * @see LayoutEditPolicy#showLayoutTargetFeedback(Request)
 	 */
 	protected void showLayoutTargetFeedback(Request request) {
-		if (getHost().getChildren().size() == 0)
+		if (!getHost().getChildren().isEmpty())
 			return;
 		Polyline fb = getLineFeedback();
 		Transposer transposer = new Transposer();
@@ -188,10 +188,10 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 		if (epIndex == -1) {
 			before = false;
 			epIndex = getHost().getChildren().size() - 1;
-			EditPart editPart = (EditPart) getHost().getChildren().get(epIndex);
+			EditPart editPart = getHost().getChildren().get(epIndex);
 			r = transposer.t(getAbsoluteBounds((GraphicalEditPart) editPart));
 		} else {
-			EditPart editPart = (EditPart) getHost().getChildren().get(epIndex);
+			EditPart editPart = getHost().getChildren().get(epIndex);
 			r = transposer.t(getAbsoluteBounds((GraphicalEditPart) editPart));
 			Point p = transposer.t(getLocationFromRequest(request));
 			if (p.x <= r.x + (r.width / 2))
@@ -204,7 +204,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 				 */
 				before = false;
 				epIndex--;
-				editPart = (EditPart) getHost().getChildren().get(epIndex);
+				editPart = getHost().getChildren().get(epIndex);
 				r = transposer
 						.t(getAbsoluteBounds((GraphicalEditPart) editPart));
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/LayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/LayoutEditPolicy.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gef.editpolicies;
 
-import java.util.List;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.Graphics;
@@ -134,9 +132,7 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	 * Decorates all existing children. This method is called on activation.
 	 */
 	protected void decorateChildren() {
-		List children = getHost().getChildren();
-		for (int i = 0; i < children.size(); i++)
-			decorateChild((EditPart) children.get(i));
+		getHost().getChildren().forEach(this::decorateChild);
 	}
 
 	/**
@@ -427,9 +423,7 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	 * Removes all decorations added by {@link #decorateChildren()}.
 	 */
 	protected void undecorateChildren() {
-		List children = getHost().getChildren();
-		for (int i = 0; i < children.size(); i++)
-			undecorateChild((EditPart) children.get(i));
+		getHost().getChildren().forEach(this::undecorateChild);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ScrollableSelectionFeedbackEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ScrollableSelectionFeedbackEditPolicy.java
@@ -89,7 +89,8 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 				getHost().getViewer().select(getHost());
 			}
 			// update feedback in case the viewport's view location changed
-			if (event.getPropertyName().equals(Viewport.PROPERTY_VIEW_LOCATION)) {
+			if (event.getPropertyName()
+					.equals(Viewport.PROPERTY_VIEW_LOCATION)) {
 				updateFeedback();
 			}
 		}
@@ -105,12 +106,13 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 		// to the host figure itself will be registered within showFeedback()
 		// and
 		// unregistered within hideFeedback()
-		for (Iterator iterator = ViewportUtilities.getViewportsPath(
-				getHostFigureViewport(),
-				ViewportUtilities.getRootViewport(getHostFigure())).iterator(); iterator
-				.hasNext();) {
+		for (Iterator iterator = ViewportUtilities
+				.getViewportsPath(getHostFigureViewport(),
+						ViewportUtilities.getRootViewport(getHostFigure()))
+				.iterator(); iterator.hasNext();) {
 			Viewport viewport = (Viewport) iterator.next();
-			viewport.addPropertyChangeListener(viewportViewLocationChangeListener);
+			viewport.addPropertyChangeListener(
+					viewportViewLocationChangeListener);
 		}
 	}
 
@@ -142,9 +144,10 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	 */
 	protected void createConnectionFeedbackFigure(
 			ConnectionEditPart connectionEditPart) {
-		addFeedbackFigure(new GhostImageFigure(connectionEditPart.getFigure(),
-				getAlpha(), getLayer(LayerConstants.CONNECTION_LAYER)
-						.getBackgroundColor().getRGB()),
+		addFeedbackFigure(
+				new GhostImageFigure(connectionEditPart.getFigure(), getAlpha(),
+						getLayer(LayerConstants.CONNECTION_LAYER)
+								.getBackgroundColor().getRGB()),
 				getAbsoluteBounds(connectionEditPart.getFigure()));
 	}
 
@@ -155,8 +158,8 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 		HashSet transitiveNestedConnections = EditPartUtilities
 				.getAllNestedConnectionEditParts((GraphicalEditPart) getHost());
 
-		for (Iterator iterator = transitiveNestedConnections.iterator(); iterator
-				.hasNext();) {
+		for (Iterator iterator = transitiveNestedConnections
+				.iterator(); iterator.hasNext();) {
 			Object connection = iterator.next();
 			if (connection instanceof ConnectionEditPart) {
 				createConnectionFeedbackFigure((ConnectionEditPart) connection);
@@ -173,7 +176,8 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	 */
 	protected void createNodeFeedbackFigure(GraphicalEditPart childEditPart) {
 		addFeedbackFigure(new GhostImageFigure(childEditPart.getFigure(),
-				getAlpha(), null), getAbsoluteBounds(childEditPart.getFigure()));
+				getAlpha(), null),
+				getAbsoluteBounds(childEditPart.getFigure()));
 	}
 
 	/**
@@ -181,13 +185,11 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	 */
 	protected void createNodeFeedbackFigures() {
 		// create ghost feedback for node children
-		for (Iterator iterator = getHost().getChildren().iterator(); iterator
-				.hasNext();) {
-			Object child = iterator.next();
+		getHost().getChildren().forEach(child -> {
 			if (child instanceof GraphicalEditPart) {
 				createNodeFeedbackFigure((GraphicalEditPart) child);
 			}
-		}
+		});
 	}
 
 	/**
@@ -197,12 +199,13 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 		// remove viewport listeners; listener to host figure, which were
 		// registered during showSelection() will be unregistered during
 		// hideSelection(), so they do not have to be unregistered here
-		for (Iterator iterator = ViewportUtilities.getViewportsPath(
-				getHostFigureViewport(),
-				ViewportUtilities.getRootViewport(getHostFigure())).iterator(); iterator
-				.hasNext();) {
+		for (Iterator iterator = ViewportUtilities
+				.getViewportsPath(getHostFigureViewport(),
+						ViewportUtilities.getRootViewport(getHostFigure()))
+				.iterator(); iterator.hasNext();) {
 			Viewport viewport = (Viewport) iterator.next();
-			viewport.removePropertyChangeListener(viewportViewLocationChangeListener);
+			viewport.removePropertyChangeListener(
+					viewportViewLocationChangeListener);
 
 		}
 		super.deactivate();
@@ -241,7 +244,8 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	 * {@link #feedbackFigures} list.
 	 */
 	protected void hideFeedback() {
-		for (Iterator iterator = feedbackFigures.iterator(); iterator.hasNext();) {
+		for (Iterator iterator = feedbackFigures.iterator(); iterator
+				.hasNext();) {
 			removeFeedback((IFigure) iterator.next());
 		}
 		feedbackFigures.clear();
@@ -292,8 +296,8 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 
 		// check if there is a node child exceeding the client are
 		Rectangle clientArea = getAbsoluteClientArea(getHostFigure());
-		boolean primaryLayerChildExceedsViewport = !clientArea
-				.equals(getAbsoluteViewportArea(((IScrollableFigure) getHostFigure())
+		boolean primaryLayerChildExceedsViewport = !clientArea.equals(
+				getAbsoluteViewportArea(((IScrollableFigure) getHostFigure())
 						.getScrollPane().getViewport()));
 		// check if there is a connection exceeding the client area
 		boolean connectionLayerChildExceedsClientArea = false;
@@ -303,10 +307,11 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 				.hasNext() && !connectionLayerChildExceedsClientArea;) {
 			IFigure connectionLayerChild = (IFigure) iterator.next();
 			connectionLayerChildExceedsClientArea = (ViewportUtilities
-					.getNearestEnclosingViewport(connectionLayerChild) == ((IScrollableFigure) getHostFigure())
-					.getScrollPane().getViewport() && !clientArea.getExpanded(
-					new Insets(1, 1, 1, 1)).contains(
-					getAbsoluteBounds(connectionLayerChild)));
+					.getNearestEnclosingViewport(
+							connectionLayerChild) == ((IScrollableFigure) getHostFigure())
+									.getScrollPane().getViewport()
+					&& !clientArea.getExpanded(new Insets(1, 1, 1, 1))
+							.contains(getAbsoluteBounds(connectionLayerChild)));
 		}
 
 		// Only show feedback if there is a child or connection figure whose
@@ -366,8 +371,8 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 		int heightMax = viewport.getVerticalRangeModel().getMaximum();
 		int heightMin = viewport.getVerticalRangeModel().getMinimum();
 
-		viewportParentBounds
-				.setSize(widthMax - widthMin, heightMax - heightMin);
+		viewportParentBounds.setSize(widthMax - widthMin,
+				heightMax - heightMin);
 		viewportParentBounds.translate(widthMin, heightMin);
 		viewportParentBounds.translate(viewport.getViewLocation().getNegated());
 		viewport.getParent().translateToAbsolute(viewportParentBounds);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
@@ -38,6 +38,7 @@ import org.eclipse.draw2d.StackLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
@@ -55,8 +56,8 @@ import org.eclipse.gef.ui.palette.editparts.PaletteEditPart;
  * @author Whitney Sorenson
  * @since 3.0
  */
-public class PaletteStackEditPart extends PaletteEditPart implements
-		IPaletteStackEditPart {
+public class PaletteStackEditPart extends PaletteEditPart
+		implements IPaletteStackEditPart {
 
 	private static final Dimension EMPTY_DIMENSION = new Dimension(0, 0);
 
@@ -64,11 +65,11 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 	private ChangeListener clickableListener = new ChangeListener() {
 		public void handleStateChanged(ChangeEvent event) {
 			if (event.getPropertyName().equals(ButtonModel.MOUSEOVER_PROPERTY))
-				arrowFigure.getModel().setMouseOver(
-						activeFigure.getModel().isMouseOver());
+				arrowFigure.getModel()
+						.setMouseOver(activeFigure.getModel().isMouseOver());
 			else if (event.getPropertyName().equals(ButtonModel.ARMED_PROPERTY))
-				arrowFigure.getModel().setArmed(
-						activeFigure.getModel().isArmed());
+				arrowFigure.getModel()
+						.setArmed(activeFigure.getModel().isArmed());
 		}
 	};
 
@@ -76,11 +77,11 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 	private ChangeListener clickableArrowListener = new ChangeListener() {
 		public void handleStateChanged(ChangeEvent event) {
 			if (event.getPropertyName().equals(ButtonModel.MOUSEOVER_PROPERTY))
-				activeFigure.getModel().setMouseOver(
-						arrowFigure.getModel().isMouseOver());
+				activeFigure.getModel()
+						.setMouseOver(arrowFigure.getModel().isMouseOver());
 			if (event.getPropertyName().equals(ButtonModel.ARMED_PROPERTY))
-				activeFigure.getModel().setArmed(
-						arrowFigure.getModel().isArmed());
+				activeFigure.getModel()
+						.setArmed(arrowFigure.getModel().isArmed());
 		}
 	};
 
@@ -143,8 +144,8 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 		Clickable clickable = null;
 
 		if (newValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(
-					newValue);
+			part = (GraphicalEditPart) getViewer().getEditPartRegistry()
+					.get(newValue);
 			clickable = (Clickable) part.getFigure();
 			clickable.setVisible(true);
 			clickable.addChangeListener(clickableListener);
@@ -154,8 +155,8 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 		}
 
 		if (oldValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(
-					oldValue);
+			part = (GraphicalEditPart) getViewer().getEditPartRegistry()
+					.get(oldValue);
 			// if part is null, its no longer a child.
 			if (part != null) {
 				clickable = (Clickable) part.getFigure();
@@ -217,7 +218,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 	 * @see org.eclipse.gef.EditPart#eraseTargetFeedback(org.eclipse.gef.Request)
 	 */
 	public void eraseTargetFeedback(Request request) {
-		Iterator children = getChildren().iterator();
+		Iterator<EditPart> children = getChildren().iterator();
 
 		while (children.hasNext()) {
 			PaletteEditPart part = (PaletteEditPart) children.next();
@@ -243,18 +244,17 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 	public void openMenu() {
 		MenuManager menuManager = new MenuManager();
 
-		Iterator children = getChildren().iterator();
+		Iterator<EditPart> children = getChildren().iterator();
 		PaletteEditPart part = null;
 		PaletteEntry entry = null;
 		while (children.hasNext()) {
 			part = (PaletteEditPart) children.next();
 			entry = (PaletteEntry) part.getModel();
 
-			menuManager
-					.add(new SetActivePaletteToolAction(getPaletteViewer(),
-							entry.getLabel(), entry.getSmallIcon(), getStack()
-									.getActiveEntry().equals(entry),
-							(ToolEntry) entry));
+			menuManager.add(new SetActivePaletteToolAction(getPaletteViewer(),
+					entry.getLabel(), entry.getSmallIcon(),
+					getStack().getActiveEntry().equals(entry),
+					(ToolEntry) entry));
 		}
 
 		menu = menuManager.createContextMenu(getPaletteViewer().getControl());
@@ -271,8 +271,8 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 		eraseTargetFeedback(new Request(RequestConstants.REQ_SELECTION));
 
 		menu.setLocation(menuLocation);
-		menu.addMenuListener(new StackMenuListener(menu, getViewer()
-				.getControl().getDisplay()));
+		menu.addMenuListener(new StackMenuListener(menu,
+				getViewer().getControl().getDisplay()));
 		menu.setVisible(true);
 	}
 
@@ -309,7 +309,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 		if (menu != null && !menu.isDisposed() && menu.isVisible())
 			return;
 
-		Iterator children = getChildren().iterator();
+		Iterator<EditPart> children = getChildren().iterator();
 		while (children.hasNext()) {
 			PaletteEditPart part = (PaletteEditPart) children.next();
 			part.showTargetFeedback(request);
@@ -319,8 +319,8 @@ public class PaletteStackEditPart extends PaletteEditPart implements
 	}
 
 	public PaletteEditPart getActiveEntry() {
-		return (PaletteEditPart) getViewer().getEditPartRegistry().get(
-				getStack().getActiveEntry());
+		return (PaletteEditPart) getViewer().getEditPartRegistry()
+				.get(getStack().getActiveEntry());
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
@@ -12,7 +12,6 @@ package org.eclipse.gef.internal.ui.palette.editparts;
 
 import java.beans.PropertyChangeEvent;
 import java.util.Iterator;
-import java.util.List;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -34,8 +33,8 @@ import org.eclipse.gef.ui.palette.editparts.PaletteEditPart;
  * @author Whitney Sorenson, crevells
  * @since 3.4
  */
-public class PinnablePaletteStackEditPart extends PaletteEditPart implements
-		IPaletteStackEditPart, IPinnableEditPart {
+public class PinnablePaletteStackEditPart extends PaletteEditPart
+		implements IPaletteStackEditPart, IPinnableEditPart {
 
 	// listen to see if active tool is changed in the palette
 	private PaletteListener paletteListener = new PaletteListener() {
@@ -89,8 +88,8 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements
 		int index = -1;
 
 		if (oldValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(
-					oldValue);
+			part = (GraphicalEditPart) getViewer().getEditPartRegistry()
+					.get(oldValue);
 			// if part is null, its no longer a child.
 			if (part != null) {
 				oldFigure = part.getFigure();
@@ -101,8 +100,8 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements
 		}
 
 		if (newValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(
-					newValue);
+			part = (GraphicalEditPart) getViewer().getEditPartRegistry()
+					.get(newValue);
 			newFigure = part.getFigure();
 		}
 
@@ -128,7 +127,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements
 	}
 
 	public void eraseTargetFeedback(Request request) {
-		Iterator children = getChildren().iterator();
+		Iterator<EditPart> children = getChildren().iterator();
 
 		while (children.hasNext()) {
 			PaletteEditPart part = (PaletteEditPart) children.next();
@@ -156,14 +155,12 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements
 		IFigure childFigure = ((GraphicalEditPart) childEP).getFigure();
 		if (childFigure == getStackFigure().getActiveFigure()) {
 			// no need to reorder figures if this is the active figure
-			List children = getChildren();
-			children.remove(childEP);
-			children.add(index, childEP);
+			getChildren().remove(childEP);
+			getChildren().add(index, childEP);
 		} else {
 			removeChildVisual(childEP);
-			List children = getChildren();
-			children.remove(childEP);
-			children.add(index, childEP);
+			getChildren().remove(childEP);
+			getChildren().add(index, childEP);
 			index = updateIndexBasedOnActiveFigure(index, childEP);
 			addChildVisual(childEP, index);
 		}
@@ -171,7 +168,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements
 
 	private int updateIndexBasedOnActiveFigure(int index, EditPart childEP) {
 		for (int i = 0; i < index; i++) {
-			Object ep = getChildren().get(i);
+			EditPart ep = getChildren().get(i);
 			if (((GraphicalEditPart) ep).getFigure() == getStackFigure()
 					.getActiveFigure()) {
 				return index - 1;
@@ -225,8 +222,8 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements
 	}
 
 	public PaletteEditPart getActiveEntry() {
-		return (PaletteEditPart) getViewer().getEditPartRegistry().get(
-				getStack().getActiveEntry());
+		return (PaletteEditPart) getViewer().getEditPartRegistry()
+				.get(getStack().getActiveEntry());
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
@@ -27,6 +27,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.AccessibleHandleProvider;
 import org.eclipse.gef.DragTracker;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
@@ -132,8 +133,8 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 			accPart = new AccessibleGraphicalEditPart() {
 				public void getDescription(AccessibleEvent e) {
 					if (getRulerProvider() != null)
-						getRulerProvider()
-								.getAccGuideDescription(e, getModel());
+						getRulerProvider().getAccGuideDescription(e,
+								getModel());
 				}
 
 				public void getName(AccessibleEvent e) {
@@ -252,15 +253,14 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 			// is selected, determine which part is to be selected next.
 			int thisPos = getRulerProvider().getGuidePosition(getModel());
 			if (getSelected() != SELECTED_NONE || hasFocus()) {
-				List siblings = getParent().getChildren();
+				List<EditPart> siblings = getParent().getChildren();
 				int minDistance = -1;
 				for (int i = 0; i < siblings.size(); i++) {
 					GuideEditPart guide = (GuideEditPart) siblings.get(i);
 					if (guide == this)
 						continue;
-					int posDiff = Math.abs(thisPos
-							- getRulerProvider().getGuidePosition(
-									guide.getModel()));
+					int posDiff = Math.abs(thisPos - getRulerProvider()
+							.getGuidePosition(guide.getModel()));
 					if (minDistance == -1 || posDiff < minDistance) {
 						minDistance = posDiff;
 						nextSelection = guide;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectAllAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectAllAction.java
@@ -11,7 +11,6 @@
 package org.eclipse.gef.ui.actions;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.jface.action.Action;
@@ -51,8 +50,8 @@ public class SelectAllAction extends Action {
 		GraphicalViewer viewer = (GraphicalViewer) part
 				.getAdapter(GraphicalViewer.class);
 		if (viewer != null) {
-			viewer.setSelection(new StructuredSelection(
-					getSelectableEditParts(viewer)));
+			viewer.setSelection(
+					new StructuredSelection(getSelectableEditParts(viewer)));
 		}
 	}
 
@@ -65,15 +64,10 @@ public class SelectAllAction extends Action {
 	 * @since 3.5
 	 */
 	private List getSelectableEditParts(GraphicalViewer viewer) {
-		List selectableChildren = new ArrayList();
-		List children = viewer.getContents().getChildren();
-		for (Iterator iter = children.iterator(); iter.hasNext();) {
-			Object child = iter.next();
-			if (child instanceof EditPart) {
-				EditPart childPart = (EditPart) child;
-				if (childPart.isSelectable() == true) {
-					selectableChildren.add(childPart);
-				}
+		List<EditPart> selectableChildren = new ArrayList<>();
+		for (EditPart childPart : viewer.getContents().getChildren()) {
+			if (childPart.isSelectable()) {
+				selectableChildren.add(childPart);
 			}
 		}
 		return selectableChildren;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
@@ -13,7 +13,6 @@ package org.eclipse.gef.ui.palette;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.swt.events.DisposeEvent;
@@ -65,11 +64,11 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 				refreshAllEditParts(root);
 			} else if (property
 					.equals(PaletteViewerPreferences.PREFERENCE_LAYOUT)
-					|| property
-							.equals(PaletteViewerPreferences.PREFERENCE_AUTO_COLLAPSE)
-					|| property
-							.equals(DefaultPaletteViewerPreferences
-									.convertLayoutToPreferenceName(getPaletteViewerPreferences()
+					|| property.equals(
+							PaletteViewerPreferences.PREFERENCE_AUTO_COLLAPSE)
+					|| property.equals(DefaultPaletteViewerPreferences
+							.convertLayoutToPreferenceName(
+									getPaletteViewerPreferences()
 											.getLayoutSetting()))) {
 				refreshAllEditParts(root);
 			}
@@ -77,11 +76,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 
 		private void refreshAllEditParts(EditPart part) {
 			part.refresh();
-			List children = part.getChildren();
-			for (Iterator iter = children.iterator(); iter.hasNext();) {
-				EditPart child = (EditPart) iter.next();
-				refreshAllEditParts(child);
-			}
+			part.getChildren().forEach(this::refreshAllEditParts);
 		}
 	}
 
@@ -194,8 +189,8 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	public PaletteCustomizerDialog getCustomizerDialog() {
 		if (customizerDialog == null) {
-			customizerDialog = new PaletteCustomizerDialog(getControl()
-					.getShell(), getCustomizer(), getPaletteRoot());
+			customizerDialog = new PaletteCustomizerDialog(
+					getControl().getShell(), getCustomizer(), getPaletteRoot());
 		}
 		return customizerDialog;
 	}
@@ -267,8 +262,8 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 		canvas.getViewport().setContentsTracksWidth(true);
 		canvas.getViewport().setContentsTracksHeight(!globalScrollbar);
 		canvas.setHorizontalScrollBarVisibility(FigureCanvas.NEVER);
-		canvas.setVerticalScrollBarVisibility(globalScrollbar ? FigureCanvas.ALWAYS
-				: FigureCanvas.AUTOMATIC);
+		canvas.setVerticalScrollBarVisibility(
+				globalScrollbar ? FigureCanvas.ALWAYS : FigureCanvas.AUTOMATIC);
 		if (prefs != null)
 			prefs.addPropertyChangeListener(prefListener);
 		updateFont();
@@ -328,8 +323,8 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	public boolean restoreState(IMemento memento) {
 		try {
-			PaletteEditPart part = (PaletteEditPart) getEditPartRegistry().get(
-					getPaletteRoot());
+			PaletteEditPart part = (PaletteEditPart) getEditPartRegistry()
+					.get(getPaletteRoot());
 			if (part != null)
 				part.restoreState(memento);
 		} catch (RuntimeException re) {
@@ -370,8 +365,8 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	public void saveState(IMemento memento) {
 		// Bug# 69026 - The PaletteRoot can be null initially for VEP
-		PaletteEditPart base = (PaletteEditPart) getEditPartRegistry().get(
-				getPaletteRoot());
+		PaletteEditPart base = (PaletteEditPart) getEditPartRegistry()
+				.get(getPaletteRoot());
 		if (base != null)
 			base.saveState(memento);
 	}
@@ -420,8 +415,8 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 			return;
 		paletteRoot = root;
 		if (paletteRoot != null) {
-			EditPart palette = getEditPartFactory().createEditPart(
-					getRootEditPart(), root);
+			EditPart palette = getEditPartFactory()
+					.createEditPart(getRootEditPart(), root);
 			getRootEditPart().setContents(palette);
 		}
 	}
@@ -464,8 +459,8 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 		if (getControl() == null || getControl().isDisposed())
 			return;
 
-		font = new Font(Display.getCurrent(), getPaletteViewerPreferences()
-				.getFontData());
+		font = new Font(Display.getCurrent(),
+				getPaletteViewerPreferences().getFontData());
 		getControl().setFont(font);
 		getFigureCanvas().getViewport().invalidateTree();
 		getFigureCanvas().getViewport().revalidate();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
@@ -34,6 +34,7 @@ import org.eclipse.draw2d.text.TextFlow;
 
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.DragTracker;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.gef.palette.PaletteContainer;
@@ -298,10 +299,9 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart
 				text = entry.getLabel();
 		} else {
 			if (needName)
-				text = entry.getLabel()
-						+ " " //$NON-NLS-1$
-						+ PaletteMessages.NAME_DESCRIPTION_SEPARATOR
-						+ " " + desc; //$NON-NLS-1$
+				text = entry.getLabel() + " " //$NON-NLS-1$
+						+ PaletteMessages.NAME_DESCRIPTION_SEPARATOR + " " //$NON-NLS-1$
+						+ desc;
 			else
 				text = desc;
 		}
@@ -354,7 +354,7 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart
 	 *            the saved state of the palette entry.
 	 */
 	public void restoreState(IMemento memento) {
-		Iterator iter = getChildren().iterator();
+		Iterator<EditPart> iter = getChildren().iterator();
 		IMemento[] childMementos = memento.getChildren(XML_NAME);
 		int index = 0;
 		while (iter.hasNext())
@@ -369,10 +369,10 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart
 	 *            the saved state of the palette entry.
 	 */
 	public void saveState(IMemento memento) {
-		Iterator iter = getChildren().iterator();
+		Iterator<EditPart> iter = getChildren().iterator();
 		while (iter.hasNext())
-			((PaletteEditPart) iter.next()).saveState(memento
-					.createChild(XML_NAME));
+			((PaletteEditPart) iter.next())
+					.saveState(memento.createChild(XML_NAME));
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerKeyHandler.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerKeyHandler.java
@@ -124,9 +124,11 @@ public class GraphicalViewerKeyHandler extends KeyHandler {
 
 	boolean acceptScroll(KeyEvent event) {
 		return ((event.stateMask & SWT.CTRL) != 0
-				&& (event.stateMask & SWT.SHIFT) != 0 && (event.keyCode == SWT.ARROW_DOWN
-				|| event.keyCode == SWT.ARROW_LEFT
-				|| event.keyCode == SWT.ARROW_RIGHT || event.keyCode == SWT.ARROW_UP));
+				&& (event.stateMask & SWT.SHIFT) != 0
+				&& (event.keyCode == SWT.ARROW_DOWN
+						|| event.keyCode == SWT.ARROW_LEFT
+						|| event.keyCode == SWT.ARROW_RIGHT
+						|| event.keyCode == SWT.ARROW_UP));
 	}
 
 	/**
@@ -156,8 +158,8 @@ public class GraphicalViewerKeyHandler extends KeyHandler {
 		while (counter < 0)
 			counter += connections.size();
 		counter %= connections.size();
-		return (ConnectionEditPart) connections.get(counter
-				% connections.size());
+		return (ConnectionEditPart) connections
+				.get(counter % connections.size());
 	}
 
 	private List getValidNavigationTargets(List candidateEditParts) {
@@ -364,9 +366,8 @@ public class GraphicalViewerKeyHandler extends KeyHandler {
 		GraphicalEditPart node = getCachedNode();
 		if (focus instanceof ConnectionEditPart) {
 			current = (ConnectionEditPart) focus;
-			if (node == null
-					|| (node != current.getSource() && node != current
-							.getTarget())) {
+			if (node == null || (node != current.getSource()
+					&& node != current.getTarget())) {
 				node = (GraphicalEditPart) current.getSource();
 				counter = 0;
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/PaletteViewerKeyHandler.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/PaletteViewerKeyHandler.java
@@ -62,9 +62,8 @@ public class PaletteViewerKeyHandler extends GraphicalViewerKeyHandler {
 
 	private boolean acceptIntoExpandedDrawer(KeyEvent event) {
 		boolean result = event.keyCode == SWT.ARROW_DOWN;
-		result = result
-				|| (isViewerMirrored() ? event.keyCode == SWT.ARROW_LEFT
-						: event.keyCode == SWT.ARROW_RIGHT);
+		result = result || (isViewerMirrored() ? event.keyCode == SWT.ARROW_LEFT
+				: event.keyCode == SWT.ARROW_RIGHT);
 		return result && isExpandedDrawer(getFocusEditPart());
 	}
 
@@ -82,10 +81,12 @@ public class PaletteViewerKeyHandler extends GraphicalViewerKeyHandler {
 	private boolean acceptSetFocusOnDrawer(KeyEvent event) {
 		boolean result = isViewerMirrored() ? event.keyCode == SWT.ARROW_RIGHT
 				: event.keyCode == SWT.ARROW_LEFT;
-		return (result || event.keyCode == SWT.ARROW_UP)
-				&& (getFocusEditPart().getParent() instanceof DrawerEditPart || (getFocusEditPart()
-						.getParent() instanceof IPaletteStackEditPart && getFocusEditPart()
-						.getParent().getParent() instanceof DrawerEditPart));
+		return (result || event.keyCode == SWT.ARROW_UP) && (getFocusEditPart()
+				.getParent() instanceof DrawerEditPart
+				|| (getFocusEditPart()
+						.getParent() instanceof IPaletteStackEditPart
+						&& getFocusEditPart().getParent()
+								.getParent() instanceof DrawerEditPart));
 	}
 
 	private boolean acceptNextContainer(KeyEvent event) {
@@ -115,7 +116,8 @@ public class PaletteViewerKeyHandler extends GraphicalViewerKeyHandler {
 					navList.add(palettePart);
 				}
 			} else if ((palettePart instanceof ToolEntryEditPart
-					|| palettePart instanceof DrawerEditPart || palettePart instanceof TemplateEditPart)) {
+					|| palettePart instanceof DrawerEditPart
+					|| palettePart instanceof TemplateEditPart)) {
 				navList.add(palettePart);
 			}
 		}
@@ -201,8 +203,9 @@ public class PaletteViewerKeyHandler extends GraphicalViewerKeyHandler {
 	boolean isCollapsedStack(EditPart focusPart) {
 		EditPart parent = focusPart.getParent();
 		return parent instanceof PaletteStackEditPart
-				|| (parent instanceof PinnablePaletteStackEditPart && !((PinnablePaletteStackEditPart) parent)
-						.isExpanded());
+				|| (parent instanceof PinnablePaletteStackEditPart
+						&& !((PinnablePaletteStackEditPart) parent)
+								.isExpanded());
 	}
 
 	/**
@@ -212,8 +215,9 @@ public class PaletteViewerKeyHandler extends GraphicalViewerKeyHandler {
 	boolean isExpandedStack(EditPart focusPart) {
 		EditPart parent = focusPart.getParent();
 		return parent instanceof PaletteStackEditPart
-				|| (parent instanceof PinnablePaletteStackEditPart && ((PinnablePaletteStackEditPart) parent)
-						.isExpanded());
+				|| (parent instanceof PinnablePaletteStackEditPart
+						&& ((PinnablePaletteStackEditPart) parent)
+								.isExpanded());
 	}
 
 	/**
@@ -301,13 +305,13 @@ public class PaletteViewerKeyHandler extends GraphicalViewerKeyHandler {
 		while (current != null) {
 			if (current instanceof DrawerEditPart
 					|| current instanceof GroupEditPart) {
-				List siblings = current.getParent().getChildren();
+				List<EditPart> siblings = current.getParent().getChildren();
 				int index = siblings.indexOf(current);
 				if (index != -1 && siblings.size() > index + 1) {
-					EditPart part = (EditPart) siblings.get(index + 1);
+					EditPart part = siblings.get(index + 1);
 					if (part instanceof GroupEditPart
-							&& part.getChildren().size() > 0) {
-						EditPart child = (EditPart) part.getChildren().get(0);
+							&& !part.getChildren().isEmpty()) {
+						EditPart child = part.getChildren().get(0);
 						navigateTo(child, event);
 					} else
 						navigateTo(part, event);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
@@ -28,7 +28,8 @@ import org.eclipse.gef.commands.UnexecutableCommand;
 import org.eclipse.gef.dnd.AbstractTransferDropTargetListener;
 import org.eclipse.gef.requests.ChangeBoundsRequest;
 
-class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener {
+class TreeViewerTransferDropListener
+		extends AbstractTransferDropTargetListener {
 
 	public TreeViewerTransferDropListener(EditPartViewer viewer) {
 		super(viewer, TreeViewerTransfer.getInstance());
@@ -38,8 +39,8 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 	protected Request createTargetRequest() {
 		ChangeBoundsRequest request = new ChangeBoundsRequest(
 				RequestConstants.REQ_MOVE);
-		request.setEditParts((List) TreeViewerTransfer.getInstance()
-				.getObject());
+		request.setEditParts(
+				(List) TreeViewerTransfer.getInstance().getObject());
 		return request;
 	}
 
@@ -102,7 +103,7 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 	protected List includeChildren(List list) {
 		List result = new ArrayList();
 		for (int i = 0; i < list.size(); i++) {
-			List children = ((EditPart) list.get(i)).getChildren();
+			List<EditPart> children = ((EditPart) list.get(i)).getChildren();
 			result.addAll(children);
 			result.addAll(includeChildren(children));
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/util/EditPartUtilities.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/util/EditPartUtilities.java
@@ -45,11 +45,13 @@ public final class EditPartUtilities {
 	 * 
 	 * @return the transitive child edit part set
 	 */
-	public static LinkedHashSet getAllChildren(GraphicalEditPart parentEditPart) {
+	public static LinkedHashSet getAllChildren(
+			GraphicalEditPart parentEditPart) {
 		LinkedHashSet transitiveChildren = new LinkedHashSet();
-		List children = parentEditPart.getChildren();
+		List<EditPart> children = parentEditPart.getChildren();
 		transitiveChildren.addAll(children);
-		for (Iterator iterator = children.iterator(); iterator.hasNext();) {
+		for (Iterator<EditPart> iterator = children.iterator(); iterator
+				.hasNext();) {
 			GraphicalEditPart child = (GraphicalEditPart) iterator.next();
 			transitiveChildren.addAll(getAllChildren(child));
 		}
@@ -90,9 +92,7 @@ public final class EditPartUtilities {
 	public static HashSet getNestedConnectionEditParts(
 			GraphicalEditPart graphicalEditPart) {
 		HashSet edges = new HashSet();
-		List children = graphicalEditPart.getChildren();
-		for (Iterator iterator = children.iterator(); iterator.hasNext();) {
-			Object child = iterator.next();
+		for (EditPart child : graphicalEditPart.getChildren()) {
 			if (child instanceof GraphicalEditPart) {
 				GraphicalEditPart childEditPart = (GraphicalEditPart) child;
 				edges.addAll(childEditPart.getSourceConnections());


### PR DESCRIPTION
One of the biggest drawbacks of current GEF Classic code is that it is not yet using typed generics. This requires a lot of checks and casts in client code. This commit is a start to move GEF Classic to a more modern java.