### PR TITLE
Partially revert removal of com.ibm.icu package dependencies

### DIFF
--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Export-Package: org.eclipse.draw2d,
  org.eclipse.draw2d.parts,
  org.eclipse.draw2d.text,
  org.eclipse.draw2d.widgets
+Import-Package: com.ibm.icu.text
 Require-Bundle: org.eclipse.swt;visibility:=reexport;bundle-version="[3.4.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProcessor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProcessor.java
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.draw2d.text;
 
-import java.text.Bidi;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.TextLayout;
+
+import com.ibm.icu.text.Bidi;
 
 /**
  * A helper class for a BlockFlow that does Bidi evaluation of all the text in

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.draw2d.text;
 
-import java.text.BreakIterator;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Rectangle;
@@ -20,6 +18,8 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.TextUtilities;
+
+import com.ibm.icu.text.BreakIterator;
 
 /**
  * Utility class for FlowFigures.


### PR DESCRIPTION
- Use com.ibm.icu.text classes for Bidi and BreakIterator
- This will restore original BreakIterator's line break behaviour and possible changes in Bidi behaviour
- See #116