### PR TITLE
Remove redundant isEnqueued() checks

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
@@ -55,7 +55,7 @@ public class SelectionTool extends TargetingTool {
 	private DragTracker dragTracker;
 	private LocationRequest hoverRequest;
 
-	private WeakReference cachedHandlePart;
+	private WeakReference<EditPart> cachedHandlePart;
 
 	/**
 	 * Default constructor.
@@ -137,10 +137,7 @@ public class SelectionTool extends TargetingTool {
 	private EditPart getLastHandleProvider() {
 		if (cachedHandlePart == null)
 			return null;
-		EditPart part = (EditPart) cachedHandlePart.get();
-		if (cachedHandlePart.isEnqueued())
-			return null;
-		return part;
+		return cachedHandlePart.get();
 	}
 
 	/**
@@ -616,7 +613,7 @@ public class SelectionTool extends TargetingTool {
 		if (part == null)
 			cachedHandlePart = null;
 		else
-			cachedHandlePart = new WeakReference(part);
+			cachedHandlePart = new WeakReference<>(part);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerKeyHandler.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerKeyHandler.java
@@ -57,7 +57,7 @@ public class GraphicalViewerKeyHandler extends KeyHandler {
 	 * When navigating through connections, a "Node" EditPart is used as a
 	 * reference.
 	 */
-	private WeakReference cachedNode;
+	private WeakReference<GraphicalEditPart> cachedNode;
 	private GraphicalViewer viewer;
 
 	/**
@@ -215,9 +215,7 @@ public class GraphicalViewerKeyHandler extends KeyHandler {
 	private GraphicalEditPart getCachedNode() {
 		if (cachedNode == null)
 			return null;
-		if (cachedNode.isEnqueued())
-			return null;
-		return (GraphicalEditPart) cachedNode.get();
+		return cachedNode.get();
 	}
 
 	/**
@@ -527,7 +525,7 @@ public class GraphicalViewerKeyHandler extends KeyHandler {
 		if (node == null)
 			cachedNode = null;
 		else
-			cachedNode = new WeakReference(node);
+			cachedNode = new WeakReference<>(node);
 	}
 
 }


### PR DESCRIPTION
- The isEnqueued() check is not needed because get() will return null if this reference object has been cleared

- See https://github.com/eclipse/gef-classic/issues/122