### PR TITLE
Adresses #128 add color customization and icon overloads

### DIFF
--- a/org.eclipse.draw2d/.settings/.api_filters
+++ b/org.eclipse.draw2d/.settings/.api_filters
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.draw2d" version="2">
+    <resource path="src/org/eclipse/draw2d/ColorConstants.java" type="org.eclipse.draw2d.ColorConstants">
+        <filter comment="Adding fields to constant interface is fine" id="403767336">
+            <message_arguments>
+                <message_argument value="org.eclipse.draw2d.ColorConstants"/>
+                <message_argument value="lineForeground"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Adding fields to constant interface is fine" id="403767336">
+            <message_arguments>
+                <message_argument value="org.eclipse.draw2d.ColorConstants"/>
+                <message_argument value="listHoverBackgroundColor"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Adding fields to constant interface is fine" id="403767336">
+            <message_arguments>
+                <message_argument value="org.eclipse.draw2d.ColorConstants"/>
+                <message_argument value="listSelectedBackgroundColor"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
-Bundle-SymbolicName: org.eclipse.draw2d
+Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
 Bundle-Version: 3.12.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
@@ -15,7 +15,8 @@ Export-Package: org.eclipse.draw2d,
  org.eclipse.draw2d.widgets,
  org.eclipse.draw2d.zoom
 Import-Package: com.ibm.icu.text
-Require-Bundle: org.eclipse.swt;visibility:=reexport;bundle-version="[3.4.0,4.0.0)"
+Require-Bundle: org.eclipse.swt;bundle-version="[3.4.0,4.0.0)";visibility:=reexport,
+ org.eclipse.ui;bundle-version="3.201.100"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.draw2d

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.draw2d/build.properties
+++ b/org.eclipse.draw2d/build.properties
@@ -12,7 +12,8 @@ bin.includes = about.*,\
                META-INF/,\
                .,\
                plugin.properties,\
-               gef_eclipse_logo_32.png
+               gef_eclipse_logo_32.png,\
+               plugin.xml
 source.. = src/
 src.includes = src/org/eclipse/draw2d/images/,\
                about.html

--- a/org.eclipse.draw2d/css/gef_dark.css
+++ b/org.eclipse.draw2d/css/gef_dark.css
@@ -1,0 +1,12 @@
+IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-draw2d {
+	preferences:
+		'org.eclipse.draw2d.color.line.foreground=64,64,64'
+		'org.eclipse.draw2d.color.list.selected.background=90,90,124'
+		'org.eclipse.draw2d.color.list.hover.background=80,80,100'
+		'org.eclipse.draw2d.color.list.background=57,66,72'
+		'org.eclipse.draw2d.color.list.foreground=224,224,224'
+		'org.eclipse.draw2d.color.menu.background=57,66,72'
+		'org.eclipse.draw2d.color.menu.foreground=224,224,224'
+		'org.eclipse.draw2d.color.menu.foreground.selected=105,105,105'
+		'org.eclipse.draw2d.color.button=64,64,64'
+}

