### PR TITLE
GH verification build on Linux and Windows and multiple Java versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Maven Tycho build
+name: GEF Class verification build
 
 on:
   push:
@@ -6,24 +6,29 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        java: [ 17 ]
+    runs-on: ${{ matrix.os }} 
+    name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v3
+    - name: Set up Java
+      uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
-        java-version: '17'
-    - name: Cache local Maven repository
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Run build
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
+    - name: Build with Maven
       uses: GabrielBB/xvfb-action@v1
       with:
-       run: mvn clean verify
+       run: >- 
+        mvn -V -B -D maven.test.failure.ignore=true clean verify
+    - name: Upload Test Results for Java-${{ matrix.java }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results-${{ matrix.config.native }}-java${{ matrix.java }}
+        if-no-files-found: error
+        path: |
+          ${{ github.workspace }}/**/target/surefire-reports/*.xml


### PR DESCRIPTION
Currently we use Java 11 and Java 17, if GEF moves to Java 17 we may want to use latest and greatest in addition to Java 17.