### PR TITLE
[Modernize Code] use generic version of getAdapter

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
@@ -174,10 +174,9 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 					"org.eclipse.gef.examples.logic.outline.contextmenu", //$NON-NLS-1$
 					provider, getSite().getSelectionProvider());
 			getViewer().setKeyHandler(getCommonKeyHandler());
-			getViewer()
-					.addDropTargetListener(
-							(TransferDropTargetListener) new TemplateTransferDropTargetListener(
-									getViewer()));
+			getViewer().addDropTargetListener(
+					(TransferDropTargetListener) new TemplateTransferDropTargetListener(
+							getViewer()));
 			IToolBarManager tbm = getSite().getActionBars().getToolBarManager();
 			showOutlineAction = new Action() {
 				public void run() {
@@ -186,8 +185,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 			};
 			showOutlineAction.setImageDescriptor(ImageDescriptor
 					.createFromFile(LogicPlugin.class, "icons/outline.gif")); //$NON-NLS-1$
-			showOutlineAction
-					.setToolTipText(LogicMessages.LogicEditor_outline_show_outline);
+			showOutlineAction.setToolTipText(
+					LogicMessages.LogicEditor_outline_show_outline);
 			tbm.add(showOutlineAction);
 			showOverviewAction = new Action() {
 				public void run() {
@@ -196,8 +195,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 			};
 			showOverviewAction.setImageDescriptor(ImageDescriptor
 					.createFromFile(LogicPlugin.class, "icons/overview.gif")); //$NON-NLS-1$
-			showOverviewAction
-					.setToolTipText(LogicMessages.LogicEditor_outline_show_overview);
+			showOverviewAction.setToolTipText(
+					LogicMessages.LogicEditor_outline_show_overview);
 			tbm.add(showOverviewAction);
 			showPage(ID_OUTLINE);
 		}
@@ -223,10 +222,11 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 			outlinePage = null;
 		}
 