--- a/org.eclipse.draw2d/css/gef_dark.css
+++ b/org.eclipse.draw2d/css/gef_dark.css
@@ -1,11 +1,11 @@
 IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-draw2d {
 	preferences:
 		'org.eclipse.draw2d.color.line.foreground=64,64,64'
-		'org.eclipse.draw2d.color.list.selected.background=90,90,124'
-		'org.eclipse.draw2d.color.list.hover.background=80,80,100'
-		'org.eclipse.draw2d.color.list.background=57,66,72'
+		'org.eclipse.draw2d.color.list.selected.background=90,90,90'
+		'org.eclipse.draw2d.color.list.hover.background=70,70,70'
+		'org.eclipse.draw2d.color.list.background=60,60,60'
 		'org.eclipse.draw2d.color.list.foreground=224,224,224'
-		'org.eclipse.draw2d.color.menu.background=57,66,72'
+		'org.eclipse.draw2d.color.menu.background=40,40,40'
 		'org.eclipse.draw2d.color.menu.foreground=224,224,224'
 		'org.eclipse.draw2d.color.menu.foreground.selected=105,105,105'
 		'org.eclipse.draw2d.color.button=64,64,64'

--- a/org.eclipse.draw2d/plugin.properties
+++ b/org.eclipse.draw2d/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2009 IBM Corporation and others.
+# Copyright (c) 2007, 2022 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -7,6 +7,61 @@
 #
 # Contributors:
 #     IBM Corporation - initial API and implementation
+#     Georgii Gvinepadze - georgii.gvinepadze@dbeaver.com
+#     Serge Rider - serge@dbeaver.com
 ###############################################################################
 Plugin.name=GEF Classic Draw2d
 Plugin.providerName=Eclipse GEF
+
+themeElementCategory.org.eclipse.draw2d.label = GEF
+themeElementCategory.org.eclipse.draw2d.description = GEF
+
+colorDefinition.org.eclipse.draw2d.color.button.lightest.label = Button Light Color
+colorDefinition.org.eclipse.draw2d.color.button.lightest.description = Button Light Color
+colorDefinition.org.eclipse.draw2d.color.button.label = Button Color
+colorDefinition.org.eclipse.draw2d.color.button.description = Button Color
+colorDefinition.org.eclipse.draw2d.color.button.darker.label = Button Dark Color
+colorDefinition.org.eclipse.draw2d.color.button.darker.description = Button Dark Color
+colorDefinition.org.eclipse.draw2d.color.button.darkest.label = Button Darkest Color
+colorDefinition.org.eclipse.draw2d.color.button.darkest.description = Button Darkest Color
+
+colorDefinition.org.eclipse.draw2d.color.list.background.label = List Background Color
+colorDefinition.org.eclipse.draw2d.color.list.background.description = List Background Color
+colorDefinition.org.eclipse.draw2d.color.list.foreground.label = List Foreground Color
+colorDefinition.org.eclipse.draw2d.color.list.foreground.description = List Foreground Color
+
+colorDefinition.org.eclipse.draw2d.color.line.foreground.label = Line Foreground Color
+colorDefinition.org.eclipse.draw2d.color.line.foreground.description = Line Foreground Color
+
+colorDefinition.org.eclipse.draw2d.color.menu.background.label = Menu Background Color
+colorDefinition.org.eclipse.draw2d.color.menu.background.description = Menu Background Color
+colorDefinition.org.eclipse.draw2d.color.menu.foreground.label = Menu Foreground Color
+colorDefinition.org.eclipse.draw2d.color.menu.foreground.description = Menu Foreground Color
+colorDefinition.org.eclipse.draw2d.color.menu.background.selected.label = Menu Selection Background Color
+colorDefinition.org.eclipse.draw2d.color.menu.background.selected.description = Menu Selection Background Color
+colorDefinition.org.eclipse.draw2d.color.menu.foreground.selected.label = Menu Selection Foreground Color
+colorDefinition.org.eclipse.draw2d.color.menu.foreground.selected.description = Menu Selection Foreground Color
+
+colorDefinition.org.eclipse.draw2d.color.title.background.label = Title Background Color
+colorDefinition.org.eclipse.draw2d.color.title.background.description = Title Background Color
+colorDefinition.org.eclipse.draw2d.color.title.gradient.label = Title Gradient Color
+colorDefinition.org.eclipse.draw2d.color.title.gradient.description = Title Gradient Color
+colorDefinition.org.eclipse.draw2d.color.title.foreground.label = Title Foreground Color
+colorDefinition.org.eclipse.draw2d.color.title.foreground.description = Title Foreground Color
+colorDefinition.org.eclipse.draw2d.color.title.inactive.foreground.label = Inactive Title Foreground Color
+colorDefinition.org.eclipse.draw2d.color.title.inactive.foreground.description = Inactive Title Foreground Color
+colorDefinition.org.eclipse.draw2d.color.title.inactive.background.label = Inactive Title Background Color
+colorDefinition.org.eclipse.draw2d.color.title.inactive.background.description = Inactive Title Background Color
+colorDefinition.org.eclipse.draw2d.color.title.inactive.gradient.label = Inactive Title Gradient Color
+colorDefinition.org.eclipse.draw2d.color.title.inactive.gradient.description = Inactive Title Gradient Color
+
+
+colorDefinition.org.eclipse.draw2d.color.tooltip.foreground.label = Tooltip Foreground Color
+colorDefinition.org.eclipse.draw2d.color.tooltip.foreground.description = Tooltip Foreground Color
+colorDefinition.org.eclipse.draw2d.color.tooltip.background.label = Tooltip Background Color
+colorDefinition.org.eclipse.draw2d.color.tooltip.background.description = Tooltip Background Color
+
+colorDefinition.org.eclipse.draw2d.color.list.hover.background.label = List Hover Color
+colorDefinition.org.eclipse.draw2d.color.list.hover.background.description = List Hover Color
+colorDefinition.org.eclipse.draw2d.color.list.selected.background.label = List Selection Color
+colorDefinition.org.eclipse.draw2d.color.list.selected.background.description = List Selection Color

--- a/org.eclipse.draw2d/plugin.xml
+++ b/org.eclipse.draw2d/plugin.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<!--
+    Copyright (c) 2005, 2022 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+        Georgii Gvinepadze - georgii.gvinepadze@dbeaver.com
+        Serge Rider - serge@dbeaver.com
+ -->
+
+<plugin>
+	<extension point="org.eclipse.ui.themes">
+
+		<themeElementCategory label="%themeElementCategory.org.eclipse.draw2d.label" id="org.eclipse.draw2d">
+			<description>%themeElementCategory.org.eclipse.draw2d.description</description>
+		</themeElementCategory>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.button.lightest.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.button.lightest"
+				value="COLOR_WIDGET_HIGHLIGHT_SHADOW">
+			<description>%colorDefinition.org.eclipse.draw2d.color.button.lightest.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.button.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.button"
+				value="COLOR_WIDGET_BACKGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.button.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.button.darker.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.button.darker"
+				value="COLOR_WIDGET_NORMAL_SHADOW">
+			<description>%colorDefinition.org.eclipse.draw2d.color.button.darker.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.button.darkest.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.button.darkest"
+				value="COLOR_WIDGET_DARK_SHADOW">
+			<description>%colorDefinition.org.eclipse.draw2d.color.button.darkest.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.list.background.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.list.background"
+				value="COLOR_WIDGET_BACKGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.list.background.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.list.foreground.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.list.foreground"
+				value="COLOR_LIST_FOREGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.list.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.line.foreground.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.line.foreground"
+				value="COLOR_LIST_FOREGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.line.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.menu.background.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.menu.background"
+				value="COLOR_WIDGET_BACKGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.menu.background.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.menu.foreground.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.menu.foreground"
+				value="COLOR_WIDGET_FOREGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.menu.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.menu.background.selected.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.menu.background.selected"
+				value="COLOR_LIST_SELECTION">
+			<description>%colorDefinition.org.eclipse.draw2d.color.menu.background.selected.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.menu.foreground.selected.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.menu.foreground.selected"
+				value="COLOR_LIST_SELECTION_TEXT">
+			<description>%colorDefinition.org.eclipse.draw2d.color.menu.foreground.selected.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.title.background.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.title.background"
+				value="COLOR_TITLE_BACKGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.title.background.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.title.gradient.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.title.gradient"
+				value="COLOR_TITLE_BACKGROUND_GRADIENT">
+			<description>%colorDefinition.org.eclipse.draw2d.color.title.gradient.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.title.foreground.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.title.foreground"
+				value="COLOR_TITLE_FOREGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.title.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.title.inactive.foreground.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.title.inactive.foreground"
+				value="COLOR_TITLE_INACTIVE_FOREGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.title.inactive.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.title.inactive.background.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.title.inactive.background"
+				value="COLOR_TITLE_INACTIVE_BACKGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.title.inactive.background.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.title.inactive.gradient.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.title.inactive.gradient"
+				value="COLOR_TITLE_INACTIVE_BACKGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.title.inactive.gradient.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.tooltip.foreground.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.tooltip.foreground"
+				value="COLOR_INFO_FOREGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.tooltip.foreground.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.tooltip.background.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.tooltip.background"
+				value="COLOR_INFO_BACKGROUND">
+			<description>%colorDefinition.org.eclipse.draw2d.color.tooltip.background.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.list.hover.background.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.list.hover.background"
+				value="COLOR_WIDGET_NORMAL_SHADOW">
+			<description>%colorDefinition.org.eclipse.draw2d.color.list.hover.background.description</description>
+		</colorDefinition>
+		<colorDefinition
+				label="%colorDefinition.org.eclipse.draw2d.color.list.selected.background.label"
+				categoryId="org.eclipse.draw2d"
+				id="org.eclipse.draw2d.color.list.selected.background"
+				value="COLOR_WIDGET_DARK_SHADOW">
+			<description>%colorDefinition.org.eclipse.draw2d.color.list.selected.background.description</description>
+		</colorDefinition>
+
+	</extension>
+</plugin>

--- a/org.eclipse.draw2d/plugin.xml
+++ b/org.eclipse.draw2d/plugin.xml
@@ -40,7 +40,7 @@
 				categoryId="org.eclipse.draw2d"
 				id="org.eclipse.draw2d.color.button"
 				value="COLOR_WIDGET_BACKGROUND">
-			<description>%colorDefinition.org.eclipse.draw2d.color.button.foreground.description</description>
+			<description>%colorDefinition.org.eclipse.draw2d.color.button.description</description>
 		</colorDefinition>
 		<colorDefinition
 				label="%colorDefinition.org.eclipse.draw2d.color.button.darker.label"
@@ -60,7 +60,7 @@
 				label="%colorDefinition.org.eclipse.draw2d.color.list.background.label"
 				categoryId="org.eclipse.draw2d"
 				id="org.eclipse.draw2d.color.list.background"
-				value="COLOR_WIDGET_BACKGROUND">
+				value="COLOR_LIST_BACKGROUND">
 			<description>%colorDefinition.org.eclipse.draw2d.color.list.background.description</description>
 		</colorDefinition>
 		<colorDefinition

--- a/org.eclipse.draw2d/plugin.xml
+++ b/org.eclipse.draw2d/plugin.xml
@@ -103,7 +103,7 @@
 				categoryId="org.eclipse.draw2d"
 				id="org.eclipse.draw2d.color.menu.foreground.selected"
 				value="COLOR_LIST_SELECTION_TEXT">
-			<description>%colorDefinition.org.eclipse.draw2d.color.menu.foreground.selected.foreground.description</description>
+			<description>%colorDefinition.org.eclipse.draw2d.color.menu.foreground.selected.description</description>
 		</colorDefinition>
 		<colorDefinition
 				label="%colorDefinition.org.eclipse.draw2d.color.title.background.label"

--- a/org.eclipse.draw2d/plugin.xml
+++ b/org.eclipse.draw2d/plugin.xml
@@ -14,6 +14,15 @@
  -->
 
 <plugin>
+	<extension
+			point="org.eclipse.e4.ui.css.swt.theme">
+		<stylesheet
+				uri="css/gef_dark.css">
+			<themeid
+					refid="org.eclipse.e4.ui.css.theme.e4_dark">
+			</themeid>
+		</stylesheet>
+	</extension>
 	<extension point="org.eclipse.ui.themes">
 
 		<themeElementCategory label="%themeElementCategory.org.eclipse.draw2d.label" id="org.eclipse.draw2d">
@@ -156,14 +165,14 @@
 				label="%colorDefinition.org.eclipse.draw2d.color.list.hover.background.label"
 				categoryId="org.eclipse.draw2d"
 				id="org.eclipse.draw2d.color.list.hover.background"
-				value="COLOR_WIDGET_NORMAL_SHADOW">
+				value="252, 228, 179">
 			<description>%colorDefinition.org.eclipse.draw2d.color.list.hover.background.description</description>
 		</colorDefinition>
 		<colorDefinition
 				label="%colorDefinition.org.eclipse.draw2d.color.list.selected.background.label"
 				categoryId="org.eclipse.draw2d"
 				id="org.eclipse.draw2d.color.list.selected.background"
-				value="COLOR_WIDGET_DARK_SHADOW">
+				value="207, 227, 250">
 			<description>%colorDefinition.org.eclipse.draw2d.color.list.selected.background.description</description>
 		</colorDefinition>
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
@@ -12,11 +12,37 @@ package org.eclipse.draw2d;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * A collection of color-related constants.
+ * 
+ * @since 3.13
  */
 public interface ColorConstants {
+
+	/**
+	 * @deprecated Color Provider should be used instead of SystemColorFactory
+	 */
+	class SystemColorFactory {
+		private static Color getColor(final int which) {
+			Display display = Display.getCurrent();
+			if (display != null)
+				return display.getSystemColor(which);
+			display = Display.getDefault();
+			final Color result[] = new Color[1];
+			display.syncExec(new Runnable() {
+				public void run() {
+					synchronized (result) {
+						result[0] = Display.getCurrent().getSystemColor(which);
+					}
+				}
+			});
+			synchronized (result) {
+				return result[0];
+			}
+		}
+	}
 
 	/**
 	 * @see SWT#COLOR_WIDGET_HIGHLIGHT_SHADOW
@@ -41,9 +67,13 @@ public interface ColorConstants {
 	Color listBackground = ColorProvider.SystemColorFactory.colorProvider.getListBackground();
 	/**
 	 * @see SWT#COLOR_LIST_FOREGROUND
+	 * @since 3.13
 	 */
 	Color listForeground = ColorProvider.SystemColorFactory.colorProvider.getListForeground();
 
+	/**
+	 * @since 3.13
+	 */
 	Color lineForeground = ColorProvider.SystemColorFactory.colorProvider.getLineForeground();
 
 	/**
@@ -94,11 +124,18 @@ public interface ColorConstants {
 	Color tooltipForeground = ColorProvider.SystemColorFactory.colorProvider.getTooltipForeground();
 	/**
 	 * @see SWT#COLOR_INFO_BACKGROUND
+	 * @since 3.13
 	 */
 	Color tooltipBackground = ColorProvider.SystemColorFactory.colorProvider.getTooltipBackground();
 
+	/**
+	 * @since 3.13
+	 */
 	Color listHoverBackgroundColor = ColorProvider.SystemColorFactory.colorProvider.getListHoverBackgroundColor();
 
+	/**
+	 * @since 3.13
+	 */
 	Color listSelectedBackgroundColor = ColorProvider.SystemColorFactory.colorProvider.getListSelectedBackgroundColor();
 	/*
 	 * Misc. colors

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
@@ -12,110 +12,94 @@ package org.eclipse.draw2d;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * A collection of color-related constants.
  */
 public interface ColorConstants {
 
-	class SystemColorFactory {
-		private static Color getColor(final int which) {
-			Display display = Display.getCurrent();
-			if (display != null)
-				return display.getSystemColor(which);
-			display = Display.getDefault();
-			final Color result[] = new Color[1];
-			display.syncExec(new Runnable() {
-				public void run() {
-					synchronized (result) {
-						result[0] = Display.getCurrent().getSystemColor(which);
-					}
-				}
-			});
-			synchronized (result) {
-				return result[0];
-			}
-		}
-	}
-
 	/**
 	 * @see SWT#COLOR_WIDGET_HIGHLIGHT_SHADOW
 	 */
-	Color buttonLightest = SystemColorFactory.getColor(SWT.COLOR_WIDGET_HIGHLIGHT_SHADOW);
+	Color buttonLightest = ColorProvider.SystemColorFactory.colorProvider.getButtonLightest();
 	/**
 	 * @see SWT#COLOR_WIDGET_BACKGROUND
 	 */
-	Color button = SystemColorFactory.getColor(SWT.COLOR_WIDGET_BACKGROUND);
+	Color button = ColorProvider.SystemColorFactory.colorProvider.getButton();
 	/**
 	 * @see SWT#COLOR_WIDGET_NORMAL_SHADOW
 	 */
-	Color buttonDarker = SystemColorFactory.getColor(SWT.COLOR_WIDGET_NORMAL_SHADOW);
+	Color buttonDarker = ColorProvider.SystemColorFactory.colorProvider.getButtonDarker();
 	/**
 	 * @see SWT#COLOR_WIDGET_DARK_SHADOW
 	 */
-	Color buttonDarkest = SystemColorFactory.getColor(SWT.COLOR_WIDGET_DARK_SHADOW);
+	Color buttonDarkest = ColorProvider.SystemColorFactory.colorProvider.getButtonDarkest();
 
 	/**
 	 * @see SWT#COLOR_LIST_BACKGROUND
 	 */
-	Color listBackground = SystemColorFactory.getColor(SWT.COLOR_LIST_BACKGROUND);
+	Color listBackground = ColorProvider.SystemColorFactory.colorProvider.getListBackground();
 	/**
 	 * @see SWT#COLOR_LIST_FOREGROUND
 	 */
-	Color listForeground = SystemColorFactory.getColor(SWT.COLOR_LIST_FOREGROUND);
+	Color listForeground = ColorProvider.SystemColorFactory.colorProvider.getListForeground();
+
+	Color lineForeground = ColorProvider.SystemColorFactory.colorProvider.getLineForeground();
 
 	/**
 	 * @see SWT#COLOR_WIDGET_BACKGROUND
 	 */
-	Color menuBackground = SystemColorFactory.getColor(SWT.COLOR_WIDGET_BACKGROUND);
+	Color menuBackground = ColorProvider.SystemColorFactory.colorProvider.getMenuBackground();
 	/**
 	 * @see SWT#COLOR_WIDGET_FOREGROUND
 	 */
-	Color menuForeground = SystemColorFactory.getColor(SWT.COLOR_WIDGET_FOREGROUND);
+	Color menuForeground = ColorProvider.SystemColorFactory.colorProvider.getMenuForeground();
 	/**
 	 * @see SWT#COLOR_LIST_SELECTION
 	 */
-	Color menuBackgroundSelected = SystemColorFactory.getColor(SWT.COLOR_LIST_SELECTION);
+	Color menuBackgroundSelected = ColorProvider.SystemColorFactory.colorProvider.getMenuBackgroundSelected();
 	/**
 	 * @see SWT#COLOR_LIST_SELECTION_TEXT
 	 */
-	Color menuForegroundSelected = SystemColorFactory.getColor(SWT.COLOR_LIST_SELECTION_TEXT);
+	Color menuForegroundSelected = ColorProvider.SystemColorFactory.colorProvider.getMenuForegroundSelected();
 
 	/**
 	 * @see SWT#COLOR_TITLE_BACKGROUND
 	 */
-	Color titleBackground = SystemColorFactory.getColor(SWT.COLOR_TITLE_BACKGROUND);
+	Color titleBackground = ColorProvider.SystemColorFactory.colorProvider.getTitleBackground();
 	/**
 	 * @see SWT#COLOR_TITLE_BACKGROUND_GRADIENT
 	 */
-	Color titleGradient = SystemColorFactory.getColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT);
+	Color titleGradient = ColorProvider.SystemColorFactory.colorProvider.getTitleGradient();
 	/**
 	 * @see SWT#COLOR_TITLE_FOREGROUND
 	 */
-	Color titleForeground = SystemColorFactory.getColor(SWT.COLOR_TITLE_FOREGROUND);
+	Color titleForeground = ColorProvider.SystemColorFactory.colorProvider.getTitleForeground();
 	/**
 	 * @see SWT#COLOR_TITLE_INACTIVE_FOREGROUND
 	 */
-	Color titleInactiveForeground = SystemColorFactory.getColor(SWT.COLOR_TITLE_INACTIVE_FOREGROUND);
+	Color titleInactiveForeground = ColorProvider.SystemColorFactory.colorProvider.getTitleInactiveForeground();
 	/**
 	 * @see SWT#COLOR_TITLE_INACTIVE_BACKGROUND
 	 */
-	Color titleInactiveBackground = SystemColorFactory.getColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND);
+	Color titleInactiveBackground = ColorProvider.SystemColorFactory.colorProvider.getTitleInactiveBackground();
 	/**
 	 * @see SWT#COLOR_TITLE_INACTIVE_BACKGROUND_GRADIENT
 	 */
-	Color titleInactiveGradient = SystemColorFactory.getColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND_GRADIENT);
+	Color titleInactiveGradient = ColorProvider.SystemColorFactory.colorProvider.getTitleInactiveGradient();
 
 	/**
 	 * @see SWT#COLOR_INFO_FOREGROUND
 	 */
