### PR TITLE
removed unnecessary redrawing of zest Graph upon scrolling

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -132,18 +132,6 @@ public class Graph extends FigureCanvas implements IContainer {
 
 		this.setViewport(new FreeformViewport());
 
-		this.getVerticalBar().addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent e) {
-				Graph.this.redraw();
-			}
-
-		});
-		this.getHorizontalBar().addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent e) {
-				Graph.this.redraw();
-			}
-		});
-
 		// @tag CGraph.workaround : this allows me to handle mouse events
 		// outside of the canvas
 		this.getLightweightSystem().setEventDispatcher(


### PR DESCRIPTION
As the Viewport already redraws the Graph on demand redrawing upon moving the scrollbars is unnecessary and reduces performance in bigger graphs.