### PR TITLE
Fix drag operation unwanted artifacts

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
@@ -44,7 +44,15 @@ public final class NativeGraphicsSource implements GraphicsSource {
 	 */
 	public Graphics getGraphics(Rectangle r) {
 		canvas.redraw(r.x, r.y, r.width, r.height, false);
-		canvas.update();
+
+		// This is needed to avoid SWT/GEF bug 137786
+		// (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=137786) where drag over
+		// feedback (ie the drag feedback provided by the drag source) and drag under
+		// feedback (ie the feedback provided by the drop target) interfere with each
+		// other, causing flickering and more importantly ugly graphical artifacts.
+
+		// canvas.update();
+
 		return null;
 	}
 


### PR DESCRIPTION
Don't call canvas.update() in NativeGraphicsSource#getGraphics

This is needed to avoid SWT/GEF bug 137786 where drag over feedback (ie the drag feedback provided by the drag source) and drag under feedback (ie the feedback provided by the drop target) interfere with each other, causing flickering and more importantly ugly graphical artifacts.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=137786