### PR TITLE
[releng] #134 Update version numbers and target platform for 2023-03

### DIFF
--- a/org.eclipse.draw2d-feature/feature.xml
+++ b/org.eclipse.draw2d-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.draw2d"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.1">

--- a/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.doc.isv; singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.12.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Eclipse-LazyStart: true

--- a/org.eclipse.draw2d.doc.isv/pom.xml
+++ b/org.eclipse.draw2d.doc.isv/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.16.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.doc.isv</artifactId>
-	<version>3.11.200-SNAPSHOT</version>
+	<version>3.12.100-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<build>
 		<plugins>

--- a/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.examples
-Bundle-Version: 3.14.100.qualifier
+Bundle-Version: 3.14.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.draw2d;bundle-version="[3.2.0,4.0.0)"
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.draw2d.sdk-feature/feature.xml
+++ b/org.eclipse.draw2d.sdk-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.draw2d.sdk"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.draw2d"
       license-feature="org.eclipse.license"

--- a/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.tests
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.12.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.draw2d.tests/pom.xml
+++ b/org.eclipse.draw2d.tests/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.16.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.tests</artifactId>
-	<version>3.11.200-SNAPSHOT</version>
+	<version>3.12.100-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<profiles>
 		<profile>

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d
-Bundle-Version: 3.12.0.qualifier
+Bundle-Version: 3.12.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.gef-feature/feature.xml
+++ b/org.eclipse.gef-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gef"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       image="eclipse_update_120.jpg"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.baseline/API-baseline-3.15.0/gef-classic-3.15.0.target
+++ b/org.eclipse.gef.baseline/API-baseline-3.15.0/gef-classic-3.15.0.target
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="GEF Classic 3.15.0 Base Line Target" sequenceNumber="1">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+<repository location="http://download.eclipse.org/releases/2022-12"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.zest.sdk.feature.group" version="3.15.0.202211301913"/>
+<unit id="org.eclipse.draw2d.sdk.feature.group" version="3.15.0.202211301913"/>
+<unit id="org.eclipse.gef.sdk.feature.group" version="3.15.0.202211301913"/>
+<unit id="org.eclipse.gef.examples.feature.group" version="3.15.0.202211301913"/>
+<repository location="https://download.eclipse.org/tools/gef/classic/releases/3.15.0"/>
+	<unit id="org.eclipse.draw2d.examples" version="3.14.100.202211301913"/>
+	<unit id="org.eclipse.draw2d.examples.source" version="3.14.100.202211301913"/>
+	<unit id="org.eclipse.draw2d.feature.group" version="3.15.0.202211301913"/>
+	<unit id="org.eclipse.draw2d.source.feature.group" version="3.15.0.202211301913"/>
+	<unit id="org.eclipse.gef.examples.source.feature.group" version="3.15.0.202211301913"/>
+	<unit id="org.eclipse.gef.feature.group" version="3.15.0.202211301913"/>
+	<unit id="org.eclipse.gef.source.feature.group" version="3.15.0.202211301913"/>
+	<unit id="org.eclipse.zest.examples" version="3.14.100.202211301913"/>
+	<unit id="org.eclipse.zest.examples.source" version="3.14.100.202211301913"/>
+	<unit id="org.eclipse.zest.feature.group" version="3.15.0.202211301913"/>
+	<unit id="org.eclipse.zest.source.feature.group" version="3.15.0.202211301913"/>
+</location>
+</locations>
+</target>

--- a/org.eclipse.gef.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.doc.isv; singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)";resolution:=optional,

--- a/org.eclipse.gef.doc.isv/pom.xml
+++ b/org.eclipse.gef.doc.isv/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.16.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.doc.isv</artifactId>
-	<version>3.12.200-SNAPSHOT</version>
+	<version>3.13.100-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<build>
 		<plugins>

--- a/org.eclipse.gef.examples-feature/feature.xml
+++ b/org.eclipse.gef.examples-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gef.examples"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef.examples.logic"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.examples.digraph1/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.digraph1/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.gef.examples.digraph1;singleton:=true
-Bundle-Version: 1.1.200
+Bundle-Version: 1.1.300
 Require-Bundle: org.eclipse.gef;bundle-version="[3.3.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="[3.3.0,4.0.0)";visibility:=reexport,
  org.eclipse.ui;bundle-version="[3.3.0,4.0.0)";visibility:=reexport,

--- a/org.eclipse.gef.examples.digraph2/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.digraph2/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.gef.examples.digraph2;singleton:=true
-Bundle-Version: 1.1.200
+Bundle-Version: 1.1.300
 Require-Bundle: org.eclipse.gef.examples.digraph1;bundle-version="[1.0.0,2.0.0)";visibility:=reexport
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.gef.examples.flow/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.flow/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.gef.examples.flow; singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Activator: org.eclipse.gef.examples.flow.FlowPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.logic/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.logic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.logic; singleton:=true
-Bundle-Version: 3.13.0.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Activator: org.eclipse.gef.examples.logicdesigner.LogicPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.shapes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.shapes; singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Activator: org.eclipse.gef.examples.shapes.ShapesPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.text; singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Import-Package: com.ibm.icu.text