-	Color tooltipForeground = SystemColorFactory.getColor(SWT.COLOR_INFO_FOREGROUND);
+	Color tooltipForeground = ColorProvider.SystemColorFactory.colorProvider.getTooltipForeground();
 	/**
 	 * @see SWT#COLOR_INFO_BACKGROUND
 	 */
-	Color tooltipBackground = SystemColorFactory.getColor(SWT.COLOR_INFO_BACKGROUND);
+	Color tooltipBackground = ColorProvider.SystemColorFactory.colorProvider.getTooltipBackground();
 
+	Color listHoverBackgroundColor = ColorProvider.SystemColorFactory.colorProvider.getListHoverBackgroundColor();
+
+	Color listSelectedBackgroundColor = ColorProvider.SystemColorFactory.colorProvider.getListSelectedBackgroundColor();
 	/*
 	 * Misc. colors
 	 */

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProvider.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProvider.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Georgii Gvinepadze - georgii.gvinepadze@dbeaver.com
+ *     Serge Rider - serge@dbeaver.com
+ *******************************************************************************/
+package org.eclipse.draw2d;
+
+import org.eclipse.swt.graphics.Color;
+
+/**
+ * A collection of color-related constants.
+ */
+public interface ColorProvider {
+
+	Color getButtonLightest();
+
+	Color getButton();
+
+	Color getButtonDarker();
+
+	Color getButtonDarkest();
+
+	Color getListBackground();
+
+	Color getListForeground();
+
+	Color getLineForeground();
+
+	Color getMenuBackground();
+
+	Color getMenuForeground();
+
+	Color getMenuBackgroundSelected();
+
+	Color getMenuForegroundSelected();
+
+	Color getTitleBackground();
+
+	Color getTitleGradient();
+
+	Color getTitleForeground();
+
+	Color getTitleInactiveForeground();
+
+	Color getTitleInactiveBackground();
+
+	Color getTitleInactiveGradient();
+
+	Color getTooltipForeground();
+
+	Color getTooltipBackground();
+
+	Color getListHoverBackgroundColor();
+
+	Color getListSelectedBackgroundColor();
+
+	class SystemColorFactory {
+		static ColorProvider colorProvider = new ColorProviderDefault();
+
+		public static void setColorProvider(ColorProvider colorProvider) {
+			SystemColorFactory.colorProvider = colorProvider;
+		}
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProvider.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProvider.java
@@ -15,6 +15,8 @@ import org.eclipse.swt.graphics.Color;
 
 /**
  * A collection of color-related constants.
+ * 
+ * @since 3.13
  */
 public interface ColorProvider {
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProviderDefault.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProviderDefault.java
@@ -114,12 +114,12 @@ public class ColorProviderDefault implements ColorProvider {
 
 	@Override
 	public Color getTooltipForeground() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TOOLTIP_BACKGROUND);
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TOOLTIP_FOREGROUND);
 	}
 
 	@Override
 	public Color getTooltipBackground() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TOOLTIP_FOREGROUND);
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TOOLTIP_BACKGROUND);
 	}
 
 	@Override

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProviderDefault.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProviderDefault.java
@@ -13,11 +13,14 @@
 package org.eclipse.draw2d;
 
 import org.eclipse.swt.graphics.Color;
