### PR TITLE
Addresses #124: A first proposal for IZoomScrollPolicies

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
@@ -66,14 +66,35 @@ public abstract class AbstractZoomManager {
 	DecimalFormat format = new DecimalFormat("####%"); //$NON-NLS-1$
 
 	/**
+	 * The zoom scroll policy associated with this zoom manager. Zoom scroll
+	 * policies regulate how the position of the scroll bars are treated during
+	 * zooming.
+	 */
+	private IZoomScrollPolicy scrollPolicy;
+
+	/**
+	 * Creates a new ZoomManager.
+	 * 
+	 * @param pane         The ScalableFigure associated with this ZoomManager
+	 * @param viewport     The Viewport associated with this ZoomManager
+	 * @param scrollPolicy The zoom scroll policy to be used with this ZoomManager
+	 * 
+	 * @since 3.12
+	 */
+	protected AbstractZoomManager(ScalableFigure pane, Viewport viewport, IZoomScrollPolicy scrollPolicy) {
+		this.pane = pane;
+		this.viewport = viewport;
+		this.scrollPolicy = scrollPolicy;
+	}
+
+	/**
 	 * Creates a new ZoomManager.
 	 * 
 	 * @param pane     The ScalableFigure associated with this ZoomManager
 	 * @param viewport The Viewport associated with this ZoomManager
 	 */
 	protected AbstractZoomManager(ScalableFigure pane, Viewport viewport) {
-		this.pane = pane;
-		this.viewport = viewport;
+		this(pane, viewport, new DefaultScrollPolicy());
 	}
 
 	/**
@@ -322,20 +343,12 @@ public abstract class AbstractZoomManager {
 	 * @param zoom the new zoom level
 	 */
 	protected void primSetZoom(double zoom) {
-		Point p1 = getViewport().getClientArea().getCenter();
-		Point p2 = p1.getCopy();
-		Point p = getViewport().getViewLocation();
-		double prevZoom = this.zoom;
+		Point newLocation = scrollPolicy.calcNewViewLocation(getViewport(), this.zoom, zoom);
 		this.zoom = zoom;
 		pane.setScale(zoom);
 		fireZoomChanged();
 		getViewport().validate();
-
-		p2.scale(zoom / prevZoom);
-		Dimension dif = p2.getDifference(p1);
-		p.x += dif.width;
-		p.y += dif.height;
-		setViewLocation(p);
+		setViewLocation(newLocation);
 	}
 
 	/**
@@ -477,6 +490,13 @@ public abstract class AbstractZoomManager {
 	 */
 	public void setZoomLevels(double[] zoomLevels) {
 		this.zoomLevels = zoomLevels;
+	}
+
+	/**
+	 * @since 3.12
+	 */
+	public void setScrollPolicy(IZoomScrollPolicy scrollPolicy) {
+		this.scrollPolicy = scrollPolicy;
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/DefaultScrollPolicy.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/DefaultScrollPolicy.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Johannes Kepler University Linz
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.zoom;
+
+import org.eclipse.draw2d.Viewport;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+
+/**
+ * A scroll policy which ensures that the center of the canvas is maintained
+ * during zooming.
+ * 
+ * This behavior was the default behavior of GEF Classic and Zest pre version
+ * 3.15.
+ * 
+ * @since 3.12
+ */
+public class DefaultScrollPolicy implements IZoomScrollPolicy {
+
+	@Override
+	public Point calcNewViewLocation(Viewport vp, double oldZoom, double newZoom) {
+		Point center = vp.getClientArea().getCenter();
+		Point zoomedCenter = center.getScaled(newZoom / oldZoom);
+		Dimension dif = zoomedCenter.getDifference(center);
+		return vp.getViewLocation().getTranslated(dif);
+	}
+
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/IZoomScrollPolicy.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/IZoomScrollPolicy.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Johannes Kepler University Linz
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.zoom;
+
+import org.eclipse.draw2d.Viewport;
+import org.eclipse.draw2d.geometry.Point;
+
+/**
+ * With this policy the scrolling behavior during zooming can be controlled.
+ * 
+ * It is used by the {@link AbstractZoomManager} to calculate the new viewport
+ * location after zooming.
+ * 
+ * @since 3.12
+ */
+public interface IZoomScrollPolicy {
+
+	/**
+	 * Calculate the viewport location for the given viewport that should be set by
+	 * {@link AbstractZoomManager} after zooming is completed.
+	 * 
+	 * @param vp      the viewport that the zooming will be applied to
+	 * @param oldZoom the current zoom scaling factor
+	 * @param newZoom the upcoming new zoom scaling factor
+	 * @return the new viewport location to be applied after zooming is completed.
+	 * 
+	 * @since 3.2
+	 */
+	Point calcNewViewLocation(Viewport vp, double oldZoom, double newZoom);
+
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/MouseLocationZoomScrollPolicy.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/MouseLocationZoomScrollPolicy.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Johannes Kepler University Linz
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.zoom;
+
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Control;
+
+import org.eclipse.draw2d.Viewport;
+import org.eclipse.draw2d.geometry.Point;
+
+/** A scroll policy which ensures that the content under the mouse cursor stays where it is after scrolling. If the
+ * mouse is not inside of the viewerControl the {@link DefaultScrollPolicy} is used as fallback.
+ * 
+ * In order to keep the target under the mouse stable we have to calculate the new view location such that the following
+ * equation holds:
+ * 
+ * (mousepos + oldViewLocation) / oldZoom = (mousepos + newViewLocation)/newZoom
+ * 
+ * @since 3.12 */
+public class MouseLocationZoomScrollPolicy extends DefaultScrollPolicy {
+
+	final Control viewerControl;
+
+	public MouseLocationZoomScrollPolicy(Control viewerControl) {
+		this.viewerControl = viewerControl;
+	}
+
+	@Override
+	public Point calcNewViewLocation(Viewport vp, double oldZoom, double newZoom) {
+		final Rectangle controlBounds = viewerControl.getBounds();
+		org.eclipse.swt.graphics.Point mouseLocation = viewerControl.getDisplay().getCursorLocation();
+		mouseLocation = viewerControl.toControl(mouseLocation);
+		if (controlBounds.contains(mouseLocation)) {
+			return calcMouseBasedViewLocation(vp, oldZoom, newZoom, new Point(mouseLocation));
+		}
+
+		return super.calcNewViewLocation(vp, oldZoom, newZoom);
+	}
+
+	private static Point calcMouseBasedViewLocation(Viewport vp, double oldZoom, double newZoom, Point mouseLocation) {
+		final Point oldViewLocation = vp.getViewLocation();
+		final Point newviewLocation = mouseLocation.getCopy();
+		newviewLocation.performTranslate(oldViewLocation.x, oldViewLocation.y);
+		newviewLocation.scale(newZoom / oldZoom);
+		newviewLocation.performTranslate(-mouseLocation.x, -mouseLocation.y);
+		return newviewLocation;
+	}
+
+}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/LogicEditor.java
@@ -80,6 +80,7 @@ import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.ViewportAwareConnectionLayerClippingStrategy;
 import org.eclipse.draw2d.parts.ScrollableThumbnail;
 import org.eclipse.draw2d.parts.Thumbnail;
+import org.eclipse.draw2d.zoom.MouseLocationZoomScrollPolicy;
 
 import org.eclipse.gef.ContextMenuProvider;
 import org.eclipse.gef.DefaultEditDomain;
@@ -432,6 +433,7 @@ public class LogicEditor extends GraphicalEditorWithFlyoutPalette {
 		zoomLevels.add(ZoomManager.FIT_WIDTH);
 		zoomLevels.add(ZoomManager.FIT_HEIGHT);
 		root.getZoomManager().setZoomLevelContributions(zoomLevels);
+		root.getZoomManager().setScrollPolicy(new MouseLocationZoomScrollPolicy(viewer.getControl()));
 
 		IAction zoomIn = new ZoomInAction(root.getZoomManager());
 		IAction zoomOut = new ZoomOutAction(root.getZoomManager());

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ZoomManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ZoomManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.ScalableFreeformLayeredPane;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.zoom.AbstractZoomManager;
+import org.eclipse.draw2d.zoom.IZoomScrollPolicy;
 
 import org.eclipse.gef.SharedMessages;
 
@@ -82,6 +83,19 @@ public class ZoomManager extends AbstractZoomManager {
 	 */
 	public ZoomManager(ScalableFreeformLayeredPane pane, Viewport viewport) {
 		super(pane, viewport);
+	}
+
+	/**
+	 * Creates a new ZoomManager.
+	 * 
+	 * @param pane         The ScalableFigure associated with this ZoomManager
+	 * @param viewport     The Viewport associated with this ZoomManager
+	 * @param scrollPolicy The zoom scroll policy to be used with this ZoomManager
+	 * 
+	 * @since 3.13
+	 */
+	public ZoomManager(ScalableFigure pane, Viewport viewport, IZoomScrollPolicy scrollPolicy) {
+		super(pane, viewport, scrollPolicy);
 	}
 
 	/**


### PR DESCRIPTION
With a zoom scroll policy a client can adjust how the scroll position should be maintained during zooming. Two implementations are provided:
  - The default which is the original GEF Classic behavior (i.e. maintain the center of the diagram)
  - The mouse location based which tries to maintain the location under the mouse

This is a first POC for getting feedback. More documentation is needed.