-		public Object getAdapter(Class type) {
+		@Override
+		public <T> T getAdapter(final Class<T> type) {
 			if (type == ZoomManager.class)
-				return getGraphicalViewer().getProperty(
-						ZoomManager.class.toString());
+				return type.cast(getGraphicalViewer()
+						.getProperty(ZoomManager.class.toString()));
 			return null;
 		}
 
@@ -247,10 +247,11 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 			RootEditPart rep = getGraphicalViewer().getRootEditPart();
 			if (rep instanceof ScalableFreeformRootEditPart) {
 				ScalableFreeformRootEditPart root = (ScalableFreeformRootEditPart) rep;
-				thumbnail = new ScrollableThumbnail((Viewport) root.getFigure());
+				thumbnail = new ScrollableThumbnail(
+						(Viewport) root.getFigure());
 				thumbnail.setBorder(new MarginBorder(3));
-				thumbnail.setSource(root
-						.getLayer(LayerConstants.PRINTABLE_LAYERS));
+				thumbnail.setSource(
+						root.getLayer(LayerConstants.PRINTABLE_LAYERS));
 				lws.setContents(thumbnail);
 				disposeListener = new DisposeListener() {
 					public void widgetDisposed(DisposeEvent e) {
@@ -303,8 +304,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 	// 1) An open, saved file gets deleted -> close the editor
 	// 2) An open file gets renamed or moved -> change the editor's input
 	// accordingly
-	class ResourceTracker implements IResourceChangeListener,
-			IResourceDeltaVisitor {
+	class ResourceTracker
+			implements IResourceChangeListener, IResourceDeltaVisitor {
 		public void resourceChanged(IResourceChangeEvent event) {
 			IResourceDelta delta = event.getDelta();
 			try {
@@ -316,9 +317,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		}
 
 		public boolean visit(IResourceDelta delta) {
-			if (delta == null
-					|| !delta.getResource().equals(
-							((IFileEditorInput) getEditorInput()).getFile()))
+			if (delta == null || !delta.getResource()
+					.equals(((IFileEditorInput) getEditorInput()).getFile()))
 				return true;
 
 			if (delta.getKind() == IResourceDelta.REMOVED) {
@@ -415,8 +415,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 	protected static final int DEFAULT_PALETTE_SIZE = 130;
 
 	static {
-		LogicPlugin.getDefault().getPreferenceStore()
-				.setDefault(PALETTE_SIZE, DEFAULT_PALETTE_SIZE);
+		LogicPlugin.getDefault().getPreferenceStore().setDefault(PALETTE_SIZE,
+				DEFAULT_PALETTE_SIZE);
 	}
 
 	public LogicEditor() {
@@ -441,8 +441,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		// set clipping strategy for connection layer
 		ConnectionLayer connectionLayer = (ConnectionLayer) root
 				.getLayer(LayerConstants.CONNECTION_LAYER);
-		connectionLayer
-				.setClippingStrategy(new ViewportAwareConnectionLayerClippingStrategy(
+		connectionLayer.setClippingStrategy(
+				new ViewportAwareConnectionLayerClippingStrategy(
 						connectionLayer));
 
 		List zoomLevels = new ArrayList(3);
@@ -503,8 +503,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		return new CustomPalettePage(getPaletteViewerProvider()) {
 			public void init(IPageSite pageSite) {
 				super.init(pageSite);
-				IAction copy = getActionRegistry().getAction(
-						ActionFactory.COPY.getId());
+				IAction copy = getActionRegistry()
+						.getAction(ActionFactory.COPY.getId());
 				pageSite.getActionBars().setGlobalActionHandler(
 						ActionFactory.COPY.getId(), copy);
 			}
@@ -518,8 +518,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 			protected void configurePaletteViewer(PaletteViewer viewer) {
 				super.configurePaletteViewer(viewer);
 				viewer.setCustomizer(new LogicPaletteCustomizer());
-				viewer.addDragSourceListener(new TemplateTransferDragSourceListener(
-						viewer));
+				viewer.addDragSourceListener(
+						new TemplateTransferDragSourceListener(viewer));
 			}
 
 			protected void hookPaletteViewer(PaletteViewer viewer) {
@@ -530,8 +530,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 				if (menuListener == null)
 					menuListener = new IMenuListener() {
 						public void menuAboutToShow(IMenuManager manager) {
-							manager.appendToGroup(
-									GEFActionConstants.GROUP_COPY, copy);
+							manager.appendToGroup(GEFActionConstants.GROUP_COPY,
+									copy);
 						}
 					};
 				viewer.getContextMenu().addMenuListener(menuListener);
@@ -568,14 +568,15 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		performSaveAs();
 	}
 
-	public Object getAdapter(Class type) {
+	@Override
+	public <T> T getAdapter(final Class<T> type) {
 		if (type == IContentOutlinePage.class) {
 			outlinePage = new OutlinePage(new TreeViewer());
-			return outlinePage;
+			return type.cast(outlinePage);
 		}
 		if (type == ZoomManager.class)
-			return getGraphicalViewer().getProperty(
-					ZoomManager.class.toString());
+			return type.cast(getGraphicalViewer()
+					.getProperty(ZoomManager.class.toString()));
 
 		return super.getAdapter(type);
 	}
@@ -591,10 +592,9 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 	protected KeyHandler getCommonKeyHandler() {
 		if (sharedKeyHandler == null) {
 			sharedKeyHandler = new KeyHandler();
-			sharedKeyHandler.put(
-					KeyStroke.getPressed(SWT.F2, 0),
-					getActionRegistry().getAction(
-							GEFActionConstants.DIRECT_EDIT));
+			sharedKeyHandler.put(KeyStroke.getPressed(SWT.F2, 0),
+					getActionRegistry()
+							.getAction(GEFActionConstants.DIRECT_EDIT));
 		}
 		return sharedKeyHandler;
 	}
@@ -617,10 +617,10 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		IAction copy = null;
 		if (event.type == SWT.Deactivate)
 			copy = getActionRegistry().getAction(ActionFactory.COPY.getId());
-		if (getEditorSite().getActionBars().getGlobalActionHandler(
-				ActionFactory.COPY.getId()) != copy) {
-			getEditorSite().getActionBars().setGlobalActionHandler(
-					ActionFactory.COPY.getId(), copy);
+		if (getEditorSite().getActionBars()
+				.getGlobalActionHandler(ActionFactory.COPY.getId()) != copy) {
+			getEditorSite().getActionBars()
+					.setGlobalActionHandler(ActionFactory.COPY.getId(), copy);
 			getEditorSite().getActionBars().updateActionBars();
 		}
 	}
@@ -629,15 +629,12 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		super.initializeGraphicalViewer();
 		getGraphicalViewer().setContents(getLogicDiagram());
 
-		getGraphicalViewer()
-				.addDropTargetListener(
-						(TransferDropTargetListener) new TemplateTransferDropTargetListener(
-								getGraphicalViewer()));
-		getGraphicalViewer()
-				.addDropTargetListener(
-						(TransferDropTargetListener) new TextTransferDropTargetListener(
-								getGraphicalViewer(), TextTransfer
-										.getInstance()));
+		getGraphicalViewer().addDropTargetListener(
+				(TransferDropTargetListener) new TemplateTransferDropTargetListener(
+						getGraphicalViewer()));
+		getGraphicalViewer().addDropTargetListener(
+				(TransferDropTargetListener) new TextTransferDropTargetListener(
+						getGraphicalViewer(), TextTransfer.getInstance()));
 	}
 
 	protected void createActions() {
@@ -710,15 +707,14 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 	/*
 	 * (non-Javadoc)
 	 * 
-	 * @see
-	 * org.eclipse.gef.ui.parts.GraphicalEditor#createGraphicalViewer(org.eclipse
-	 * .swt.widgets.Composite)
+	 * @see org.eclipse.gef.ui.parts.GraphicalEditor#createGraphicalViewer(org.
+	 * eclipse .swt.widgets.Composite)
 	 */
 	protected void createGraphicalViewer(Composite parent) {
 		rulerComp = new RulerComposite(parent, SWT.NONE);
 		super.createGraphicalViewer(rulerComp);
-		rulerComp
-				.setGraphicalViewer((ScrollingGraphicalViewer) getGraphicalViewer());
+		rulerComp.setGraphicalViewer(
+				(ScrollingGraphicalViewer) getGraphicalViewer());
 	}
 
 	protected FigureCanvas getEditor() {
@@ -743,8 +739,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		if (ruler != null) {
 			provider = new LogicRulerProvider(ruler);
 		}
-		getGraphicalViewer().setProperty(
-				RulerProvider.PROPERTY_HORIZONTAL_RULER, provider);
+		getGraphicalViewer()
+				.setProperty(RulerProvider.PROPERTY_HORIZONTAL_RULER, provider);
 		getGraphicalViewer().setProperty(
 				RulerProvider.PROPERTY_RULER_VISIBILITY,
 				Boolean.valueOf(getLogicDiagram().getRulerVisibility()));
@@ -761,8 +757,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 				Boolean.valueOf(getLogicDiagram().isGridEnabled()));
 
 		// Zoom
-		ZoomManager manager = (ZoomManager) getGraphicalViewer().getProperty(
-				ZoomManager.class.toString());
+		ZoomManager manager = (ZoomManager) getGraphicalViewer()
+				.getProperty(ZoomManager.class.toString());
 		if (manager != null)
 			manager.setZoom(getLogicDiagram().getZoom());
 		// Scroll-wheel Zoom
@@ -773,8 +769,8 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 	}
 
 	protected boolean performSaveAs() {
-		SaveAsDialog dialog = new SaveAsDialog(getSite().getWorkbenchWindow()
-				.getShell());
+		SaveAsDialog dialog = new SaveAsDialog(
+				getSite().getWorkbenchWindow().getShell());
 		dialog.setOriginalFile(((IFileEditorInput) getEditorInput()).getFile());
 		dialog.open();
 		IPath path = dialog.getResult();
@@ -792,8 +788,7 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 					try {
 						ByteArrayOutputStream out = new ByteArrayOutputStream();
 						writeToOutputStream(out);
-						file.create(
-								new ByteArrayInputStream(out.toByteArray()),
+						file.create(new ByteArrayInputStream(out.toByteArray()),
 								true, monitor);
 						out.close();
 					} catch (Exception e) {
@@ -802,8 +797,9 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 				}
 			};
 			try {
-				new ProgressMonitorDialog(getSite().getWorkbenchWindow()
-						.getShell()).run(false, true, op);
+				new ProgressMonitorDialog(
+						getSite().getWorkbenchWindow().getShell()).run(false,
+								true, op);
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
@@ -819,18 +815,16 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 	}
 
 	protected void saveProperties() {
-		getLogicDiagram().setRulerVisibility(
-				((Boolean) getGraphicalViewer().getProperty(
-						RulerProvider.PROPERTY_RULER_VISIBILITY))
+		getLogicDiagram().setRulerVisibility(((Boolean) getGraphicalViewer()
+				.getProperty(RulerProvider.PROPERTY_RULER_VISIBILITY))
 						.booleanValue());
-		getLogicDiagram().setGridEnabled(
-				((Boolean) getGraphicalViewer().getProperty(
-						SnapToGrid.PROPERTY_GRID_ENABLED)).booleanValue());
-		getLogicDiagram().setSnapToGeometry(
-				((Boolean) getGraphicalViewer().getProperty(
-						SnapToGeometry.PROPERTY_SNAP_ENABLED)).booleanValue());
-		ZoomManager manager = (ZoomManager) getGraphicalViewer().getProperty(
-				ZoomManager.class.toString());
+		getLogicDiagram().setGridEnabled(((Boolean) getGraphicalViewer()
+				.getProperty(SnapToGrid.PROPERTY_GRID_ENABLED)).booleanValue());
+		getLogicDiagram().setSnapToGeometry(((Boolean) getGraphicalViewer()
+				.getProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED))
+						.booleanValue());
+		ZoomManager manager = (ZoomManager) getGraphicalViewer()
+				.getProperty(ZoomManager.class.toString());
 		if (manager != null)
 			getLogicDiagram().setZoom(manager.getZoom());
 	}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/CircuitEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/CircuitEditPart.java
@@ -18,6 +18,7 @@ import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.IScrollableFigure;
 import org.eclipse.draw2d.XYLayout;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.AccessibleAnchorProvider;
@@ -38,8 +39,8 @@ import org.eclipse.gef.examples.logicdesigner.figures.FigureFactory;
  * Holds a circuit, which is a container capable of holding other
  * LogicEditParts.
  */
-public class CircuitEditPart extends LogicContainerEditPart implements
-		IScrollableEditPart {
+public class CircuitEditPart extends LogicContainerEditPart
+		implements IScrollableEditPart {
 
 	private static final String SCROLLABLE_SELECTION_FEEDBACK = "SCROLLABLE_SELECTION_FEEDBACK"; //$NON-NLS-1$
 
@@ -62,15 +63,17 @@ public class CircuitEditPart extends LogicContainerEditPart implements
 		return FigureFactory.createNewCircuit();
 	}
 
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AutoexposeHelper.class)
-			return new ViewportAutoexposeHelper(this);
+			return key.cast(new ViewportAutoexposeHelper(this));
 		if (key == ExposeHelper.class)
-			return new ViewportExposeHelper(this);
+			return key.cast(new ViewportExposeHelper(this));
 		if (key == AccessibleAnchorProvider.class)
-			return new DefaultAccessibleAnchorProvider() {
-				public List getSourceAnchorLocations() {
-					List list = new ArrayList();
+			return key.cast(new DefaultAccessibleAnchorProvider() {
+				@Override
+				public List<Point> getSourceAnchorLocations() {
+					List<Point> list = new ArrayList<>();
 					Vector sourceAnchors = getNodeFigure()
 							.getSourceConnectionAnchors();
 					Vector targetAnchors = getNodeFigure()
@@ -80,9 +83,8 @@ public class CircuitEditPart extends LogicContainerEditPart implements
 								.get(i);
 						ConnectionAnchor targetAnchor = (ConnectionAnchor) targetAnchors
 								.get(i);
-						list.add(new Rectangle(
-								sourceAnchor.getReferencePoint(), targetAnchor
-										.getReferencePoint()).getCenter());
+						list.add(new Rectangle(sourceAnchor.getReferencePoint(),
+								targetAnchor.getReferencePoint()).getCenter());
 					}
 					return list;
 				}
@@ -90,9 +92,9 @@ public class CircuitEditPart extends LogicContainerEditPart implements
 				public List getTargetAnchorLocations() {
 					return getSourceAnchorLocations();
 				}
-			};
+			});
 		if (key == MouseWheelHelper.class)
-			return new ViewportMouseWheelHelper(this);
+			return key.cast(new ViewportMouseWheelHelper(this));
 		return super.getAdapter(key);
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/GateEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/GateEditPart.java
@@ -16,6 +16,7 @@ import java.util.Vector;
 
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AccessibleAnchorProvider;
 
@@ -53,24 +54,25 @@ public class GateEditPart extends OutputEditPart {
 		return figure;
 	}
 
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleAnchorProvider.class)
-			return new DefaultAccessibleAnchorProvider() {
-				public List getSourceAnchorLocations() {
-					List list = new ArrayList();
+			return key.cast(new DefaultAccessibleAnchorProvider() {
+				public List<Point> getSourceAnchorLocations() {
+					List<Point> list = new ArrayList<>();
 					Vector sourceAnchors = getNodeFigure()
 							.getSourceConnectionAnchors();
 					for (int i = 0; i < sourceAnchors.size(); i++) {
 						ConnectionAnchor anchor = (ConnectionAnchor) sourceAnchors
 								.get(i);
-						list.add(anchor.getReferencePoint()
-								.getTranslated(0, -3));
+						list.add(anchor.getReferencePoint().getTranslated(0,
+								-3));
 					}
 					return list;
 				}
 
-				public List getTargetAnchorLocations() {
-					List list = new ArrayList();
+				public List<Object> getTargetAnchorLocations() {
+					List<Object> list = new ArrayList<>();
 					Vector targetAnchors = getNodeFigure()
 							.getTargetConnectionAnchors();
 					for (int i = 0; i < targetAnchors.size(); i++) {
@@ -80,7 +82,7 @@ public class GateEditPart extends OutputEditPart {
 					}
 					return list;
 				}
-			};
+			});
 		return super.getAdapter(key);
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LEDEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LEDEditPart.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AccessibleAnchorProvider;
 import org.eclipse.gef.AccessibleEditPart;
@@ -78,34 +79,36 @@ public class LEDEditPart extends LogicEditPart {
 		return FigureFactory.createNewLED();
 	}
 
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleAnchorProvider.class)
-			return new DefaultAccessibleAnchorProvider() {
-				public List getSourceAnchorLocations() {
-					List list = new ArrayList();
+			return key.cast(new DefaultAccessibleAnchorProvider() {
+				public List<Point> getSourceAnchorLocations() {
+					List<Point> list = new ArrayList<>();
 					Vector sourceAnchors = getNodeFigure()
 							.getSourceConnectionAnchors();
 					for (int i = 0; i < sourceAnchors.size(); i++) {
 						ConnectionAnchor anchor = (ConnectionAnchor) sourceAnchors
 								.get(i);
-						list.add(anchor.getReferencePoint()
-								.getTranslated(0, -3));
+						list.add(anchor.getReferencePoint().getTranslated(0,
+								-3));
 					}
 					return list;
 				}
 
-				public List getTargetAnchorLocations() {
-					List list = new ArrayList();
+				public List<Point> getTargetAnchorLocations() {
+					List<Point> list = new ArrayList<>();
 					Vector targetAnchors = getNodeFigure()
 							.getTargetConnectionAnchors();
 					for (int i = 0; i < targetAnchors.size(); i++) {
 						ConnectionAnchor anchor = (ConnectionAnchor) targetAnchors
 								.get(i);
-						list.add(anchor.getReferencePoint().getTranslated(0, 3));
+						list.add(
+								anchor.getReferencePoint().getTranslated(0, 3));
 					}
 					return list;
 				}
-			};
+			});
 		return super.getAdapter(key);
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicDiagramEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicDiagramEditPart.java
@@ -58,8 +58,8 @@ import org.eclipse.gef.examples.logicdesigner.model.LogicDiagram;
  * LogicEditorPart, to hold the entire model. It is sort of a blank board where
  * all other EditParts get added.
  */
-public class LogicDiagramEditPart extends LogicContainerEditPart implements
-		LayerConstants {
+public class LogicDiagramEditPart extends LogicContainerEditPart
+		implements LayerConstants {
 
 	protected AccessibleEditPart createAccessible() {
 		return new AccessibleGraphicalEditPart() {
@@ -102,31 +102,32 @@ public class LogicDiagramEditPart extends LogicContainerEditPart implements
 	/**
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class adapter) {
+	@Override
+	public <T> T getAdapter(final Class<T> adapter) {
 		if (adapter == SnapToHelper.class) {
 			List snapStrategies = new ArrayList();
-			Boolean val = (Boolean) getViewer().getProperty(
-					RulerProvider.PROPERTY_RULER_VISIBILITY);
+			Boolean val = (Boolean) getViewer()
+					.getProperty(RulerProvider.PROPERTY_RULER_VISIBILITY);
 			if (val != null && val.booleanValue())
 				snapStrategies.add(new SnapToGuides(this));
-			val = (Boolean) getViewer().getProperty(
-					SnapToGeometry.PROPERTY_SNAP_ENABLED);
+			val = (Boolean) getViewer()
+					.getProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED);
 			if (val != null && val.booleanValue())
 				snapStrategies.add(new SnapToGeometry(this));
-			val = (Boolean) getViewer().getProperty(
-					SnapToGrid.PROPERTY_GRID_ENABLED);
+			val = (Boolean) getViewer()
+					.getProperty(SnapToGrid.PROPERTY_GRID_ENABLED);
 			if (val != null && val.booleanValue())
 				snapStrategies.add(new SnapToGrid(this));
 
 			if (snapStrategies.size() == 0)
 				return null;
 			if (snapStrategies.size() == 1)
-				return snapStrategies.get(0);
+				return adapter.cast(snapStrategies.get(0));
 
 			SnapToHelper ss[] = new SnapToHelper[snapStrategies.size()];
 			for (int i = 0; i < snapStrategies.size(); i++)
 				ss[i] = (SnapToHelper) snapStrategies.get(i);
-			return new CompoundSnapToHelper(ss);
+			return adapter.cast(new CompoundSnapToHelper(ss));
 		}
 		return super.getAdapter(adapter);
 	}
@@ -189,17 +190,17 @@ public class LogicDiagramEditPart extends LogicContainerEditPart implements
 		if ((getViewer().getControl().getStyle() & SWT.MIRRORED) == 0)
 			cLayer.setAntialias(SWT.ON);
 
-		if (getLogicDiagram().getConnectionRouter().equals(
-				LogicDiagram.ROUTER_MANUAL)) {
+		if (getLogicDiagram().getConnectionRouter()
+				.equals(LogicDiagram.ROUTER_MANUAL)) {
 			AutomaticRouter router = new FanRouter();
 			router.setNextRouter(new BendpointConnectionRouter());
 			cLayer.setConnectionRouter(router);
-		} else if (getLogicDiagram().getConnectionRouter().equals(
-				LogicDiagram.ROUTER_MANHATTAN))
+		} else if (getLogicDiagram().getConnectionRouter()
+				.equals(LogicDiagram.ROUTER_MANHATTAN))
 			cLayer.setConnectionRouter(new ManhattanConnectionRouter());
 		else
-			cLayer.setConnectionRouter(new ShortestPathConnectionRouter(
-					getFigure()));
+			cLayer.setConnectionRouter(
+					new ShortestPathConnectionRouter(getFigure()));
 		Animation.run(400);
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/OutputEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/OutputEditPart.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AccessibleAnchorProvider;
 import org.eclipse.gef.AccessibleEditPart;
@@ -58,23 +59,24 @@ public class OutputEditPart extends LogicEditPart {
 		return figure;
 	}
 
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleAnchorProvider.class)
-			return new DefaultAccessibleAnchorProvider() {
-				public List getSourceAnchorLocations() {
-					List list = new ArrayList();
+			return key.cast(new DefaultAccessibleAnchorProvider() {
+				public List<Point> getSourceAnchorLocations() {
+					List<Point> list = new ArrayList<>();
 					Vector sourceAnchors = getNodeFigure()
 							.getSourceConnectionAnchors();
 					for (int i = 0; i < sourceAnchors.size(); i++) {
 						ConnectionAnchor anchor = (ConnectionAnchor) sourceAnchors
 								.get(i);
-						list.add(anchor.getReferencePoint()
-								.getTranslated(0, -3));
+						list.add(anchor.getReferencePoint().getTranslated(0,
+								-3));
 					}
 					return list;
 				}
 
-			};
+			});
 		return super.getAdapter(key);
 	}
 

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
@@ -7,7 +7,7 @@
  *
  * Contributors:
  * Elias Volanakis - initial API and implementation
- *******************************************************************************/
+ï¿½*******************************************************************************/
 package org.eclipse.gef.examples.shapes;
 
 import java.io.ByteArrayInputStream;
@@ -144,8 +144,8 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 				// CombinatedTemplateCreationEntries
 				// from the palette into the editor
 				// @see ShapesEditor#createTransferDropTargetListener()
-				viewer.addDragSourceListener(new TemplateTransferDragSourceListener(
-						viewer));
+				viewer.addDragSourceListener(
+						new TemplateTransferDragSourceListener(viewer));
 			}
 		};
 	}
@@ -168,9 +168,8 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 	/*
 	 * (non-Javadoc)
 	 * 
-	 * @see
-	 * org.eclipse.ui.ISaveablePart#doSave(org.eclipse.core.runtime.IProgressMonitor
-	 * )
+	 * @see org.eclipse.ui.ISaveablePart#doSave(org.eclipse.core.runtime.
+	 * IProgressMonitor )
 	 */
 	public void doSave(IProgressMonitor monitor) {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -220,13 +219,14 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 				new ProgressMonitorDialog(shell).run(false, // don't fork
 						false, // not cancelable
 						new WorkspaceModifyOperation() { // run this operation
-							public void execute(final IProgressMonitor monitor) {
+							public void execute(
+									final IProgressMonitor monitor) {
 								try {
 									ByteArrayOutputStream out = new ByteArrayOutputStream();
 									createOutputStream(out);
 									file.create(
-											new ByteArrayInputStream(out
-													.toByteArray()), // contents
+											new ByteArrayInputStream(
+													out.toByteArray()), // contents
 											true, // keep saving, even if IFile
 													// is out of sync with the
 													// Workspace
@@ -250,9 +250,10 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 		}
 	}
 
-	public Object getAdapter(Class type) {
+	@Override
+	public <T> T getAdapter(final Class<T> type) {
 		if (type == IContentOutlinePage.class)
-			return new ShapesOutlinePage(new TreeViewer());
+			return type.cast(new ShapesOutlinePage(new TreeViewer()));
 		return super.getAdapter(type);
 	}
 
@@ -343,9 +344,8 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 		/*
 		 * (non-Javadoc)
 		 * 
-		 * @see
-		 * org.eclipse.ui.part.IPage#createControl(org.eclipse.swt.widgets.Composite
-		 * )
+		 * @see org.eclipse.ui.part.IPage#createControl(org.eclipse.swt.widgets.
+		 * Composite )
 		 */
 		public void createControl(Composite parent) {
 			// create outline viewer page

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
@@ -160,13 +160,13 @@ public class TextEditor extends GraphicalEditor {
 
 		action = new MultiStyleAction(styleService,
 				TextActionConstants.BLOCK_ALIGN_CENTER,
-				Style.PROPERTY_ALIGNMENT, Integer.valueOf(PositionConstants.CENTER));
+				Style.PROPERTY_ALIGNMENT,
+				Integer.valueOf(PositionConstants.CENTER));
 		registry.registerAction(action);
 
 		action = new MultiStyleAction(styleService,
-				TextActionConstants.BLOCK_ALIGN_RIGHT,
-				Style.PROPERTY_ALIGNMENT, Integer.valueOf(
-						PositionConstants.ALWAYS_RIGHT));
+				TextActionConstants.BLOCK_ALIGN_RIGHT, Style.PROPERTY_ALIGNMENT,
+				Integer.valueOf(PositionConstants.ALWAYS_RIGHT));
 		registry.registerAction(action);
 
 		action = new MultiStyleAction(styleService,
@@ -192,11 +192,12 @@ public class TextEditor extends GraphicalEditor {
 		initializeGraphicalViewer();
 	}
 
-	public Object getAdapter(Class type) {
+	@Override
+	public <T> T getAdapter(final Class<T> type) {
 		if (type == IContentOutlinePage.class)
-			return createOutlinePage();
+			return type.cast(createOutlinePage());
 		if (type == StyleService.class)
-			return styleService;
+			return type.cast(styleService);
 		return super.getAdapter(type);
 	}
 
@@ -272,8 +273,8 @@ public class TextEditor extends GraphicalEditor {
 	public void init(IEditorSite site, IEditorInput input)
 			throws PartInitException {
 		setEditDomain(new DefaultEditDomain(this));
-		getCommandStack().addCommandStackEventListener(
-				new CommandStackEventListener() {
+		getCommandStack()
+				.addCommandStackEventListener(new CommandStackEventListener() {
 					public void stackChanged(CommandStackEvent event) {
 						TextCommand command = (TextCommand) event.getCommand();
 						if (command != null) {
@@ -281,10 +282,12 @@ public class TextEditor extends GraphicalEditor {
 							if (event.getDetail() == CommandStack.POST_EXECUTE)
 								textViewer.setSelectionRange(command
 										.getExecuteSelectionRange(textViewer));
-							else if (event.getDetail() == CommandStack.POST_REDO)
+							else if (event
+									.getDetail() == CommandStack.POST_REDO)
 								textViewer.setSelectionRange(command
 										.getRedoSelectionRange(textViewer));
-							else if (event.getDetail() == CommandStack.POST_UNDO)
+							else if (event
+									.getDetail() == CommandStack.POST_UNDO)
 								textViewer.setSelectionRange(command
 										.getUndoSelectionRange(textViewer));
 						}
@@ -293,8 +296,8 @@ public class TextEditor extends GraphicalEditor {
 
 		super.init(site, input);
 
-		site.getKeyBindingService().setScopes(
-				new String[] { GEFActionConstants.CONTEXT_TEXT });
+		site.getKeyBindingService()
+				.setScopes(new String[] { GEFActionConstants.CONTEXT_TEXT });
 		site.getActionBars().setGlobalActionHandler(ActionFactory.UNDO.getId(),
 				getActionRegistry().getAction(ActionFactory.UNDO.getId()));
 		site.getActionBars().setGlobalActionHandler(ActionFactory.REDO.getId(),
@@ -347,11 +350,10 @@ public class TextEditor extends GraphicalEditor {
 			Container code = new Block(Container.TYPE_PARAGRAPH);
 			code.getStyle().setFontFamily("Courier New");
 			doc.add(code);
-			code.add(new TextRun(
-					"public void countToANumber(int limit) {\n"
-							+ "    for (int i = 0; i < limit; i++)\n"
-							+ "        System.out.println(\"Counting: \" + i); //$NON-NLS-1$\n\n"
-							+ "}", TextRun.TYPE_CODE));
+			code.add(new TextRun("public void countToANumber(int limit) {\n"
+					+ "    for (int i = 0; i < limit; i++)\n"
+					+ "        System.out.println(\"Counting: \" + i); //$NON-NLS-1$\n\n"
+					+ "}", TextRun.TYPE_CODE));
 			// }
 		}
 

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/actions/StyleComboContributionItem.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/actions/StyleComboContributionItem.java
@@ -47,8 +47,7 @@ public abstract class StyleComboContributionItem extends ContributionItem {
 		public void partActivated(IWorkbenchPartReference partRef) {
 			IWorkbenchPart part = partRef.getPart(false);
 			if (part instanceof TextEditor)
-				setStyleService((StyleService) part
-						.getAdapter(StyleService.class));
+				setStyleService(part.getAdapter(StyleService.class));
 		}
 
 		public void partBroughtToTop(IWorkbenchPartReference partRef) {
@@ -165,8 +164,8 @@ public abstract class StyleComboContributionItem extends ContributionItem {
 		if (styleService == null)
 			enablement = false;
 		else {
-			if (!styleService.getStyleState(getProperty()).equals(
-					StyleService.STATE_EDITABLE))
+			if (!styleService.getStyleState(getProperty())
+					.equals(StyleService.STATE_EDITABLE))
 				// we want the combo disabled, but still want to update the
 				// value
 				enablement = false;

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/edit/DocumentPart.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/edit/DocumentPart.java
@@ -35,9 +35,10 @@ public class DocumentPart extends BlockTextPart implements TextStyleManager {
 		installEditPolicy("Text Editing", new BlockEditPolicy());
 	}
 
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == TextStyleManager.class)
-			return this;
+			return key.cast(this);
 		return super.getAdapter(key);
 	}
 
@@ -87,8 +88,8 @@ public class DocumentPart extends BlockTextPart implements TextStyleManager {
 				TextRun run = (TextRun) ((TextEditPart) iter.next()).getModel();
 				if (fontName == null)
 					fontName = run.getContainer().getStyle().getFontFamily();
-				else if (!fontName.equals(run.getContainer().getStyle()
-						.getFontFamily()))
+				else if (!fontName
+						.equals(run.getContainer().getStyle().getFontFamily()))
 					return StyleService.UNDEFINED;
 			}
 			return fontName;

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
@@ -280,14 +280,14 @@ public class TextTool extends SelectionTool implements StyleProvider {
 		setTextInputMode(MODE_BS);
 		SelectionRange range = getSelectionRange();
 		if (range.isEmpty()) {
-			if (handleTextEdit(new TextRequest(TextRequest.REQ_BACKSPACE,
-					range, pendingCommand)))
+			if (handleTextEdit(new TextRequest(TextRequest.REQ_BACKSPACE, range,
+					pendingCommand)))
 				return true;
 			doSelect(CaretRequest.COLUMN, false, false, null);
 			return false;
 		} else
-			return handleTextEdit(new TextRequest(TextRequest.REQ_REMOVE_RANGE,
-					range));
+			return handleTextEdit(
+					new TextRequest(TextRequest.REQ_REMOVE_RANGE, range));
 	}
 
 	private boolean doDelete() {
@@ -301,8 +301,8 @@ public class TextTool extends SelectionTool implements StyleProvider {
 			doSelect(CaretRequest.COLUMN, true, false, null);
 			return false;
 		} else
-			return handleTextEdit(new TextRequest(TextRequest.REQ_REMOVE_RANGE,
-					range));
+			return handleTextEdit(
+					new TextRequest(TextRequest.REQ_REMOVE_RANGE, range));
 	}
 
 	/**
@@ -395,8 +395,9 @@ public class TextTool extends SelectionTool implements StyleProvider {
 		} else {
 			TextLocation caretLocation = getCaretLocation();
 			if (loc == null)
-				search.setLocation(new Point(xCaptured ? caretXLoc
-						: getCaretBounds().x, getCaretInfo().getBaseline()));
+				search.setLocation(
+						new Point(xCaptured ? caretXLoc : getCaretBounds().x,
+								getCaretInfo().getBaseline()));
 			search.where = caretLocation;
 			caretLocation.part.getTextLocation(search, result);
 			// isForward = range.isForward;
@@ -545,8 +546,7 @@ public class TextTool extends SelectionTool implements StyleProvider {
 		EditPart target = getTextTarget(req);
 		if (target == null)
 			return StyleService.UNDEFINED;
-		TextStyleManager manager = (TextStyleManager) target
-				.getAdapter(TextStyleManager.class);
+		TextStyleManager manager = target.getAdapter(TextStyleManager.class);
 		if (isState)
 			return manager.getStyleState(styleID, getSelectionRange());
 		return manager.getStyleValue(styleID, getSelectionRange());
@@ -567,8 +567,8 @@ public class TextTool extends SelectionTool implements StyleProvider {
 		SelectionRange range = getSelectionRange();
 		if (range == null)
 			return null;
-		EditPart target, candidate = ToolUtilities.findCommonAncestor(
-				range.begin.part, range.end.part);
+		EditPart target, candidate = ToolUtilities
+				.findCommonAncestor(range.begin.part, range.end.part);
 
 		do {
 			target = candidate.getTargetEditPart(request);
@@ -608,7 +608,8 @@ public class TextTool extends SelectionTool implements StyleProvider {
 	}
 
 	protected void handleKeyTraversed(TraverseEvent event) {
-		if ((event.detail == SWT.TRAVERSE_TAB_PREVIOUS || event.detail == SWT.TRAVERSE_TAB_NEXT)
+		if ((event.detail == SWT.TRAVERSE_TAB_PREVIOUS
+				|| event.detail == SWT.TRAVERSE_TAB_NEXT)
 				&& (event.stateMask & SWT.CTRL) == 0)
 			event.doit = false;
 	}
@@ -781,8 +782,8 @@ public class TextTool extends SelectionTool implements StyleProvider {
 			UpdateManager manager = getUpdateManager();
 			if (manager != null)
 				manager.removeUpdateListener(updateListener);
-			currentViewer.setProperty(KEY_OVERWRITE, overwrite ? Boolean.TRUE
-					: Boolean.FALSE);
+			currentViewer.setProperty(KEY_OVERWRITE,
+					overwrite ? Boolean.TRUE : Boolean.FALSE);
 			if (styleService != null)
 				styleService.setStyleProvider(null);
 			setTextInputMode(0);

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
@@ -13,8 +13,6 @@ package org.eclipse.gef.test;
 
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
@@ -29,6 +27,8 @@ import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.IPropertyListener;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PartInitException;
+
+import junit.framework.TestCase;
 
 public class DragEditPartsTrackerTest extends TestCase {
 	/**
@@ -45,8 +45,8 @@ public class DragEditPartsTrackerTest extends TestCase {
 		super.tearDown();
 	}
 
-	private static class TestGraphicalEditPart extends
-			AbstractGraphicalEditPart {
+	private static class TestGraphicalEditPart
+			extends AbstractGraphicalEditPart {
 
 		/*
 		 * (non-Javadoc)
@@ -148,7 +148,8 @@ public class DragEditPartsTrackerTest extends TestCase {
 			return false;
 		}
 
-		public Object getAdapter(Class adapter) {
+		@Override
+		public <T> T getAdapter(final Class<T> adapter) {
 			return null;
 		}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/AutoexposeHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/AutoexposeHelper.java
@@ -19,9 +19,9 @@ import org.eclipse.draw2d.geometry.Point;
  * <code>DragTrackers</code> tools and native drop listeners will make use of
  * autoexpose helpers to reveal any potential drop areas that are currently not
  * visible to the user. An example of this is scrolling a container to reveal
- * unexposed area. Another example is a bunch of stacked containers in a
- * "tab folder" arrangement, whever hovering over a tab should switch which
- * container is on top.
+ * unexposed area. Another example is a bunch of stacked containers in a "tab
+ * folder" arrangement, whever hovering over a tab should switch which container
+ * is on top.
  * <P>
  * Autoexpose helpers are obtained from editparts that are target of whatever
  * operation is being performed. If the target provides no helper, its parent
@@ -95,8 +95,7 @@ public interface AutoexposeHelper {
 		public AutoexposeHelper result;
 
 		public boolean evaluate(EditPart editpart) {
-			result = editpart
-					.getAdapter(AutoexposeHelper.class);
+			result = editpart.getAdapter(AutoexposeHelper.class);
 			if (result != null && result.detect(where))
 				return true;
 			result = null;

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractConnectionEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractConnectionEditPart.java
@@ -34,8 +34,9 @@ import org.eclipse.gef.tools.SelectEditPartTracker;
 /**
  * The base implementation for {@link org.eclipse.gef.ConnectionEditPart}.
  */
-public abstract class AbstractConnectionEditPart extends
-		AbstractGraphicalEditPart implements ConnectionEditPart, LayerConstants {
+public abstract class AbstractConnectionEditPart
+		extends AbstractGraphicalEditPart
+		implements ConnectionEditPart, LayerConstants {
 
 	private static final ConnectionAnchor DEFAULT_SOURCE_ANCHOR = new XYAnchor(
 			new Point(10, 10));
@@ -50,8 +51,8 @@ public abstract class AbstractConnectionEditPart extends
 	 * @author hudsonr
 	 * @since 2.0
 	 */
-	protected final class DefaultAccessibleAnchorProvider implements
-			AccessibleAnchorProvider {
+	protected final class DefaultAccessibleAnchorProvider
+			implements AccessibleAnchorProvider {
 		/**
 		 * This class is internal, but is made protected so that JavaDoc will
 		 * see it.
@@ -132,9 +133,10 @@ public abstract class AbstractConnectionEditPart extends
 	 *            the adapter Class
 	 * @return the adapter
 	 */
-	public Object getAdapter(Class adapter) {
+	@Override
+	public <T> T getAdapter(final Class<T> adapter) {
 		if (adapter == AccessibleAnchorProvider.class)
-			return new DefaultAccessibleAnchorProvider();
+			return adapter.cast(new DefaultAccessibleAnchorProvider());
 		return super.getAdapter(adapter);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
@@ -458,9 +458,10 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants,
 	 * 
 	 * @see IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (AccessibleEditPart.class == key)
-			return getAccessibleEditPart();
+			return key.cast(getAccessibleEditPart());
 		return Platform.getAdapterManager().getAdapter(this, key);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
@@ -71,8 +71,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * 
 	 * @since 2.0
 	 */
-	protected abstract class AccessibleGraphicalEditPart extends
-			AccessibleEditPart {
+	protected abstract class AccessibleGraphicalEditPart
+			extends AccessibleEditPart {
 		/**
 		 * @see AccessibleEditPart#getChildCount(AccessibleControlEvent)
 		 */
@@ -119,7 +119,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 			e.detail = ACC.STATE_SELECTABLE | ACC.STATE_FOCUSABLE;
 			if (getSelected() != EditPart.SELECTED_NONE)
 				e.detail |= ACC.STATE_SELECTED;
-			if (getViewer().getFocusEditPart() == AbstractGraphicalEditPart.this)
+			if (getViewer()
+					.getFocusEditPart() == AbstractGraphicalEditPart.this)
 				e.detail |= ACC.STATE_FOCUSED;
 		}
 
@@ -138,8 +139,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * 
 	 * @since 2.0
 	 */
-	protected class DefaultAccessibleAnchorProvider implements
-			AccessibleAnchorProvider {
+	protected class DefaultAccessibleAnchorProvider
+			implements AccessibleAnchorProvider {
 		private List getDefaultLocations() {
 			List list = new ArrayList();
 			Rectangle r = getFigure().getBounds();
@@ -250,7 +251,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * @param index
 	 *            Index where it is being added
 	 */
-	protected void addSourceConnection(ConnectionEditPart connection, int index) {
+	protected void addSourceConnection(ConnectionEditPart connection,
+			int index) {
 		primAddSourceConnection(connection, index);
 
 		GraphicalEditPart source = (GraphicalEditPart) connection.getSource();
@@ -281,7 +283,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * @param index
 	 *            Index where it is being added
 	 */
-	protected void addTargetConnection(ConnectionEditPart connection, int index) {
+	protected void addTargetConnection(ConnectionEditPart connection,
+			int index) {
 		primAddTargetConnection(connection, index);
 
 		GraphicalEditPart target = (GraphicalEditPart) connection.getTarget();
@@ -447,16 +450,18 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 * adapter types. Currently, these types include
 	 * {@link AccessibleHandleProvider} and {@link AccessibleAnchorProvider}.
 	 * Subclasses should <em>extend</em> this method to support additional
-	 * adapter types, or to replace the default provided adapaters.
+	 * adapter types, or to replace the default provided adapters.
 	 * 
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(Class)
 	 */
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleHandleProvider.class)
-			return new MergedAccessibleHandles(getEditPolicyIterator());
+			return key
+					.cast(new MergedAccessibleHandles(getEditPolicyIterator()));
 
 		if (key == AccessibleAnchorProvider.class)
-			return new DefaultAccessibleAnchorProvider();
+			return key.cast(new DefaultAccessibleAnchorProvider());
 
 		return super.getAdapter(key);
 	}
@@ -686,7 +691,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 			model = modelObjects.get(i);
 
 			if (i < sourceConnections.size()
-					&& ((EditPart) sourceConnections.get(i)).getModel() == model)
+					&& ((EditPart) sourceConnections.get(i))
+							.getModel() == model)
 				continue;
 
 			editPart = (ConnectionEditPart) modelToEditPart.get(model);
@@ -749,7 +755,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 			model = modelObjects.get(i);
 
 			if (i < targetConnections.size()
-					&& ((EditPart) targetConnections.get(i)).getModel() == model)
+					&& ((EditPart) targetConnections.get(i))
+							.getModel() == model)
 				continue;
 
 			editPart = (ConnectionEditPart) modelToEditPart.get(model);
@@ -833,8 +840,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 *            Connection being removed
 	 */
 	protected void removeSourceConnection(ConnectionEditPart connection) {
-		fireRemovingSourceConnection(connection, getSourceConnections()
-				.indexOf(connection));
+		fireRemovingSourceConnection(connection,
+				getSourceConnections().indexOf(connection));
 		if (connection.getSource() == this) {
 			connection.deactivate();
 			connection.setSource(null);
@@ -852,8 +859,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart
 	 *            Connection being removed
 	 */
 	protected void removeTargetConnection(ConnectionEditPart connection) {
-		fireRemovingTargetConnection(connection, getTargetConnections()
-				.indexOf(connection));
+		fireRemovingTargetConnection(connection,
+				getTargetConnections().indexOf(connection));
 		if (connection.getTarget() == this)
 			connection.setTarget(null);
 		primRemoveTargetConnection(connection);

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
@@ -82,8 +82,8 @@ import org.eclipse.gef.tools.MarqueeDragTracker;
  * </table>
  * 
  */
-public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
-		LayerConstants, LayerManager {
+public class FreeformGraphicalRootEditPart extends SimpleRootEditPart
+		implements LayerConstants, LayerManager {
 
 	private LayeredPane innerLayers;
 	private LayeredPane printableLayers;
@@ -151,9 +151,10 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	/**
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class adapter) {
+	@Override
+	public <T> T getAdapter(final Class<T> adapter) {
 		if (adapter == AutoexposeHelper.class)
-			return new ViewportAutoexposeHelper(this);
+			return adapter.cast(new ViewportAutoexposeHelper(this));
 		return super.getAdapter(adapter);
 	}
 
@@ -230,14 +231,14 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	protected void refreshGridLayer() {
 		boolean visible = false;
 		GridLayer grid = (GridLayer) getLayer(GRID_LAYER);
-		Boolean val = (Boolean) getViewer().getProperty(
-				SnapToGrid.PROPERTY_GRID_VISIBLE);
+		Boolean val = (Boolean) getViewer()
+				.getProperty(SnapToGrid.PROPERTY_GRID_VISIBLE);
 		if (val != null)
 			visible = val.booleanValue();
-		grid.setOrigin((Point) getViewer().getProperty(
-				SnapToGrid.PROPERTY_GRID_ORIGIN));
-		grid.setSpacing((Dimension) getViewer().getProperty(
-				SnapToGrid.PROPERTY_GRID_SPACING));
+		grid.setOrigin((Point) getViewer()
+				.getProperty(SnapToGrid.PROPERTY_GRID_ORIGIN));
+		grid.setSpacing((Dimension) getViewer()
+				.getProperty(SnapToGrid.PROPERTY_GRID_SPACING));
 		grid.setVisible(visible);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
@@ -245,9 +245,10 @@ public class ScalableRootEditPart extends SimpleRootEditPart implements
 	/**
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AutoexposeHelper.class)
-			return new ViewportAutoexposeHelper(this);
+			return key.cast(new ViewportAutoexposeHelper(this));
 		return super.getAdapter(key);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SelectionHandlesEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SelectionHandlesEditPolicy.java
@@ -64,11 +64,12 @@ public abstract class SelectionHandlesEditPolicy extends SelectionEditPolicy
 	/**
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(Class)
 	 */
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleHandleProvider.class)
-			return new AccessibleHandleProvider() {
-				public List getAccessibleHandleLocations() {
-					List result = new ArrayList();
+			return key.cast(new AccessibleHandleProvider() {
+				public List<Point> getAccessibleHandleLocations() {
+					List<Point> result = new ArrayList<>();
 					if (handles != null) {
 						for (int i = 0; i < handles.size(); i++) {
 							Point p = ((Handle) handles.get(i))
@@ -79,7 +80,7 @@ public abstract class SelectionHandlesEditPolicy extends SelectionEditPolicy
 					}
 					return result;
 				}
-			};
+			});
 		return null;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/PropertySourceAdapterFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/PropertySourceAdapterFactory.java
@@ -21,7 +21,8 @@ import org.eclipse.gef.editparts.AbstractEditPart;
 
 public class PropertySourceAdapterFactory implements IAdapterFactory {
 
-	public Object getAdapter(Object adaptableObject, Class adapterType) {
+	@Override
+	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
 		AbstractEditPart part = (AbstractEditPart) adaptableObject;
 		Object model = part.getModel();
 		// model can be null
@@ -30,12 +31,12 @@ public class PropertySourceAdapterFactory implements IAdapterFactory {
 		}
 		// check if model is already of the desired adapter type
 		if (adapterType.isInstance(model)) {
-			return model;
+			return adapterType.cast(model);
 		}
 		// check if model is adaptable and does provide an adapter of the
 		// desired type
 		if (model instanceof IAdaptable) {
-			Object adapter = ((IAdaptable) model).getAdapter(adapterType);
+			T adapter = ((IAdaptable) model).getAdapter(adapterType);
 			if (adapter != null) {
 				return adapter;
 			}
@@ -44,7 +45,7 @@ public class PropertySourceAdapterFactory implements IAdapterFactory {
 		return Platform.getAdapterManager().getAdapter(model, adapterType);
 	}
 
-	public Class[] getAdapterList() {
+	public Class<?>[] getAdapterList() {
 		return new Class[] { IPropertySource.class };
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
@@ -44,8 +44,8 @@ import org.eclipse.gef.ui.palette.editparts.PaletteEditPart;
  * 
  * @author Pratik Shah
  */
-public class DrawerEditPart extends PaletteEditPart implements
-		IPinnableEditPart {
+public class DrawerEditPart extends PaletteEditPart
+		implements IPinnableEditPart {
 
 	private static final String PROPERTY_EXPANSION_STATE = "expansion"; //$NON-NLS-1$
 	private static final String PROPERTY_PINNED_STATE = "pinned"; //$NON-NLS-1$
@@ -87,22 +87,23 @@ public class DrawerEditPart extends PaletteEditPart implements
 	/**
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(Class)
 	 */
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == ExposeHelper.class) {
 			ViewportExposeHelper helper = new ViewportExposeHelper(this);
 			helper.setMinimumFrameCount(6);
 			helper.setMargin(new Insets(PaletteScrollBar.BUTTON_HEIGHT, 0,
 					PaletteScrollBar.BUTTON_HEIGHT, 0));
-			return helper;
+			return key.cast(helper);
 		}
 		if (key == MouseWheelHelper.class)
-			return new ViewportMouseWheelHelper(this);
+			return key.cast(new ViewportMouseWheelHelper(this));
 		return super.getAdapter(key);
 	}
 
 	private PaletteAnimator getPaletteAnimator() {
-		return (PaletteAnimator) getViewer().getEditPartRegistry().get(
-				PaletteAnimator.class);
+		return (PaletteAnimator) getViewer().getEditPartRegistry()
+				.get(PaletteAnimator.class);
 	}
 
 	/**
@@ -196,12 +197,14 @@ public class DrawerEditPart extends PaletteEditPart implements
 		getDrawerFigure().setTitle(getPaletteEntry().getLabel());
 		getDrawerFigure().setLayoutMode(getLayoutSetting());
 
-		boolean showPin = getPreferenceSource().getAutoCollapseSetting() == PaletteViewerPreferences.COLLAPSE_AS_NEEDED;
+		boolean showPin = getPreferenceSource()
+				.getAutoCollapseSetting() == PaletteViewerPreferences.COLLAPSE_AS_NEEDED;
 		getDrawerFigure().showPin(showPin);
 
-		Color background = getDrawer().getDrawerType().equals(
-				PaletteTemplateEntry.PALETTE_TYPE_TEMPLATE) ? PaletteColorUtil.WIDGET_LIST_BACKGROUND
-				: null;
+		Color background = getDrawer().getDrawerType()
+				.equals(PaletteTemplateEntry.PALETTE_TYPE_TEMPLATE)
+						? PaletteColorUtil.WIDGET_LIST_BACKGROUND
+						: null;
 		getDrawerFigure().getScrollpane().setBackgroundColor(background);
 	}
 
@@ -224,14 +227,14 @@ public class DrawerEditPart extends PaletteEditPart implements
 				.booleanValue());
 		RangeModel rModel = getDrawerFigure().getScrollpane().getViewport()
 				.getVerticalRangeModel();
-		rModel.setMinimum(memento.getInteger(RangeModel.PROPERTY_MINIMUM)
-				.intValue());
-		rModel.setMaximum(memento.getInteger(RangeModel.PROPERTY_MAXIMUM)
-				.intValue());
-		rModel.setExtent(memento.getInteger(RangeModel.PROPERTY_EXTENT)
-				.intValue());
-		rModel.setValue(memento.getInteger(RangeModel.PROPERTY_VALUE)
-				.intValue());
+		rModel.setMinimum(
+				memento.getInteger(RangeModel.PROPERTY_MINIMUM).intValue());
+		rModel.setMaximum(
+				memento.getInteger(RangeModel.PROPERTY_MAXIMUM).intValue());
+		rModel.setExtent(
+				memento.getInteger(RangeModel.PROPERTY_EXTENT).intValue());
+		rModel.setValue(
+				memento.getInteger(RangeModel.PROPERTY_VALUE).intValue());
 		super.restoreState(memento);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
@@ -91,8 +91,8 @@ public class ToolEntryEditPart extends PaletteEditPart {
 				performConditionalSelection();
 			super.handleButtonDown(button);
 			if (button == 1) {
-				getFigure().internalGetEventDispatcher().requestRemoveFocus(
-						getFigure());
+				getFigure().internalGetEventDispatcher()
+						.requestRemoveFocus(getFigure());
 				getButtonModel().setArmed(true);
 				getButtonModel().setPressed(true);
 			}
@@ -185,11 +185,10 @@ public class ToolEntryEditPart extends PaletteEditPart {
 			// win hack because button down is delayed
 			if (getParent() instanceof IPaletteStackEditPart
 					&& SWT.getPlatform().equals("win32")) { //$NON-NLS-1$
-				Point nds = getPaletteViewer().getControl().toControl(
-						event.display.getCursorLocation());
-				if (mouseDownLoc != null
-						&& (Math.abs(nds.x - mouseDownLoc.x) + Math.abs(nds.y
-								- mouseDownLoc.y)) < WIN_THRESHOLD) {
+				Point nds = getPaletteViewer().getControl()
+						.toControl(event.display.getCursorLocation());
+				if (mouseDownLoc != null && (Math.abs(nds.x - mouseDownLoc.x)
+						+ Math.abs(nds.y - mouseDownLoc.y)) < WIN_THRESHOLD) {
 					getButtonModel().setArmed(false);
 					getButtonModel().setPressed(false);
 					((IPaletteStackEditPart) getParent()).openMenu();
@@ -265,17 +264,15 @@ public class ToolEntryEditPart extends PaletteEditPart {
 				ButtonModel model = getModel();
 
 				if (model.isSelected()) {
-					graphics.setBackgroundColor(PaletteColorUtil
-							.getSelectedColor());
-					graphics.fillRoundRectangle(
-							getSelectionRectangle(getLayoutSetting(),
-									customLabel), 3, 3);
+					graphics.setBackgroundColor(
+							PaletteColorUtil.getSelectedColor());
+					graphics.fillRoundRectangle(getSelectionRectangle(
+							getLayoutSetting(), customLabel), 3, 3);
 				} else if (model.isMouseOver() || showHoverFeedback) {
-					graphics.setBackgroundColor(PaletteColorUtil
-							.getHoverColor());
-					graphics.fillRoundRectangle(
-							getSelectionRectangle(getLayoutSetting(),
-									customLabel), 3, 3);
+					graphics.setBackgroundColor(
+							PaletteColorUtil.getHoverColor());
+					graphics.fillRoundRectangle(getSelectionRectangle(
+							getLayoutSetting(), customLabel), 3, 3);
 				}
 			}
 		}
@@ -325,14 +322,15 @@ public class ToolEntryEditPart extends PaletteEditPart {
 		super(paletteEntry);
 	}
 
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == IPinnableEditPart.class) {
 			if ((getParent() instanceof PinnablePaletteStackEditPart)
 					&& ((PinnablePaletteStackEditPart) getParent())
 							.canBePinned()
 					&& ((PaletteStack) getParent().getModel()).getActiveEntry()
 							.equals(getModel())) {
-				return getParent();
+				return key.cast(getParent());
 			}
 		}
 		return super.getAdapter(key);
@@ -504,8 +502,10 @@ public class ToolEntryEditPart extends PaletteEditPart {
 	}
 
 	public void saveState(IMemento memento) {
-		memento.putString(ACTIVE_STATE, Boolean.valueOf(getPaletteViewer()
-				.getActiveTool() == getToolEntry()).toString());
+		memento.putString(ACTIVE_STATE,
+				Boolean.valueOf(
+						getPaletteViewer().getActiveTool() == getToolEntry())
+						.toString());
 		super.saveState(memento);
 	}
 
@@ -523,8 +523,7 @@ public class ToolEntryEditPart extends PaletteEditPart {
 	 */
 	public void setSelected(int value) {
 		super.setSelected(value);
-		if (value == SELECTED_PRIMARY
-				&& getPaletteViewer().getControl() != null
+		if (value == SELECTED_PRIMARY && getPaletteViewer().getControl() != null
 				&& !getPaletteViewer().getControl().isDisposed()
 				&& getPaletteViewer().getControl().isFocusControl())
 			getFigure().requestFocus();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
@@ -149,17 +149,18 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 		return accPart;
 	}
 
-	public Object getAdapter(Class key) {
+	@Override
+	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleHandleProvider.class) {
-			return new AccessibleHandleProvider() {
-				public List getAccessibleHandleLocations() {
-					List result = new ArrayList();
+			return key.cast(new AccessibleHandleProvider() {
+				public List<Point> getAccessibleHandleLocations() {
+					List<Point> result = new ArrayList<>();
 					Point pt = getFigure().getBounds().getCenter();
 					getFigure().translateToAbsolute(pt);
 					result.add(pt);
 					return result;
 				}
-			};
+			});
 		}
 		return super.getAdapter(key);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerRootEditPart.java
@@ -70,11 +70,14 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 	/**
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class adapter) {
+	@Override
+	public <T> T getAdapter(final Class<T> adapter) {
 		if (adapter == AutoexposeHelper.class) {
 			if (((RulerEditPart) getContents()).isHorizontal())
-				return new ViewportAutoexposeHelper(this, HORIZONTAL_THRESHOLD);
-			return new ViewportAutoexposeHelper(this, VERTICAL_THRESHOLD);
+				return adapter.cast(new ViewportAutoexposeHelper(this,
+						HORIZONTAL_THRESHOLD));
+			return adapter.cast(
+					new ViewportAutoexposeHelper(this, VERTICAL_THRESHOLD));
 		}
 		return super.getAdapter(adapter);
 	}
@@ -159,7 +162,8 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 					contentBounds.x = 0;
 					contentBounds.height = rModel.getMaximum()
 							- rModel.getMinimum();
-					contentBounds.width = this.getContents().getPreferredSize().width;
+					contentBounds.width = this.getContents()
+							.getPreferredSize().width;
 				}
 				if (!this.getContents().getBounds().equals(contentBounds)) {
 					this.getContents().setBounds(contentBounds);
@@ -182,8 +186,8 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 				RangeModel rModel = getVerticalRangeModel();
 				pSize.height = rModel.getMaximum() - rModel.getMinimum();
 			}
-			return pSize
-					.expand(getInsets().getWidth(), getInsets().getHeight());
+			return pSize.expand(getInsets().getWidth(),
+					getInsets().getHeight());
 		}
 
 		/**

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionCreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionCreationTool.java
@@ -90,8 +90,8 @@ public class ConnectionCreationTool extends AbstractConnectionCreationTool {
 	 * @return <code>true</code> if this focus lost event was processed
 	 */
 	protected boolean handleFocusLost() {
-		if (isInState(STATE_CONNECTION_STARTED
-				| STATE_ACCESSIBLE_DRAG_IN_PROGRESS)) {
+		if (isInState(
+				STATE_CONNECTION_STARTED | STATE_ACCESSIBLE_DRAG_IN_PROGRESS)) {
 			eraseSourceFeedback();
 			eraseTargetFeedback();
 			setState(STATE_INVALID);
@@ -200,8 +200,7 @@ public class ConnectionCreationTool extends AbstractConnectionCreationTool {
 	boolean navigateNextAnchor(int direction) {
 		EditPart focus = getCurrentViewer().getFocusEditPart();
 		AccessibleAnchorProvider provider;
-		provider = focus
-				.getAdapter(AccessibleAnchorProvider.class);
+		provider = focus.getAdapter(AccessibleAnchorProvider.class);
 		if (provider == null)
 			return false;
 

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
@@ -35,8 +35,8 @@ import org.eclipse.gef.requests.ReconnectRequest;
 /**
  * A DragTracker that moves the endpoint of a connection to another location.
  */
-public class ConnectionEndpointTracker extends TargetingTool implements
-		DragTracker {
+public class ConnectionEndpointTracker extends TargetingTool
+		implements DragTracker {
 
 	private static final int FLAG_SOURCE_FEEBBACK = TargetingTool.MAX_FLAG << 1;
 	/** The max flag */
@@ -220,15 +220,15 @@ public class ConnectionEndpointTracker extends TargetingTool implements
 				// When the drag first starts, set the focus Part to be one end
 				// of the connection
 				if (isTarget()) {
-					getCurrentViewer().setFocus(
-							getConnectionEditPart().getTarget());
-					getCurrentViewer().reveal(
-							getConnectionEditPart().getTarget());
+					getCurrentViewer()
+							.setFocus(getConnectionEditPart().getTarget());
+					getCurrentViewer()
+							.reveal(getConnectionEditPart().getTarget());
 				} else {
-					getCurrentViewer().setFocus(
-							getConnectionEditPart().getSource());
-					getCurrentViewer().reveal(
-							getConnectionEditPart().getSource());
+					getCurrentViewer()
+							.setFocus(getConnectionEditPart().getSource());
+					getCurrentViewer()
+							.reveal(getConnectionEditPart().getSource());
 				}
 			}
 			int direction = 0;
@@ -265,7 +265,8 @@ public class ConnectionEndpointTracker extends TargetingTool implements
 			e.stateMask |= SWT.CONTROL;
 			if (getCurrentViewer().getKeyHandler().keyPressed(e)) {
 				// Do not try to connect to the same connection being dragged.
-				if (getCurrentViewer().getFocusEditPart() != getConnectionEditPart())
+				if (getCurrentViewer()
+						.getFocusEditPart() != getConnectionEditPart())
 					navigateNextAnchor(0);
 				return true;
 			}
@@ -281,8 +282,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements
 	boolean navigateNextAnchor(int direction) {
 		EditPart focus = getCurrentViewer().getFocusEditPart();
 		AccessibleAnchorProvider provider;
-		provider = focus
-				.getAdapter(AccessibleAnchorProvider.class);
+		provider = focus.getAdapter(AccessibleAnchorProvider.class);
 		if (provider == null)
 			return false;
 

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
@@ -168,8 +168,7 @@ public class CreationTool extends TargetingTool {
 			lockTargetEditPart(getTargetEditPart());
 			// Snap only when size on drop is employed
 			if (getTargetEditPart() != null)
-				helper = getTargetEditPart().getAdapter(
-						SnapToHelper.class);
+				helper = getTargetEditPart().getAdapter(SnapToHelper.class);
 		}
 		return true;
 	}
@@ -183,7 +182,8 @@ public class CreationTool extends TargetingTool {
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonUp(int)
 	 */
 	protected boolean handleButtonUp(int button) {
-		if (stateTransition(STATE_DRAG | STATE_DRAG_IN_PROGRESS, STATE_TERMINAL)) {
+		if (stateTransition(STATE_DRAG | STATE_DRAG_IN_PROGRESS,
+				STATE_TERMINAL)) {
 			eraseTargetFeedback();
 			unlockTargetEditPart();
 			performCreation(button);
@@ -311,8 +311,8 @@ public class CreationTool extends TargetingTool {
 			createRequest.setSize(bounds.getSize());
 			createRequest.setLocation(bounds.getLocation());
 			createRequest.getExtendedData().clear();
-			createRequest.setSnapToEnabled(!getCurrentInput().isModKeyDown(
-					MODIFIER_NO_SNAPPING));
+			createRequest.setSnapToEnabled(
+					!getCurrentInput().isModKeyDown(MODIFIER_NO_SNAPPING));
 			if (helper != null && createRequest.isSnapToEnabled()) {
 				PrecisionRectangle baseRect = new PrecisionRectangle(bounds);
 				PrecisionRectangle result = baseRect.getPreciseCopy();
@@ -336,7 +336,8 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @since 3.7
 	 */
-	protected void enforceConstraintsForSizeOnDropCreate(CreateRequest request) {
+	protected void enforceConstraintsForSizeOnDropCreate(
+			CreateRequest request) {
 		CreateRequest createRequest = (CreateRequest) getTargetRequest();
 		if (createRequest.getSize() != null) {
 			// ensure create request respects minimum and maximum size

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
@@ -107,8 +107,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 
 	private boolean acceptSHIFT(KeyEvent e) {
 		return isInState(STATE_DRAG_IN_PROGRESS | STATE_ACCESSIBLE_DRAG
-				| STATE_ACCESSIBLE_DRAG_IN_PROGRESS)
-				&& e.keyCode == SWT.SHIFT;
+				| STATE_ACCESSIBLE_DRAG_IN_PROGRESS) && e.keyCode == SWT.SHIFT;
 	}
 
 	/**
@@ -227,8 +226,8 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 		if (getCurrentViewer() != null) {
 			List list = ToolUtilities
 					.getSelectionWithoutDependants(getCurrentViewer());
-			ToolUtilities
-					.filterEditPartsUnderstanding(list, getTargetRequest());
+			ToolUtilities.filterEditPartsUnderstanding(list,
+					getTargetRequest());
 			return list;
 		}
 
@@ -363,8 +362,8 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 			LayerManager layerManager = (LayerManager) getCurrentViewer()
 					.getEditPartRegistry().get(LayerManager.ID);
 			if (layerManager != null) {
-				exclusionSet.add(layerManager
-						.getLayer(LayerConstants.CONNECTION_LAYER));
+				exclusionSet.add(
+						layerManager.getLayer(LayerConstants.CONNECTION_LAYER));
 			}
 		}
 		return exclusionSet;
@@ -451,11 +450,12 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 				setStartLocation(getLocation());
 			switch (e.keyCode) {
 			case SWT.ARROW_DOWN:
-				placeMouseInViewer(getLocation().getTranslated(0, accGetStep()));
+				placeMouseInViewer(
+						getLocation().getTranslated(0, accGetStep()));
 				break;
 			case SWT.ARROW_UP:
-				placeMouseInViewer(getLocation()
-						.getTranslated(0, -accGetStep()));
+				placeMouseInViewer(
+						getLocation().getTranslated(0, -accGetStep()));
 				break;
 			case SWT.ARROW_RIGHT:
 				int stepping = accGetStep();
@@ -549,8 +549,8 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 		PrecisionPoint newStart = (PrecisionPoint) sourceRelativeStartPoint
 				.getCopy();
 		figure.translateToAbsolute(newStart);
-		Point delta = new Point(newStart.x - getStartLocation().x, newStart.y
-				- getStartLocation().y);
+		Point delta = new Point(newStart.x - getStartLocation().x,
+				newStart.y - getStartLocation().y);
 		setStartLocation(newStart);
 		// sourceRectangle and compoundSrcRect need to be updated as well when
 		// auto-scrolling
@@ -599,8 +599,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 		super.setTargetEditPart(editpart);
 		snapToHelper = null;
 		if (getTargetEditPart() != null && getOperationSet().size() > 0)
-			snapToHelper = getTargetEditPart().getAdapter(
-					SnapToHelper.class);
+			snapToHelper = getTargetEditPart().getAdapter(SnapToHelper.class);
 	}
 
 	/**
@@ -634,9 +633,8 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 			}
 		}
 
-		if (check
-				&& isInState(STATE_DRAG | STATE_ACCESSIBLE_DRAG
-						| STATE_ACCESSIBLE_DRAG_IN_PROGRESS))
+		if (check && isInState(STATE_DRAG | STATE_ACCESSIBLE_DRAG
+				| STATE_ACCESSIBLE_DRAG_IN_PROGRESS))
 			captureSourceDimensions();
 	}
 
@@ -654,10 +652,10 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 		request.setEditParts(getOperationSet());
 		Dimension delta = getDragMoveDelta();
 
-		request.setConstrainedMove(getCurrentInput().isModKeyDown(
-				MODIFIER_CONSTRAINED_MOVE));
-		request.setSnapToEnabled(!getCurrentInput().isModKeyDown(
-				MODIFIER_NO_SNAPPING));
+		request.setConstrainedMove(
+				getCurrentInput().isModKeyDown(MODIFIER_CONSTRAINED_MOVE));
+		request.setSnapToEnabled(
+				!getCurrentInput().isModKeyDown(MODIFIER_NO_SNAPPING));
 
 		// constrains the move to dx=0, dy=0, or dx=dy if shift is depressed
 		if (request.isConstrainedMove()) {
@@ -714,9 +712,10 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 			jointRect.translate(moveDelta);
 
 			PrecisionPoint preciseDelta = new PrecisionPoint(moveDelta);
-			snapToHelper.snapPoint(request, PositionConstants.HORIZONTAL
-					| PositionConstants.VERTICAL, new PrecisionRectangle[] {
-					baseRect, jointRect }, preciseDelta);
+			snapToHelper.snapPoint(request,
+					PositionConstants.HORIZONTAL | PositionConstants.VERTICAL,
+					new PrecisionRectangle[] { baseRect, jointRect },
+					preciseDelta);
 			request.setMoveDelta(preciseDelta);
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
@@ -113,8 +113,8 @@ public class ResizeTracker extends SimpleDragTracker {
 		super.activate();
 		if (owner != null) {
 			if (getTargetEditPart() != null)
-				snapToHelper = getTargetEditPart().getAdapter(
-						SnapToHelper.class);
+				snapToHelper = getTargetEditPart()
+						.getAdapter(SnapToHelper.class);
 
 			IFigure figure = owner.getFigure();
 			if (figure instanceof HandleBounds)
@@ -298,12 +298,12 @@ public class ResizeTracker extends SimpleDragTracker {
 		Point moveDelta = new Point(0, 0);
 		Dimension resizeDelta = new Dimension(0, 0);
 
-		request.setConstrainedResize(getCurrentInput().isModKeyDown(
-				MODIFIER_CONSTRAINED_RESIZE));
-		request.setCenteredResize(getCurrentInput().isModKeyDown(
-				MODIFIER_CENTERED_RESIZE));
-		request.setSnapToEnabled(!getCurrentInput().isModKeyDown(
-				MODIFIER_NO_SNAPPING));
+		request.setConstrainedResize(
+				getCurrentInput().isModKeyDown(MODIFIER_CONSTRAINED_RESIZE));
+		request.setCenteredResize(
+				getCurrentInput().isModKeyDown(MODIFIER_CENTERED_RESIZE));
+		request.setSnapToEnabled(
+				!getCurrentInput().isModKeyDown(MODIFIER_NO_SNAPPING));
 
 		if (request.isConstrainedResize() && owner != null) {
 			request.setConstrainedResize(true);
@@ -384,24 +384,25 @@ public class ResizeTracker extends SimpleDragTracker {
 					rect, result);
 			if (request.isCenteredResize()) {
 				if (result.preciseX() != 0.0)
-					result.setPreciseWidth(result.preciseWidth()
-							- result.preciseX());
+					result.setPreciseWidth(
+							result.preciseWidth() - result.preciseX());
 				else if (result.preciseWidth() != 0.0) {
 					result.setPreciseX(-result.preciseWidth());
 					result.setPreciseWidth(result.preciseWidth() * 2.0);
 				}
 
 				if (result.preciseY() != 0.0)
-					result.setPreciseHeight(result.preciseHeight()
-							- result.preciseY());
+					result.setPreciseHeight(
+							result.preciseHeight() - result.preciseY());
 				else if (result.preciseHeight() != 0.0) {
 					result.setPreciseY(-result.preciseHeight());
 					result.setPreciseHeight(result.preciseHeight() * 2.0);
 				}
 			}
 
-			PrecisionPoint preciseMove = new PrecisionPoint(result.preciseX()
-					+ moveDelta.x, result.preciseY() + moveDelta.y);
+			PrecisionPoint preciseMove = new PrecisionPoint(
+					result.preciseX() + moveDelta.x,
+					result.preciseY() + moveDelta.y);
 
 			PrecisionDimension preciseResize = new PrecisionDimension(
 					result.preciseWidth() + resizeDelta.width,
@@ -437,12 +438,12 @@ public class ResizeTracker extends SimpleDragTracker {
 			owner.getFigure().translateToRelative(manipulatedConstraint);
 			// validate constraint (maximum and minimum size are regarded to be
 			// 'normalized', i.e. relative to this figure's bounds coordinates).
-			manipulatedConstraint.setSize(Dimension.max(
-					manipulatedConstraint.getSize(),
-					getMinimumSizeFor(changeBoundsRequest)));
-			manipulatedConstraint.setSize(Dimension.min(
-					manipulatedConstraint.getSize(),
-					getMaximumSizeFor(changeBoundsRequest)));
+			manipulatedConstraint
+					.setSize(Dimension.max(manipulatedConstraint.getSize(),
+							getMinimumSizeFor(changeBoundsRequest)));
+			manipulatedConstraint
+					.setSize(Dimension.min(manipulatedConstraint.getSize(),
+							getMaximumSizeFor(changeBoundsRequest)));
 			// translate back to absolute
 			owner.getFigure().translateToAbsolute(manipulatedConstraint);
 			Dimension newSizeDelta = manipulatedConstraint.getSize()

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
@@ -416,8 +416,7 @@ public class SelectionTool extends TargetingTool {
 		getCurrentViewer().reveal(focus);
 
 		AccessibleHandleProvider provider;
-		provider = focus
-				.getAdapter(AccessibleHandleProvider.class);
+		provider = focus.getAdapter(AccessibleHandleProvider.class);
 		if (provider == null
 				|| provider.getAccessibleHandleLocations().isEmpty())
 			return false;
@@ -439,8 +438,8 @@ public class SelectionTool extends TargetingTool {
 		}
 
 		Point loc = (Point) locations.get(handleIndex);
-		Point current = new Point(getCurrentViewer().getControl().toControl(
-				Display.getCurrent().getCursorLocation()));
+		Point current = new Point(getCurrentViewer().getControl()
+				.toControl(Display.getCurrent().getCursorLocation()));
 
 		if (current.equals(loc)) {
 			// The cursor is already at the location that it is to be moved to.
@@ -471,7 +470,8 @@ public class SelectionTool extends TargetingTool {
 	 */
 	protected boolean handleViewerExited() {
 		if (isInState(STATE_ACCESSIBLE_DRAG | STATE_ACCESSIBLE_DRAG_IN_PROGRESS
-				| STATE_TRAVERSE_HANDLE | STATE_DRAG | STATE_DRAG_IN_PROGRESS)) {
+				| STATE_TRAVERSE_HANDLE | STATE_DRAG
+				| STATE_DRAG_IN_PROGRESS)) {
 			if (getDragTracker() != null)
 				setDragTracker(null);
 			setState(STATE_INITIAL);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ActionBarContributor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ActionBarContributor.java
@@ -148,8 +148,7 @@ public abstract class ActionBarContributor extends EditorActionBarContributor {
 	 * @see org.eclipse.ui.IEditorActionBarContributor#setActiveEditor(IEditorPart)
 	 */
 	public void setActiveEditor(IEditorPart editor) {
-		ActionRegistry registry = editor
-				.getAdapter(ActionRegistry.class);
+		ActionRegistry registry = editor.getAdapter(ActionRegistry.class);
 		IActionBars bars = getActionBars();
 		for (int i = 0; i < globalActionKeys.size(); i++) {
 			String id = (String) globalActionKeys.get(i);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PrintAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PrintAction.java
@@ -60,9 +60,8 @@ public class PrintAction extends WorkbenchPartAction {
 	 * @see org.eclipse.jface.action.Action#run()
 	 */
 	public void run() {
-		GraphicalViewer viewer;
-		viewer = getWorkbenchPart().getAdapter(
-				GraphicalViewer.class);
+		GraphicalViewer viewer = getWorkbenchPart()
+				.getAdapter(GraphicalViewer.class);
 
 		PrintDialog dialog = new PrintDialog(viewer.getControl().getShell(),
 				SWT.NULL);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectAllAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectAllAction.java
@@ -48,11 +48,10 @@ public class SelectAllAction extends Action {
 	 * Selects all edit parts in the active workbench part.
 	 */
 	public void run() {
-		GraphicalViewer viewer = part
-				.getAdapter(GraphicalViewer.class);
+		GraphicalViewer viewer = part.getAdapter(GraphicalViewer.class);
 		if (viewer != null) {
-			viewer.setSelection(new StructuredSelection(
-					getSelectableEditParts(viewer)));
+			viewer.setSelection(
+					new StructuredSelection(getSelectableEditParts(viewer)));
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/WorkbenchPartAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/WorkbenchPartAction.java
@@ -23,8 +23,8 @@ import org.eclipse.gef.commands.CommandStack;
  * obtained using the part's site. Anything can potentially be obtained using
  * {@link org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)}.
  */
-public abstract class WorkbenchPartAction extends Action implements Disposable,
-		UpdateAction {
+public abstract class WorkbenchPartAction extends Action
+		implements Disposable, UpdateAction {
 
 	private IWorkbenchPart workbenchPart;
 	private boolean lazyEnablement = true;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomComboContributionItem.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomComboContributionItem.java
@@ -38,8 +38,8 @@ import org.eclipse.gef.editparts.ZoomManager;
  * 
  * @author Eric Bordeau
  */
-public class ZoomComboContributionItem extends ContributionItem implements
-		ZoomListener {
+public class ZoomComboContributionItem extends ContributionItem
+		implements ZoomListener {
 
 	private boolean forceSetText;
 	private Combo combo;
@@ -67,7 +67,8 @@ public class ZoomComboContributionItem extends ContributionItem implements
 	 * @param initString
 	 *            the initial string displayed in the combo
 	 */
-	public ZoomComboContributionItem(IPartService partService, String initString) {
+	public ZoomComboContributionItem(IPartService partService,
+			String initString) {
 		this(partService, new String[] { initString });
 	}
 
@@ -269,8 +270,8 @@ public class ZoomComboContributionItem extends ContributionItem implements
 	private void handleWidgetDefaultSelected(SelectionEvent event) {
 		if (zoomManager != null) {
 			if (combo.getSelectionIndex() >= 0)
-				zoomManager.setZoomAsText(combo.getItem(combo
-						.getSelectionIndex()));
+				zoomManager.setZoomAsText(
+						combo.getItem(combo.getSelectionIndex()));
 			else
 				zoomManager.setZoomAsText(combo.getText());
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteContextMenuProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteContextMenuProvider.java
@@ -64,14 +64,14 @@ public class PaletteContextMenuProvider extends ContextMenuProvider {
 		menu.appendToGroup(GEFActionConstants.GROUP_VIEW, new LayoutAction(
 				getPaletteViewer().getPaletteViewerPreferences()));
 		menu.appendToGroup(GEFActionConstants.GROUP_VIEW,
-				new ChangeIconSizeAction(getPaletteViewer()
-						.getPaletteViewerPreferences()));
+				new ChangeIconSizeAction(
+						getPaletteViewer().getPaletteViewerPreferences()));
 		if (getPaletteViewer().getCustomizer() != null) {
 			menu.appendToGroup(GEFActionConstants.GROUP_REST,
 					new CustomizeAction(getPaletteViewer()));
 		}
-		menu.appendToGroup(GEFActionConstants.GROUP_REST, new SettingsAction(
-				getPaletteViewer()));
+		menu.appendToGroup(GEFActionConstants.GROUP_REST,
+				new SettingsAction(getPaletteViewer()));
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/DomainEventDispatcher.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/DomainEventDispatcher.java
@@ -64,8 +64,8 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	 * 
 	 * @author hudsonr
 	 */
-	protected class EditPartAccessibilityDispatcher extends
-			AccessibilityDispatcher {
+	protected class EditPartAccessibilityDispatcher
+			extends AccessibilityDispatcher {
 		private AccessibleEditPart get(int childID) {
 			if (childID == ACC.CHILDID_SELF || childID == ACC.CHILDID_NONE)
 				if (getViewer().getContents() != null)
@@ -73,7 +73,8 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 							.getAdapter(AccessibleEditPart.class);
 				else
 					return null;
-			return (AccessibleEditPart) accessibles.get(Integer.valueOf(childID));
+			return (AccessibleEditPart) accessibles
+					.get(Integer.valueOf(childID));
 		}
 
 		/**
@@ -86,8 +87,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 			EditPart part = getViewer().findObjectAt(new Point(p.x, p.y));
 			if (part == null)
 				return;
-			AccessibleEditPart acc = part
-					.getAdapter(AccessibleEditPart.class);
+			AccessibleEditPart acc = part.getAdapter(AccessibleEditPart.class);
 			if (acc != null)
 				e.childID = acc.getAccessibleID();
 		}
@@ -132,8 +132,8 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		 * @see AccessibleControlListener#getFocus(AccessibleControlEvent)
 		 */
 		public void getFocus(AccessibleControlEvent e) {
-			AccessibleEditPart acc = getViewer()
-					.getFocusEditPart().getAdapter(AccessibleEditPart.class);
+			AccessibleEditPart acc = getViewer().getFocusEditPart()
+					.getAdapter(AccessibleEditPart.class);
 			if (acc != null)
 				e.childID = acc.getAccessibleID();
 		}
@@ -281,7 +281,8 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseDoubleClicked(org.eclipse.swt.events.MouseEvent)
 	 */
-	public void dispatchMouseDoubleClicked(org.eclipse.swt.events.MouseEvent me) {
+	public void dispatchMouseDoubleClicked(
+			org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMouseDoubleClicked(me);
 			if (draw2dBusy())

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
@@ -59,8 +59,8 @@ import org.eclipse.gef.ui.properties.UndoablePropertySheetPage;
  * 
  * @author hudsonr
  */
-public abstract class GraphicalEditor extends EditorPart implements
-		CommandStackListener, ISelectionListener {
+public abstract class GraphicalEditor extends EditorPart
+		implements CommandStackListener, ISelectionListener {
 
 	private static class ActionIDList extends ArrayList {
 		public boolean add(Object o) {
@@ -69,7 +69,8 @@ public abstract class GraphicalEditor extends EditorPart implements
 					IAction action = (IAction) o;
 					o = action.getId();
 					throw new IllegalArgumentException(
-							"Action IDs should be added to lists, not the action: " + action); //$NON-NLS-1$
+							"Action IDs should be added to lists, not the action: " //$NON-NLS-1$
+									+ action);
 				} catch (IllegalArgumentException exc) {
 					exc.printStackTrace();
 				}
@@ -109,8 +110,8 @@ public abstract class GraphicalEditor extends EditorPart implements
 	 * extend or override this method as needed.
 	 */
 	protected void configureGraphicalViewer() {
-		getGraphicalViewer().getControl().setBackground(
-				ColorConstants.listBackground);
+		getGraphicalViewer().getControl()
+				.setBackground(ColorConstants.listBackground);
 	}
 
 	/**
@@ -223,23 +224,25 @@ public abstract class GraphicalEditor extends EditorPart implements
 	 * 
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class type) {
+	@Override
+	public <T> T getAdapter(final Class<T> type) {
 		if (type == org.eclipse.ui.views.properties.IPropertySheetPage.class) {
-			return new UndoablePropertySheetPage(getCommandStack(),
+			return type.cast(new UndoablePropertySheetPage(getCommandStack(),
 					getActionRegistry().getAction(ActionFactory.UNDO.getId()),
-					getActionRegistry().getAction(ActionFactory.REDO.getId()));
+					getActionRegistry().getAction(ActionFactory.REDO.getId())));
 		}
 		if (type == GraphicalViewer.class)
-			return getGraphicalViewer();
+			return type.cast(getGraphicalViewer());
 		if (type == CommandStack.class)
-			return getCommandStack();
+			return type.cast(getCommandStack());
 		if (type == ActionRegistry.class)
-			return getActionRegistry();
+			return type.cast(getActionRegistry());
 		if (type == EditPart.class && getGraphicalViewer() != null)
-			return getGraphicalViewer().getRootEditPart();
+			return type.cast(getGraphicalViewer().getRootEditPart());
 		if (type == IFigure.class && getGraphicalViewer() != null)
-			return ((GraphicalEditPart) getGraphicalViewer().getRootEditPart())
-					.getFigure();
+			return type.cast(
+					((GraphicalEditPart) getGraphicalViewer().getRootEditPart())
+							.getFigure());
 		return super.getAdapter(type);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithFlyoutPalette.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithFlyoutPalette.java
@@ -91,21 +91,21 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 	 * @since 3.10
 	 */
 	protected FlyoutPaletteComposite createPaletteComposite(Composite parent) {
-		return new FlyoutPaletteComposite(parent, SWT.NONE,
-				getSite().getPage(), getPaletteViewerProvider(),
-				getPalettePreferences());
+		return new FlyoutPaletteComposite(parent, SWT.NONE, getSite().getPage(),
+				getPaletteViewerProvider(), getPalettePreferences());
 	}
 
 	/**
 	 * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class type) {
+	@Override
+	public <T> T getAdapter(final Class<T> type) {
 		if (type == PalettePage.class) {
 			if (splitter == null) {
 				page = createPalettePage();
-				return page;
+				return type.cast(page);
 			}
-			return createPalettePage();
+			return type.cast(createPalettePage());
 		}
 		return super.getAdapter(type);
 	}
@@ -125,8 +125,8 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 	 *         preferences
 	 */
 	protected FlyoutPreferences getPalettePreferences() {
-		return FlyoutPaletteComposite.createFlyoutPreferences(InternalGEFPlugin
-				.getDefault().getPluginPreferences());
+		return FlyoutPaletteComposite.createFlyoutPreferences(
+				InternalGEFPlugin.getDefault().getPluginPreferences());
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
@@ -60,8 +60,8 @@ import org.eclipse.gef.editparts.ScalableRootEditPart;
  * 
  * @author hudsonr
  */
-public class GraphicalViewerImpl extends AbstractEditPartViewer implements
-		GraphicalViewer {
+public class GraphicalViewerImpl extends AbstractEditPartViewer
+		implements GraphicalViewer {
 
 	private final LightweightSystem lws = createLightweightSystem();
 	IFigure rootFigure;
@@ -140,8 +140,8 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements
 	 * @see GraphicalViewer#findHandleAt(org.eclipse.draw2d.geometry.Point)
 	 */
 	public Handle findHandleAt(Point p) {
-		LayerManager layermanager = (LayerManager) getEditPartRegistry().get(
-				LayerManager.ID);
+		LayerManager layermanager = (LayerManager) getEditPartRegistry()
+				.get(LayerManager.ID);
 		if (layermanager == null)
 			return null;
 		List list = new ArrayList(3);
@@ -176,8 +176,8 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements
 						&& (condition == null || condition.evaluate(editpart));
 			}
 		}
-		IFigure figure = getLightweightSystem().getRootFigure().findFigureAt(
-				pt.x, pt.y, new ConditionalTreeSearch(exclude));
+		IFigure figure = getLightweightSystem().getRootFigure()
+				.findFigureAt(pt.x, pt.y, new ConditionalTreeSearch(exclude));
 		EditPart part = null;
 		while (part == null && figure != null) {
 			part = (EditPart) getVisualPartMap().get(figure);
@@ -308,14 +308,12 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements
 			return;
 		EditPart current = part.getParent();
 		while (current != null) {
-			ExposeHelper helper = current
-					.getAdapter(ExposeHelper.class);
+			ExposeHelper helper = current.getAdapter(ExposeHelper.class);
 			if (helper != null)
 				helper.exposeDescendant(part);
 			current = current.getParent();
 		}
-		AccessibleEditPart acc = part
-				.getAdapter(AccessibleEditPart.class);
+		AccessibleEditPart acc = part.getAdapter(AccessibleEditPart.class);
 		if (acc != null)
 			getControl().getAccessible().setFocus(acc.getAccessibleID());
 	}
@@ -457,7 +455,8 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements
 		}
 	}
 
-	private static class MouseWheelDelegateHandler implements MouseWheelHandler {
+	private static class MouseWheelDelegateHandler
+			implements MouseWheelHandler {
 		private static final MouseWheelHandler SINGLETON = new MouseWheelDelegateHandler();
 
 		private MouseWheelDelegateHandler() {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteView.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteView.java
@@ -18,7 +18,6 @@ import org.eclipse.ui.IPerspectiveListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.IPage;
-import org.eclipse.ui.part.IPageBookViewPage;
 import org.eclipse.ui.part.MessagePage;
 import org.eclipse.ui.part.PageBook;
 import org.eclipse.ui.part.PageBookView;
@@ -98,12 +97,11 @@ public class PaletteView extends PageBookView {
 	 */
 	protected PageRec doCreatePage(IWorkbenchPart part) {
 		// Try to get a custom palette page
-		Object obj = part.getAdapter(PalettePage.class);
+		PalettePage page = part.getAdapter(PalettePage.class);
 
-		if (obj != null && obj instanceof IPage) {
-			IPage page = (IPage) obj;
+		if (page != null) {
 			page.createControl(getPageBook());
-			initPage((IPageBookViewPage) page);
+			initPage(page);
 			return new PageRec(part, page);
 		}
 		// Use the default page by returning null

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteViewerPage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteViewerPage.java
@@ -77,14 +77,16 @@ public class PaletteViewerPage extends Page implements PalettePage, IAdaptable {
 	/**
 	 * @see IAdaptable#getAdapter(java.lang.Class)
 	 */
-	public Object getAdapter(Class adapter) {
+	@Override
+	public <T> T getAdapter(final Class<T> adapter) {
 		if (adapter == EditPart.class && viewer != null)
-			return viewer.getEditPartRegistry().get(viewer.getPaletteRoot());
+			return adapter.cast(
+					viewer.getEditPartRegistry().get(viewer.getPaletteRoot()));
 		if (adapter == IFigure.class && viewer != null) {
-			Object obj = viewer.getEditPartRegistry().get(
-					viewer.getPaletteRoot());
+			Object obj = viewer.getEditPartRegistry()
+					.get(viewer.getPaletteRoot());
 			if (obj instanceof GraphicalEditPart)
-				return ((GraphicalEditPart) obj).getFigure();
+				return adapter.cast(((GraphicalEditPart) obj).getFigure());
 		}
 		return null;
 	}


### PR DESCRIPTION
This pull request updates all getAdapter methods to the generic version also used in the Eclipse Platform. This greatly improves the usability of the Adapter interface in GEF, as clients do not need to to perform instanceof and casts any more. 

@vogella @Phillipus if you have time I would be happy for a quick look. But I think I followed the Eclipse Platforms style and therefore it shouldn't have an impact on users. 

I tested with Eclipse 4diac IDE where we make quite some use of the getAdapter interface and it worked as expected.