### PR TITLE
enable custom graph nodes and connections

### DIFF
--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.6.200.qualifier
+Bundle-Version: 1.7.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;visibility:=reexport

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
@@ -230,7 +230,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	HashMap getNodesMap() {
 		return this.nodesMap;
 	}
-
+	
 	GraphNode addGraphModelContainer(Object element) {
 		GraphNode node = this.getGraphModelNode(element);
 		if (node == null) {
@@ -250,12 +250,40 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 		}
 		return node;
 	}
+	
+	/**
+	 * Implement and return the new node object, enables to define custom graph nodes
+	 * 
+	 * @param graphModel where the created nodes gets added to
+	 * @param figure of the created node object
+	 * @return instance of a {@link GraphNode}
+	 * 
+	 * @since 1.7 
+	 */
+	protected GraphNode createNodeObject(final Graph graphModel, IFigure figure) {
+		return new CGraphNode(graphModel, SWT.NONE, figure);
+	}
+
+	/**
+	 * Implement and return the new connection object, enables to define custom graph connections
+	 * 
+	 * @param graphModel where the created nodes gets added to
+	 * @param source {@link GraphNode}
+	 * @param destination {@link GraphNode}
+	 * @return instance of a {@link GraphConnection}
+	 * 
+	 * @since 1.7 
+	 */
+	protected GraphConnection createConnectionObject(final Graph graphModel, final GraphNode source, 
+			final GraphNode destination) {
+		return new GraphConnection(graphModel, SWT.NONE, source, destination);
+	}
 
 	GraphNode addGraphModelNode(Object element, IFigure figure) {
 		GraphNode node = this.getGraphModelNode(element);
 		if (node == null) {
 			if (figure != null) {
-				node = new CGraphNode((Graph) getControl(), SWT.NONE, figure);
+				node = createNodeObject((Graph) getControl(), figure);
 				this.nodesMap.put(element, node);
 				node.setData(element);
 			} else {
@@ -270,7 +298,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	GraphConnection addGraphModelConnection(Object element, GraphNode source, GraphNode target) {
 		GraphConnection connection = this.getGraphModelConnection(element);
 		if (connection == null) {
-			connection = new GraphConnection((Graph) getControl(), SWT.NONE, source, target);
+			connection = createConnectionObject(getGraphControl(), source, target);
 			this.connectionsMap.put(element, connection);
 			connection.setData(element);
 		}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -60,8 +60,8 @@ public class GraphConnection extends GraphItem {
 	private boolean isDisposed = false;
 
 	private Label connectionLabel = null;
-	private PolylineArcConnection connectionFigure = null;
-	private PolylineArcConnection cachedConnectionFigure = null;
+	private PolylineConnection connectionFigure = null;
+	private PolylineConnection cachedConnectionFigure = null;
 	private Connection sourceContainerConnectionFigure = null;
 	private Connection targetContainerConnectionFigure = null;
 
@@ -614,7 +614,12 @@ public class GraphConnection extends GraphItem {
 		connection.setToolTip(toolTip);
 	}
 
-	private PolylineArcConnection createFigure() {
+	/**
+	 * expose to allow to use custom figures
+	 * 
+	 * @since 1.7
+	 */
+	protected PolylineConnection createFigure() {
 		/*
 		 * if ((sourceNode.getParent()).getItemType() == GraphItem.CONTAINER) {
 		 * GraphContainer container = (GraphContainer) sourceNode.getParent();
@@ -632,8 +637,8 @@ public class GraphConnection extends GraphItem {
 
 	}
 
-	private PolylineArcConnection doCreateFigure() {
-		PolylineArcConnection connectionFigure = cachedOrNewConnectionFigure();
+	private PolylineConnection doCreateFigure() {
+		PolylineConnection connectionFigure = cachedOrNewConnectionFigure();
 		ChopboxAnchor sourceAnchor = null;
 		ChopboxAnchor targetAnchor = null;
 		this.connectionLabel = new Label();
@@ -655,8 +660,8 @@ public class GraphConnection extends GraphItem {
 				}
 			};
 		} else {
-			if (curveDepth != 0) {
-				connectionFigure.setDepth(this.curveDepth);
+			if (connectionFigure instanceof PolylineArcConnection && curveDepth != 0) {
+				((PolylineArcConnection) connectionFigure).setDepth(this.curveDepth);
 			}
 			sourceAnchor = new RoundedChopboxAnchor(getSource().getNodeFigure(), 8);
 			targetAnchor = new RoundedChopboxAnchor(getDestination().getNodeFigure(), 8);
@@ -671,7 +676,12 @@ public class GraphConnection extends GraphItem {
 		return connectionFigure;
 	}
 
-	private PolylineArcConnection cachedOrNewConnectionFigure() {
+	/**
+	 * expose to allow to use custom figures
+	 * 
+	 * @since 1.7
+	 */
+	protected PolylineConnection cachedOrNewConnectionFigure() {
 		return cachedConnectionFigure == null ? new PolylineArcConnection() : cachedConnectionFigure;
 	}
 


### PR DESCRIPTION
Seems like the original Idea was to make the graph nodes and connections extendable (i.e. [CGraphNode](https://github.com/eclipse/gef-classic/blob/master/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/CGraphNode.java)) and just have not been implemented in a way to accomplish this. I added exposed create methods and added the original object creation in the overridden methods in the GraphViewer.