+
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.themes.IThemeManager;
 
 /**
  * A collection of color-related constants.
+ * 
+ * @since 3.13
  */
 public class ColorProviderDefault implements ColorProvider {
 
@@ -74,12 +77,14 @@ public class ColorProviderDefault implements ColorProvider {
 
 	@Override
 	public Color getMenuBackgroundSelected() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_MENU_BACKGROUND_SELECTED);
+		return themeManager.getCurrentTheme().getColorRegistry()
+				.get(ThemeConstants.CONFIG_COLOR_MENU_BACKGROUND_SELECTED);
 	}
 
 	@Override
 	public Color getMenuForegroundSelected() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_MENU_FOREGROUND_SELECTED);
+		return themeManager.getCurrentTheme().getColorRegistry()
+				.get(ThemeConstants.CONFIG_COLOR_MENU_FOREGROUND_SELECTED);
 	}
 
 	@Override
@@ -99,17 +104,20 @@ public class ColorProviderDefault implements ColorProvider {
 
 	@Override
 	public Color getTitleInactiveForeground() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_FOREGROUND);
+		return themeManager.getCurrentTheme().getColorRegistry()
+				.get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_FOREGROUND);
 	}
 
 	@Override
 	public Color getTitleInactiveBackground() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_BACKGROUND);
