### PR TITLE
Add a new job to the GitHub action for publishing the test results.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,8 +24,9 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
        run: >- 
-        mvn -V -B -D maven.test.failure.ignore=true clean verify
+        mvn -V -B -fae clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: test-results-${{ matrix.os }}-java${{ matrix.java }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,37 @@
+name: Publish Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["GEF Class verification build"]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          files: "artifacts/**/*.xml"
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
 		<maven.compiler.target>11</maven.compiler.target>		
 		<tycho.version>${tycho-version}</tycho.version>
 		<cbi-plugins.version>1.3.2</cbi-plugins.version>
-		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gef-classic.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<comparator.repo>https://download.eclipse.org/tools/gef/classic/releases/3.15.0</comparator.repo>


### PR DESCRIPTION
With this change, test failures are no longer silently ignored. When a failure has been detected, all remaining test cases continue to be executed, then the Maven build throws an error.

Regardless of the successful build, the test results for each job are uploaded to GitHub.

Once the job has completed, a new workflow action is executed, which aggregates all test results and publishes them within the GitHub action.