### PR TITLE
Check for possible null value to avoid NPE

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
@@ -335,7 +335,10 @@ public class SWTGraphics extends Graphics {
 			sharedClipping = false;
 
 			boolean previouslyApplied = (appliedState == currentState.relativeClip);
-			currentState.relativeClip = currentState.relativeClip.getCopy();
+			// Fix: currentState.relativeClip can be null and lead to NPE
+			if (currentState.relativeClip != null) {
+				currentState.relativeClip = currentState.relativeClip.getCopy();
+			}
 			if (previouslyApplied) {
 				appliedState.relativeClip = currentState.relativeClip;
 			}


### PR DESCRIPTION
- Under some circumstances currentState.relativeClip can be null and will throw a NPE
- This checks for a null value