### PR TITLE
[WB] Add constructor to set the "enabled" flag when creating Transposers

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
@@ -19,6 +19,7 @@ import junit.framework.TestCase;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 
@@ -88,6 +89,19 @@ public abstract class BaseTestCase extends TestCase {
 		assertEquals(left, insets.left);
 		assertEquals(bottom, insets.bottom);
 		assertEquals(right, insets.right);
+	}
+
+	/**
+	 * Asserts that two objects are equal. Expected object
+	 * <code>(x, y, width, height)</code>. Actual object
+	 * <code>{@link Rectangle}</code>. If they are not an AssertionFailedError is
+	 * thrown.
+	 */
+	public void assertEquals(int x, int y, int width, int height, Rectangle rectangle) throws Exception {
+		assertEquals(x, rectangle.x);
+		assertEquals(y, rectangle.y);
+		assertEquals(width, rectangle.width);
+		assertEquals(height, rectangle.height);
 	}
 
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TransposerTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TransposerTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2023 Google, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Google, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.draw2d.test;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.geometry.Transposer;
+
+/**
+ * @author lobas_av
+ *
+ */
+public class TransposerTest extends BaseTestCase {
+
+	public void testState() throws Exception {
+		Transposer transposer = new Transposer();
+		// check "not enabled" new Transposer
+		assertFalse(transposer.isEnabled());
+		//
+		// check setEnabled()
+		transposer.setEnabled(true);
+		assertTrue(transposer.isEnabled());
+		//
+		transposer.setEnabled(false);
+		assertFalse(transposer.isEnabled());
+		//
+		// check enable()
+		transposer.enable();
+		assertTrue(transposer.isEnabled());
+		//
+		transposer.enable();
+		assertTrue(transposer.isEnabled());
+		//
+		// check disable()
+		transposer.disable();
+		assertFalse(transposer.isEnabled());
+		//
+		transposer.disable();
+		assertFalse(transposer.isEnabled());
+	}
+
+	public void testTDimension() throws Exception {
+		Dimension dimension = new Dimension(100, 200);
+		Transposer transposer = new Transposer();
+		//
+		// check work with Dimension if Transposer is enabled
+		transposer.enable();
+		Dimension result = transposer.t(dimension);
+		assertNotNull(result);
+		assertNotSame(result, dimension);
+		assertEquals(100, 200, dimension);
+		assertEquals(200, 100, result);
+		//
+		// check work with Dimension if Transposer is disabled
+		transposer.disable();
+		result = transposer.t(dimension);
+		assertSame(result, dimension);
+		assertEquals(100, 200, dimension);
+	}
+
+	public void testTInsets() throws Exception {
+		Insets insets = new Insets(1, 2, 3, 4);
+		Transposer transposer = new Transposer();
+		//
+		// check work with Insets if Transposer is enabled
+		transposer.enable();
+		Insets result = transposer.t(insets);
+		assertNotNull(result);
+		assertNotSame(result, insets);
+		assertEquals(1, 2, 3, 4, insets);
+		assertEquals(2, 1, 4, 3, result);
+		//
+		// check work with Insets if Transposer is disabled
+		transposer.disable();
+		result = transposer.t(insets);
+		assertSame(result, insets);
+		assertEquals(1, 2, 3, 4, insets);
+	}
+
+	public void testTPoint() throws Exception {
+		Point point = new Point(100, 200);
+		Transposer transposer = new Transposer();
+		//
+		// check work with Point if Transposer is enabled
+		transposer.enable();
+		Point result = transposer.t(point);
+		assertNotNull(result);
+		assertNotSame(result, point);
+		assertEquals(100, 200, point);
+		assertEquals(200, 100, result);
+		//
+		// check work with Point if Transposer is disabled
+		transposer.disable();
+		result = transposer.t(point);
+		assertSame(result, point);
+		assertEquals(100, 200, point);
+	}
+
+	public void testTRectangle() throws Exception {
+		Rectangle rectangle = new Rectangle(1, 2, 3, 4);
+		Transposer transposer = new Transposer();
+		//
+		// check work with Rectangle if Transposer is enabled
+		transposer.enable();
+		Rectangle result = transposer.t(rectangle);
+		assertNotNull(result);
+		assertNotSame(result, rectangle);
+		assertEquals(1, 2, 3, 4, rectangle);
+		assertEquals(2, 1, 4, 3, result);
+		//
+		// check work with Rectangle if Transposer is disabled
+		transposer.disable();
+		result = transposer.t(rectangle);
+		assertSame(result, rectangle);
+		assertEquals(1, 2, 3, 4, rectangle);
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Transposer.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Transposer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,19 @@ package org.eclipse.draw2d.geometry;
 public class Transposer {
 
 	private boolean enabled = false;
+
+	public Transposer() {
+	}
+
+	/**
+	 * Convenience constructor to initialize the "enabled" flag during creation.
+	 * 
+	 * @param enabled {code true}, whether geometrical objects should be transposed.
+	 * @since 3.13
+	 */
+	public Transposer(boolean enabled) {
+		this.enabled = enabled;
+	}
 
 	/**
 	 * Disables transposing of inputs.


### PR DESCRIPTION
Instead of:
Transposer t = new Transposer();
t.setEnabled(true);

One can simply do this:
Transposer t = new Transposer(true);