+		return themeManager.getCurrentTheme().getColorRegistry()
+				.get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_BACKGROUND);
 	}
 
 	@Override
 	public Color getTitleInactiveGradient() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_GRADIENT);
+		return themeManager.getCurrentTheme().getColorRegistry()
+				.get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_GRADIENT);
 	}
 
 	@Override
@@ -129,8 +137,8 @@ public class ColorProviderDefault implements ColorProvider {
 
 	@Override
 	public Color getListSelectedBackgroundColor() {
-		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_LIST_SELECTED_BACKGROUND);
+		return themeManager.getCurrentTheme().getColorRegistry()
+				.get(ThemeConstants.CONFIG_COLOR_LIST_SELECTED_BACKGROUND);
 	}
-
 
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProviderDefault.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorProviderDefault.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Georgii Gvinepadze - georgii.gvinepadze@dbeaver.com
+ *     Serge Rider - serge@dbeaver.com
+ *******************************************************************************/
+package org.eclipse.draw2d;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.themes.IThemeManager;
+
+/**
+ * A collection of color-related constants.
+ */
+public class ColorProviderDefault implements ColorProvider {
+
+	private final IThemeManager themeManager;
+
+	public ColorProviderDefault() {
+		themeManager = PlatformUI.getWorkbench().getThemeManager();
+	}
+
+	@Override
+	public Color getButtonLightest() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_BUTTON_LIGHTEST);
+	}
+
+	@Override
+	public Color getButton() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_BUTTON);
+	}
+
+	@Override
+	public Color getButtonDarker() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_BUTTON_DARKER);
+	}
+
+	@Override
+	public Color getButtonDarkest() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_BUTTON_DARKEST);
+	}
+
+	@Override
+	public Color getListBackground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_LIST_BACKGROUND);
+	}
+
+	@Override
+	public Color getListForeground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_LIST_FOREGROUND);
+	}
+
+	@Override
+	public Color getLineForeground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_LINE_FOREGROUND);
+	}
+
+	@Override
+	public Color getMenuBackground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_MENU_BACKGROUND);
+	}
+
+	@Override
+	public Color getMenuForeground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_MENU_FOREGROUND);
+	}
+
+	@Override
+	public Color getMenuBackgroundSelected() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_MENU_BACKGROUND_SELECTED);
+	}
+
+	@Override
+	public Color getMenuForegroundSelected() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_MENU_FOREGROUND_SELECTED);
+	}
+
+	@Override
+	public Color getTitleBackground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_BACKGROUND);
+	}
+
+	@Override
+	public Color getTitleGradient() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_GRADIENT);
+	}
+
+	@Override
+	public Color getTitleForeground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_FOREGROUND);
+	}
+
+	@Override
+	public Color getTitleInactiveForeground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_FOREGROUND);
+	}
+
+	@Override
+	public Color getTitleInactiveBackground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_BACKGROUND);
+	}
+
+	@Override
+	public Color getTitleInactiveGradient() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TITLE_INACTIVE_GRADIENT);
+	}
+
+	@Override
+	public Color getTooltipForeground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TOOLTIP_BACKGROUND);
+	}
+
+	@Override
+	public Color getTooltipBackground() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_TOOLTIP_FOREGROUND);
+	}
+
+	@Override
+	public Color getListHoverBackgroundColor() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_LIST_HOVER_BACKGROUND);
+	}
+
+	@Override
+	public Color getListSelectedBackgroundColor() {
+		return themeManager.getCurrentTheme().getColorRegistry().get(ThemeConstants.CONFIG_COLOR_LIST_SELECTED_BACKGROUND);
+	}
+
+
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ThemeConstants.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ThemeConstants.java
@@ -11,34 +11,37 @@
  *******************************************************************************/
 package org.eclipse.draw2d;
 
