### PR TITLE
Updated target platform to 2022-09 and to Tycho 3.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'openjdk-jdk11-latest'
+		jdk 'openjdk-jdk17-latest'
 	}
 	stages {
 		

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,12 @@
 	<!-- this is the parent POM from which all modules inherit common settings -->
 	<properties>
 		<maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
-		<tycho.version>2.7.2</tycho.version>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>		
+		<tycho.version>3.0.0</tycho.version>
 		<cbi-plugins.version>1.3.2</cbi-plugins.version>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
-		<tycho.scmUrl>scm:git:https://github.com/eclipse/gef-legacy.git</tycho.scmUrl>
+		<tycho.scmUrl>scm:git:https://github.com/eclipse/gef-classic.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<comparator.repo>https://download.eclipse.org/tools/gef/classic/releases/3.14.0</comparator.repo>
 	</properties>
@@ -221,7 +223,7 @@
 							<includePackedArtifacts>false</includePackedArtifacts>
 							<!-- add target file content to target platform -->
 						    <target>
-								<file>../target-platform/2022-03.target</file>
+								<file>../target-platform/2022-09.target</file>
 							  </target>
 							<environments>
 								<environment>
@@ -258,7 +260,7 @@
 						<includePackedArtifacts>false</includePackedArtifacts>
 						<!-- add target file content to target platform -->
 						<target>
-							<file>../target-platform/2022-03.target</file>
+							<file>../target-platform/2022-09.target</file>
 						  </target>
 						<environments>
 							<environment>

--- a/target-platform/2022-09.target
+++ b/target-platform/2022-09.target
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="2022-03" sequenceNumber="1">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
+<repository location="http://download.eclipse.org/cbi/updates/license"/>
+</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<repository location="http://download.eclipse.org/releases/2022-09"/>
+		<unit id="org.eclipse.sdk.feature.group" version="4.25.0.v20220831-1800"/>
+	</location>
+</locations>
+</target>


### PR DESCRIPTION
@vogella as we got the Jenkins problem I did the long due upgrade to the latest Eclipse platform. As part of that I would have a best practice question. Does it make sense to have an individual target file per Eclipse release or is it simpler to just have a gef target plaform file that we regularly update? 