### PR TITLE
Remove -XX:MaxPermSize=256m arg on Mac

### DIFF
--- a/org.eclipse.draw2d.tests/pom.xml
+++ b/org.eclipse.draw2d.tests/pom.xml
@@ -21,7 +21,7 @@
 				</os>
 			</activation>
 			<properties>
-				<test.vmargs>-Xmx512m -XX:MaxPermSize=256m -XstartOnFirstThread</test.vmargs>
+				<test.vmargs>-Xmx512m -XstartOnFirstThread</test.vmargs>
 			</properties>
 		</profile>
 		<profile>

--- a/org.eclipse.gef.tests/pom.xml
+++ b/org.eclipse.gef.tests/pom.xml
@@ -21,7 +21,7 @@
 				</os>
 			</activation>
 			<properties>
-				<test.vmargs>-Xmx512m -XX:MaxPermSize=256m -XstartOnFirstThread</test.vmargs>
+				<test.vmargs>-Xmx512m -XstartOnFirstThread</test.vmargs>
 			</properties>
 		</profile>
 		<profile>

--- a/org.eclipse.zest.tests/pom.xml
+++ b/org.eclipse.zest.tests/pom.xml
@@ -21,7 +21,7 @@
 				</os>
 			</activation>
 			<properties>
-				<test.vmargs>-Xmx512m -XX:MaxPermSize=256m -XstartOnFirstThread</test.vmargs>
+				<test.vmargs>-Xmx512m -XstartOnFirstThread</test.vmargs>
 			</properties>
 		</profile>
 		<profile>


### PR DESCRIPTION
- Build will fail on Mac if this argument is not removed