+/**
+ * @since 3.13
+ */
 public class ThemeConstants {
 
-    static final String CONFIG_COLOR_BUTTON_LIGHTEST = "org.eclipse.draw2d.color.button.lightest";
-    static final String CONFIG_COLOR_BUTTON = "org.eclipse.draw2d.color.button";
-    static final String CONFIG_COLOR_BUTTON_DARKER = "org.eclipse.draw2d.color.button.darker";
-    static final String CONFIG_COLOR_BUTTON_DARKEST = "org.eclipse.draw2d.color.button.darkest";
+	static final String CONFIG_COLOR_BUTTON_LIGHTEST = "org.eclipse.draw2d.color.button.lightest";
+	static final String CONFIG_COLOR_BUTTON = "org.eclipse.draw2d.color.button";
+	static final String CONFIG_COLOR_BUTTON_DARKER = "org.eclipse.draw2d.color.button.darker";
+	static final String CONFIG_COLOR_BUTTON_DARKEST = "org.eclipse.draw2d.color.button.darkest";
 
-    static final String CONFIG_COLOR_LIST_BACKGROUND = "org.eclipse.draw2d.color.list.background";
-    static final String CONFIG_COLOR_LIST_FOREGROUND = "org.eclipse.draw2d.color.list.foreground";
+	static final String CONFIG_COLOR_LIST_BACKGROUND = "org.eclipse.draw2d.color.list.background";
+	static final String CONFIG_COLOR_LIST_FOREGROUND = "org.eclipse.draw2d.color.list.foreground";
 
-    static final String CONFIG_COLOR_LINE_FOREGROUND = "org.eclipse.draw2d.color.line.foreground";
+	static final String CONFIG_COLOR_LINE_FOREGROUND = "org.eclipse.draw2d.color.line.foreground";
 
-    static final String CONFIG_COLOR_MENU_BACKGROUND = "org.eclipse.draw2d.color.menu.background";
-    static final String CONFIG_COLOR_MENU_FOREGROUND = "org.eclipse.draw2d.color.menu.foreground";
-    static final String CONFIG_COLOR_MENU_BACKGROUND_SELECTED = "org.eclipse.draw2d.color.menu.background.selected";
-    static final String CONFIG_COLOR_MENU_FOREGROUND_SELECTED = "org.eclipse.draw2d.color.menu.foreground.selected";
+	static final String CONFIG_COLOR_MENU_BACKGROUND = "org.eclipse.draw2d.color.menu.background";
+	static final String CONFIG_COLOR_MENU_FOREGROUND = "org.eclipse.draw2d.color.menu.foreground";
+	static final String CONFIG_COLOR_MENU_BACKGROUND_SELECTED = "org.eclipse.draw2d.color.menu.background.selected";
+	static final String CONFIG_COLOR_MENU_FOREGROUND_SELECTED = "org.eclipse.draw2d.color.menu.foreground.selected";
 
-    static final String CONFIG_COLOR_TITLE_BACKGROUND = "org.eclipse.draw2d.color.title.background";
-    static final String CONFIG_COLOR_TITLE_GRADIENT = "org.eclipse.draw2d.color.title.gradient";
-    static final String CONFIG_COLOR_TITLE_FOREGROUND = "org.eclipse.draw2d.color.title.foreground";
+	static final String CONFIG_COLOR_TITLE_BACKGROUND = "org.eclipse.draw2d.color.title.background";
+	static final String CONFIG_COLOR_TITLE_GRADIENT = "org.eclipse.draw2d.color.title.gradient";
+	static final String CONFIG_COLOR_TITLE_FOREGROUND = "org.eclipse.draw2d.color.title.foreground";
 
-    static final String CONFIG_COLOR_TITLE_INACTIVE_BACKGROUND = "org.eclipse.draw2d.color.title.inactive.background";
-    static final String CONFIG_COLOR_TITLE_INACTIVE_GRADIENT = "org.eclipse.draw2d.color.title.inactive.gradient";
-    static final String CONFIG_COLOR_TITLE_INACTIVE_FOREGROUND = "org.eclipse.draw2d.color.title.inactive.foreground";
+	static final String CONFIG_COLOR_TITLE_INACTIVE_BACKGROUND = "org.eclipse.draw2d.color.title.inactive.background";
+	static final String CONFIG_COLOR_TITLE_INACTIVE_GRADIENT = "org.eclipse.draw2d.color.title.inactive.gradient";
+	static final String CONFIG_COLOR_TITLE_INACTIVE_FOREGROUND = "org.eclipse.draw2d.color.title.inactive.foreground";
 
-    static final String CONFIG_COLOR_TOOLTIP_FOREGROUND = "org.eclipse.draw2d.color.tooltip.foreground";
-    static final String CONFIG_COLOR_TOOLTIP_BACKGROUND = "org.eclipse.draw2d.color.tooltip.background";
+	static final String CONFIG_COLOR_TOOLTIP_FOREGROUND = "org.eclipse.draw2d.color.tooltip.foreground";
+	static final String CONFIG_COLOR_TOOLTIP_BACKGROUND = "org.eclipse.draw2d.color.tooltip.background";
 
-    static final String CONFIG_COLOR_LIST_HOVER_BACKGROUND = "org.eclipse.draw2d.color.list.hover.background";
-    static final String CONFIG_COLOR_LIST_SELECTED_BACKGROUND = "org.eclipse.draw2d.color.list.selected.background";
+	static final String CONFIG_COLOR_LIST_HOVER_BACKGROUND = "org.eclipse.draw2d.color.list.hover.background";
+	static final String CONFIG_COLOR_LIST_SELECTED_BACKGROUND = "org.eclipse.draw2d.color.list.selected.background";
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ThemeConstants.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ThemeConstants.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Georgii Gvinepadze - georgii.gvinepadze@dbeaver.com
+ *     Serge Rider - serge@dbeaver.com
+ *******************************************************************************/
+package org.eclipse.draw2d;
+
+public class ThemeConstants {
+
+    static final String CONFIG_COLOR_BUTTON_LIGHTEST = "org.eclipse.draw2d.color.button.lightest";
+    static final String CONFIG_COLOR_BUTTON = "org.eclipse.draw2d.color.button";
+    static final String CONFIG_COLOR_BUTTON_DARKER = "org.eclipse.draw2d.color.button.darker";
+    static final String CONFIG_COLOR_BUTTON_DARKEST = "org.eclipse.draw2d.color.button.darkest";
+
+    static final String CONFIG_COLOR_LIST_BACKGROUND = "org.eclipse.draw2d.color.list.background";
+    static final String CONFIG_COLOR_LIST_FOREGROUND = "org.eclipse.draw2d.color.list.foreground";
+
+    static final String CONFIG_COLOR_LINE_FOREGROUND = "org.eclipse.draw2d.color.line.foreground";
+
+    static final String CONFIG_COLOR_MENU_BACKGROUND = "org.eclipse.draw2d.color.menu.background";
+    static final String CONFIG_COLOR_MENU_FOREGROUND = "org.eclipse.draw2d.color.menu.foreground";
+    static final String CONFIG_COLOR_MENU_BACKGROUND_SELECTED = "org.eclipse.draw2d.color.menu.background.selected";
+    static final String CONFIG_COLOR_MENU_FOREGROUND_SELECTED = "org.eclipse.draw2d.color.menu.foreground.selected";
+
+    static final String CONFIG_COLOR_TITLE_BACKGROUND = "org.eclipse.draw2d.color.title.background";
+    static final String CONFIG_COLOR_TITLE_GRADIENT = "org.eclipse.draw2d.color.title.gradient";
+    static final String CONFIG_COLOR_TITLE_FOREGROUND = "org.eclipse.draw2d.color.title.foreground";
+
+    static final String CONFIG_COLOR_TITLE_INACTIVE_BACKGROUND = "org.eclipse.draw2d.color.title.inactive.background";
+    static final String CONFIG_COLOR_TITLE_INACTIVE_GRADIENT = "org.eclipse.draw2d.color.title.inactive.gradient";
+    static final String CONFIG_COLOR_TITLE_INACTIVE_FOREGROUND = "org.eclipse.draw2d.color.title.inactive.foreground";
+
+    static final String CONFIG_COLOR_TOOLTIP_FOREGROUND = "org.eclipse.draw2d.color.tooltip.foreground";
+    static final String CONFIG_COLOR_TOOLTIP_BACKGROUND = "org.eclipse.draw2d.color.tooltip.background";
+
+    static final String CONFIG_COLOR_LIST_HOVER_BACKGROUND = "org.eclipse.draw2d.color.list.hover.background";
+    static final String CONFIG_COLOR_LIST_SELECTED_BACKGROUND = "org.eclipse.draw2d.color.list.selected.background";
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
@@ -43,7 +43,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * 
  * @author Dan Lee
  * @author Eric Bordeau
- * @since 3.12
+ * @since 3.13
  */
 public abstract class AbstractZoomManager {
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/DefaultScrollPolicy.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/DefaultScrollPolicy.java
@@ -22,7 +22,7 @@ import org.eclipse.draw2d.geometry.Point;
  * This behavior was the default behavior of GEF Classic and Zest pre version
  * 3.15.
  * 
- * @since 3.12
+ * @since 3.13
  */
 public class DefaultScrollPolicy implements IZoomScrollPolicy {
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/IZoomScrollPolicy.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/IZoomScrollPolicy.java
@@ -20,7 +20,7 @@ import org.eclipse.draw2d.geometry.Point;
  * It is used by the {@link AbstractZoomManager} to calculate the new viewport
  * location after zooming.
  * 
- * @since 3.12
+ * @since 3.13
  */
 public interface IZoomScrollPolicy {
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/MouseLocationZoomScrollPolicy.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/MouseLocationZoomScrollPolicy.java
@@ -17,15 +17,18 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Point;
 
-/** A scroll policy which ensures that the content under the mouse cursor stays where it is after scrolling. If the
- * mouse is not inside of the viewerControl the {@link DefaultScrollPolicy} is used as fallback.
+/**
+ * A scroll policy which ensures that the content under the mouse cursor stays
+ * where it is after scrolling. If the mouse is not inside of the viewerControl
+ * the {@link DefaultScrollPolicy} is used as fallback.
  * 
- * In order to keep the target under the mouse stable we have to calculate the new view location such that the following
- * equation holds:
+ * In order to keep the target under the mouse stable we have to calculate the
+ * new view location such that the following equation holds:
  * 
  * (mousepos + oldViewLocation) / oldZoom = (mousepos + newViewLocation)/newZoom
  * 
- * @since 3.12 */
+ * @since 3.13
+ */
 public class MouseLocationZoomScrollPolicy extends DefaultScrollPolicy {
 
 	final Control viewerControl;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/ZoomListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/ZoomListener.java
@@ -14,7 +14,7 @@ package org.eclipse.draw2d.zoom;
  * Listens to zoom level changes.
  * 
  * @author Eric Bordeau
- * @since 3.12
+ * @since 3.13
  */
 public interface ZoomListener {
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/GridLayer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/GridLayer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,9 @@
  *******************************************************************************/
 package org.eclipse.gef.editparts;
 
-import org.eclipse.draw2d.ColorConstants;
-import org.eclipse.draw2d.FigureUtilities;
-import org.eclipse.draw2d.FreeformLayer;
-import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.*;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
-
 import org.eclipse.gef.SnapToGrid;
 
 /**
@@ -50,7 +45,7 @@ public class GridLayer extends FreeformLayer {
 	 */
 	public GridLayer() {
 		super();
-		setForegroundColor(ColorConstants.lightGray);
+		setForegroundColor(ColorConstants.lineForeground);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalImages.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalImages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,13 @@
  *******************************************************************************/
 package org.eclipse.gef.internal;
 
-import org.eclipse.swt.graphics.Image;
-
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class InternalImages {
 
@@ -82,6 +84,8 @@ public class InternalImages {
 	 * Can be used to access the cached pinned image by using {@link #get(String)}.
 	 */
 	public static final String IMG_PALETTE = "icons/palette_view.gif";//$NON-NLS-1$
+
+	private static final Map<String, Image> overloadedImages = new HashMap<>();
 
 	static {
 		DESC_BOLD = createDescriptor("icons/style_bold.gif"); //$NON-NLS-1$
@@ -161,7 +165,17 @@ public class InternalImages {
 	 * @return the image or null if it has not been cached in the registry
 	 */
 	public static Image get(String imageName) {
+		Image image = overloadedImages.get(imageName);
+		if (image != null) {
+			return image;
+		}
 		return InternalGEFPlugin.getDefault().getImageRegistry().get(imageName);
+	}
+
+	public static void set(String imageName, Image image) {
+		synchronized (overloadedImages) {
+			overloadedImages.put(imageName, image);
+		}
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteColorUtil.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteColorUtil.java
@@ -37,9 +37,9 @@ public class PaletteColorUtil {
 
 	public static final Color ARROW_HOVER = new Color(null, 229, 229, 219);
 
-	private static final Color HOVER_COLOR = new Color(null, 252, 228, 179);
+	private static final Color HOVER_COLOR = ColorConstants.listHoverBackgroundColor;
 
-	private static final Color SELECTED_COLOR = new Color(null, 207, 227, 250);
+	private static final Color SELECTED_COLOR = ColorConstants.listSelectedBackgroundColor;
 
 	private static final Color HOVER_COLOR_HICONTRAST = new Color(null, 0, 128, 0);
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,44 +10,20 @@
  *******************************************************************************/
 package org.eclipse.gef.internal.ui.palette.editparts;
 
-import java.util.Iterator;
-import java.util.List;
-
+import org.eclipse.draw2d.*;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
+import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
+import org.eclipse.gef.ui.palette.editparts.PaletteToolbarLayout;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 
-import org.eclipse.draw2d.Animation;
-import org.eclipse.draw2d.Border;
-import org.eclipse.draw2d.BorderLayout;
-import org.eclipse.draw2d.ButtonModel;
-import org.eclipse.draw2d.ChangeEvent;
-import org.eclipse.draw2d.ChangeListener;
-import org.eclipse.draw2d.Clickable;
-import org.eclipse.draw2d.ColorConstants;
-import org.eclipse.draw2d.CompoundBorder;
-import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.FigureUtilities;
-import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.Label;
-import org.eclipse.draw2d.LayoutManager;
-import org.eclipse.draw2d.MarginBorder;
-import org.eclipse.draw2d.MouseEvent;
-import org.eclipse.draw2d.MouseListener;
-import org.eclipse.draw2d.MouseMotionListener;
-import org.eclipse.draw2d.SchemeBorder;
-import org.eclipse.draw2d.ScrollPane;
-import org.eclipse.draw2d.Toggle;
-import org.eclipse.draw2d.ToolbarLayout;
-import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.geometry.Insets;
-import org.eclipse.draw2d.geometry.Rectangle;
-
-import org.eclipse.gef.internal.ui.palette.PaletteColorUtil;
-import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
-import org.eclipse.gef.ui.palette.editparts.PaletteToolbarLayout;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * @author Pratik Shah
@@ -114,7 +90,7 @@ public class DrawerFigure extends Figure {
 			// draw top border of drawer figure
 			g.setForegroundColor(PaletteColorUtil.WIDGET_NORMAL_SHADOW);
 			g.drawLine(r.getTopLeft(), r.getTopRight());
-			g.setForegroundColor(ColorConstants.white);
+			g.setForegroundColor(ColorConstants.listBackground);
 			g.drawLine(r.getTopLeft().getTranslated(0, 1), r.getTopRight().getTranslated(0, 1));
 			r.crop(new Insets(2, 0, 0, 0));
 			if (isExpanded()) {
@@ -125,7 +101,7 @@ public class DrawerFigure extends Figure {
 
 			// draw bottom border of drawer figure
 			if (!isExpanded()) {
-				g.setForegroundColor(ColorConstants.white);
+				g.setForegroundColor(ColorConstants.listBackground);
 				g.drawLine(r.getBottomLeft().getTranslated(0, -1), r.getBottomRight().getTranslated(0, -1));
 				r.crop(new Insets(0, 0, 1, 0));
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteLabelProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,25 +10,22 @@
  *******************************************************************************/
 package org.eclipse.gef.ui.palette.customize;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Image;
-
+import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.gef.internal.InternalImages;
+import org.eclipse.gef.palette.PaletteContainer;
+import org.eclipse.gef.palette.PaletteEntry;
+import org.eclipse.gef.palette.PaletteSeparator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IColorProvider;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Image;
 
-import org.eclipse.draw2d.ColorConstants;
-
-import org.eclipse.gef.internal.InternalImages;
-import org.eclipse.gef.palette.PaletteContainer;
-import org.eclipse.gef.palette.PaletteEntry;
-import org.eclipse.gef.palette.PaletteSeparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * This class is the ILabelProvider for the
@@ -71,7 +68,7 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	public Color getForeground(Object element) {
 		PaletteEntry entry = (PaletteEntry) element;
 		if (!entry.isVisible() || !entry.getParent().isVisible()) {
-			return ColorConstants.gray;
+			return ColorConstants.lineForeground;
 		}
 		return null;
 	}


### PR DESCRIPTION
Pr adds an ability to customize colors via `org.eclipse.ui.themes`. Colors could be configured via preferences or theme settings. Additionally adds an ability to override configured images to support more extensive customization. This improvement will allow for the palette and other components to be configured for a black theme.