### PR TITLE
[WB] Extend Translatable interface with additional default methods.

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Translatable.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Translatable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,38 @@ package org.eclipse.draw2d.geometry;
  * horizontally.
  */
 public interface Translatable {
+	/**
+	 * Translates this object horizontally by <code>point.x</code> and vertically by
+	 * <code>point.y</code>.
+	 * 
+	 * @param point Point which provides translation information
+	 * @since 3.13
+	 */
+	default void performTranslate(Point point) {
+		performTranslate(point.x, point.y);
+	}
+
+	/**
+	 * Translates this object horizontally by <code>dimension.width</code> and
+	 * vertically by <code>dimension.height</code>.
+	 * 
+	 * @param dimension Dimension which provides translation information
+	 * @since 3.13
+	 */
+	default void performTranslate(Dimension dimension) {
+		performTranslate(dimension.width, dimension.height);
+	}
+
+	/**
+	 * Translates this object horizontally by <code>insets.left</code> and
+	 * vertically by <code>insets.top</code>.
+	 * 
+	 * @param insets Insets which provides translation information
+	 * @since 3.13
+	 */
+	default void performTranslate(Insets insets) {
+		performTranslate(insets.left, insets.top);
+	}
 
 	/**
 	 * Translates this object horizontally by <code>dx</code> and vertically by


### PR DESCRIPTION
Extend the interface to also allow calling the performTranslate method for points, dimensions and insets. For the sake of backwards-compatibility, provide a default implementation.