--- a/org.eclipse.gef.examples.ui.capabilities/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.ui.capabilities/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.ui.capabilities;singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.11.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.examples.ui.pde/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.ui.pde/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.ui.pde; singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Activator: org.eclipse.gef.examples.ui.pde.internal.GefExamplesPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef.sdk-feature/feature.xml
+++ b/org.eclipse.gef.sdk-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gef.sdk"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.tests
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jface;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.gef.tests/pom.xml
+++ b/org.eclipse.gef.tests/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.16.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.tests</artifactId>
-	<version>3.12.200-SNAPSHOT</version>
+	<version>3.13.100-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<profiles>
 		<profile>

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.13.0.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.zest-feature/feature.xml
+++ b/org.eclipse.zest-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.zest"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,11 +4,11 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.7.0.qualifier
+Bundle-Version: 1.7.100.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;visibility:=reexport
-Eclipse-LazyStart: false
+Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.zest.core.viewers,
  org.eclipse.zest.core.viewers.internal;x-internal:=true,
  org.eclipse.zest.core.widgets,

--- a/org.eclipse.zest.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.doc.isv; singleton:=true
-Bundle-Version: 1.8.200.qualifier
+Bundle-Version: 1.8.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Eclipse-LazyStart: true

--- a/org.eclipse.zest.doc.isv/pom.xml
+++ b/org.eclipse.zest.doc.isv/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.16.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.zest.plugins</groupId>
 	<artifactId>org.eclipse.zest.doc.isv</artifactId>
-	<version>1.8.200-SNAPSHOT</version>
+	<version>1.8.300-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<build>
 		<plugins>

--- a/org.eclipse.zest.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.examples
-Bundle-Version: 3.14.100.qualifier
+Bundle-Version: 3.14.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.layouts;singleton:=true
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.zest.layouts,

--- a/org.eclipse.zest.sdk-feature/feature.xml
+++ b/org.eclipse.zest.sdk-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.zest.sdk"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.zest.tests/.classpath
+++ b/org.eclipse.zest.tests/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.4"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins">
-		<accessrules>
-			<accessrule kind="accessible" pattern="**/internal/**"/>
-		</accessrules>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.zest.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Graphical Editing Framework Zest Tests
 Bundle-SymbolicName: org.eclipse.zest.tests;singleton:=true
-Bundle-Version: 1.8.200.qualifier
+Bundle-Version: 1.8.300.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.pde,

--- a/org.eclipse.zest.tests/pom.xml
+++ b/org.eclipse.zest.tests/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.gef</groupId>
 		<artifactId>org.eclipse.gef.releng</artifactId>
-		<version>3.15.0-SNAPSHOT</version>
+		<version>3.16.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.eclipse.zest.plugins</groupId>
 	<artifactId>org.eclipse.zest.tests</artifactId>
-	<version>1.8.200-SNAPSHOT</version>
+	<version>1.8.300-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gef</groupId>
 	<artifactId>org.eclipse.gef.releng</artifactId>
-	<version>3.15.0-SNAPSHOT</version>
+	<version>3.16.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<!-- this is the parent POM from which all modules inherit common settings -->
@@ -18,7 +18,7 @@
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gef-classic.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<comparator.repo>https://download.eclipse.org/tools/gef/classic/releases/3.14.0</comparator.repo>
+		<comparator.repo>https://download.eclipse.org/tools/gef/classic/releases/3.15.0</comparator.repo>
 	</properties>
 
 	<build>
@@ -223,7 +223,7 @@
 							<includePackedArtifacts>false</includePackedArtifacts>
 							<!-- add target file content to target platform -->
 						    <target>
-								<file>../target-platform/2022-09.target</file>
+								<file>../target-platform/2022-12.target</file>
 							  </target>
 							<environments>
 								<environment>
@@ -260,7 +260,7 @@
 						<includePackedArtifacts>false</includePackedArtifacts>
 						<!-- add target file content to target platform -->
 						<target>
-							<file>../target-platform/2022-09.target</file>
+							<file>../target-platform/2022-12.target</file>
 						  </target>
 						<environments>
 							<environment>

--- a/target-platform/2022-12.target
+++ b/target-platform/2022-12.target
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="2022-12" sequenceNumber="1">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
+<repository location="http://download.eclipse.org/cbi/updates/license"/>
+</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<repository location="http://download.eclipse.org/releases/2022-12"/>
+		<unit id="org.eclipse.sdk.feature.group" version="4.26.0.v20221123-2302"/>
+	</location>
+</locations>
+</target>


### PR DESCRIPTION
This commit updates all feature version numbers to 3.16 and updated the target platform as well as the api baseline as preparation for the work for the 2023-03 release.

Bumped all plugin maintenance version numbers to indicate the new release.