### PR TITLE
Addresses #155: Typifysearch

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ExclusionSearch.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ExclusionSearch.java
@@ -21,14 +21,14 @@ import java.util.Collection;
  */
 public class ExclusionSearch implements TreeSearch {
 
-	private final Collection c;
+	private final Collection<IFigure> c;
 
 	/**
 	 * Constructs an Exclusion search using the given collection.
 	 * 
 	 * @param collection the exclusion set
 	 */
-	public ExclusionSearch(Collection collection) {
+	public ExclusionSearch(Collection<IFigure> collection) {
 		this.c = collection;
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -374,7 +374,7 @@ public class Figure implements IFigure {
 	 */
 	@Override
 	public final IFigure findFigureAt(Point pt) {
-		return findFigureAtExcluding(pt.x, pt.y, Collections.EMPTY_LIST);
+		return findFigureAtExcluding(pt.x, pt.y, Collections.emptyList());
 	}
 
 	/**
@@ -406,7 +406,7 @@ public class Figure implements IFigure {
 	 * @see IFigure#findFigureAtExcluding(int, int, Collection)
 	 */
 	@Override
-	public final IFigure findFigureAtExcluding(int x, int y, Collection c) {
+	public final IFigure findFigureAtExcluding(int x, int y, Collection<IFigure> c) {
 		return findFigureAt(x, y, new ExclusionSearch(c));
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
@@ -249,7 +249,7 @@ public interface IFigure {
 	 * @return The IFigure at the specified location, excluding any IFigures in
 	 *         collection
 	 */
-	IFigure findFigureAtExcluding(int x, int y, Collection collection);
+	IFigure findFigureAtExcluding(int x, int y, Collection<IFigure> collection);
 
 	/**
 	 * Returns the IFigure located at the given location which will accept mouse

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
@@ -155,6 +155,7 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 	 */
 	private TransferDropTargetListener createTransferDropTargetListener() {
 		return new TemplateTransferDropTargetListener(getGraphicalViewer()) {
+			@Override
 			protected CreationFactory getFactory(Object template) {
 				return new SimpleFactory((Class) template);
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.util.TransferDragSourceListener;
 import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.jface.viewers.ISelection;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 /**
@@ -194,10 +195,10 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * {@link #findObjectAt(Point)}.
 	 * 
 	 * @param location     The mouse location
-	 * @param exclusionSet The set of EditParts to be excluded
+	 * @param exclusionSet The set of IFigures to be excluded
 	 * @return <code>null</code> or an EditPart
 	 */
-	EditPart findObjectAtExcluding(Point location, Collection exclusionSet);
+	EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet);
 
 	/**
 	 * Returns <code>null</code> or the <code>EditPart</code> at the specified
@@ -205,11 +206,11 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * similarly to {@link #findObjectAt(Point)}.
 	 * 
 	 * @param location     The mouse location
-	 * @param exclusionSet The set of EditParts to be excluded
+	 * @param exclusionSet The set of IFigures to be excluded
 	 * @param conditional  the Conditional used to evaluate a potential hit
 	 * @return <code>null</code> or an EditPart
 	 */
-	EditPart findObjectAtExcluding(Point location, Collection exclusionSet, Conditional conditional);
+	EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet, Conditional conditional);
 
 	/**
 	 * Flushes all pending updates to the Viewer.

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Cursor;
 
 import org.eclipse.draw2d.Connection;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Point;
 
@@ -42,7 +43,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	protected static final int MAX_FLAG = FLAG_SOURCE_FEEBBACK;
 
 	private String commandName;
-	private List exclusionSet;
+	private List<IFigure> exclusionSet;
 
 	private ConnectionEditPart connectionEditPart;
 
@@ -148,9 +149,9 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#getExclusionSet()
 	 */
-	protected Collection getExclusionSet() {
+	protected Collection<IFigure> getExclusionSet() {
 		if (exclusionSet == null) {
-			exclusionSet = new ArrayList();
+			exclusionSet = new ArrayList<>(1);
 			exclusionSet.add(getConnection());
 		}
 		return exclusionSet;

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
@@ -69,7 +69,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	private static final int FLAG_SOURCE_FEEDBACK = SelectEditPartTracker.MAX_FLAG << 1;
 	/** Max flag */
 	protected static final int MAX_FLAG = FLAG_SOURCE_FEEDBACK;
-	private List exclusionSet;
+	private List<IFigure> exclusionSet;
 	private PrecisionPoint sourceRelativeStartPoint;
 	private SnapToHelper snapToHelper;
 	private PrecisionRectangle sourceRectangle, compoundSrcRect;
@@ -338,10 +338,10 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#getExclusionSet()
 	 */
-	protected Collection getExclusionSet() {
+	protected Collection<IFigure> getExclusionSet() {
 		if (exclusionSet == null) {
 			List set = getOperationSet();
-			exclusionSet = new ArrayList(set.size() + 1);
+			exclusionSet = new ArrayList<>(set.size() + 1);
 			for (int i = 0; i < set.size(); i++) {
 				GraphicalEditPart editpart = (GraphicalEditPart) set.get(i);
 				exclusionSet.add(editpart.getFigure());

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/TargetingTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/TargetingTool.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 
 import org.eclipse.swt.widgets.Display;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AutoexposeHelper;
@@ -124,13 +125,14 @@ public abstract class TargetingTool extends AbstractTool {
 	}
 
 	/**
-	 * Returns a List of objects that should be excluded as potential targets for
+	 * Returns a List of figures that should be excluded as potential targets for
 	 * the operation.
 	 * 
-	 * @return the list of objects to be excluded as targets
+	 * @return the list of figures to be excluded as targets
 	 */
-	protected Collection getExclusionSet() {
-		return Collections.EMPTY_LIST;
+	@SuppressWarnings("static-method") // to be overridden by children
+	protected Collection<IFigure> getExclusionSet() {
+		return Collections.emptyList();
 	}
 
 	/**
@@ -391,7 +393,7 @@ public abstract class TargetingTool extends AbstractTool {
 			return;
 		AutoexposeHelper.Search search;
 		search = new AutoexposeHelper.Search(getLocation());
-		getCurrentViewer().findObjectAtExcluding(getLocation(), Collections.EMPTY_LIST, search);
+		getCurrentViewer().findObjectAtExcluding(getLocation(), Collections.emptyList(), search);
 		setAutoexposeHelper(search.result);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -41,6 +41,7 @@ import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AccessibleEditPart;
@@ -222,13 +223,13 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @see EditPartViewer#findObjectAt(Point)
 	 */
 	public final EditPart findObjectAt(Point pt) {
-		return findObjectAtExcluding(pt, Collections.EMPTY_SET);
+		return findObjectAtExcluding(pt, Collections.emptySet());
 	}
 
 	/**
 	 * @see EditPartViewer#findObjectAtExcluding(Point, Collection)
 	 */
-	public final EditPart findObjectAtExcluding(Point pt, Collection exclude) {
+	public final EditPart findObjectAtExcluding(Point pt, Collection<IFigure> exclude) {
 		return findObjectAtExcluding(pt, exclude, null);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
@@ -138,7 +138,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 		LayerManager layermanager = (LayerManager) getEditPartRegistry().get(LayerManager.ID);
 		if (layermanager == null)
 			return null;
-		List list = new ArrayList(3);
+		List<IFigure> list = new ArrayList<>(3);
 		list.add(layermanager.getLayer(LayerConstants.PRIMARY_LAYER));
 		list.add(layermanager.getLayer(LayerConstants.CONNECTION_LAYER));
 		list.add(layermanager.getLayer(LayerConstants.FEEDBACK_LAYER));
@@ -152,12 +152,14 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * @see EditPartViewer#findObjectAtExcluding(Point, Collection,
 	 *      EditPartViewer.Conditional)
 	 */
-	public EditPart findObjectAtExcluding(Point pt, Collection exclude, final Conditional condition) {
+	@Override
+	public EditPart findObjectAtExcluding(Point pt, Collection<IFigure> exclude, final Conditional condition) {
 		class ConditionalTreeSearch extends ExclusionSearch {
-			ConditionalTreeSearch(Collection coll) {
+			ConditionalTreeSearch(Collection<IFigure> coll) {
 				super(coll);
 			}
 
+			@Override
 			public boolean accept(IFigure figure) {
 				EditPart editpart = null;
 				while (editpart == null && figure != null) {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
@@ -71,13 +71,15 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 		return RequestConstants.REQ_ADD;
 	}
 
-	protected Collection getExclusionSet() {
+	@Override
+	protected Collection<EditPart> getExclusionSet() {
 		List selection = getViewer().getSelectedEditParts();
-		List exclude = new ArrayList(selection);
+		List<EditPart> exclude = new ArrayList<>(selection);
 		exclude.addAll(includeChildren(selection));
 		return exclude;
 	}
 
+	@Override
 	protected void handleDragOver() {
 		if (TreeViewerTransfer.getInstance().getViewer() != getViewer()) {
 			getCurrentEvent().detail = DND.DROP_NONE;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/rulers/RulerComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/rulers/RulerComposite.java
@@ -12,7 +12,7 @@ package org.eclipse.gef.ui.rulers;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
+import java.util.Collections;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
@@ -473,8 +473,9 @@ public class RulerComposite extends Composite {
 		/**
 		 * @see org.eclipse.gef.GraphicalViewer#findHandleAt(org.eclipse.draw2d.geometry.Point)
 		 */
+		@Override
 		public Handle findHandleAt(org.eclipse.draw2d.geometry.Point p) {
-			final GraphicalEditPart gep = (GraphicalEditPart) findObjectAtExcluding(p, new ArrayList());
+			final GraphicalEditPart gep = (GraphicalEditPart) findObjectAtExcluding(p, Collections.emptyList());
 			if (gep == null || !(gep instanceof GuideEditPart))
 				return null;
 			return new Handle() {
@@ -491,6 +492,7 @@ public class RulerComposite extends Composite {
 		/**
 		 * @see org.eclipse.gef.ui.parts.AbstractEditPartViewer#init()
 		 */
+		@Override
 		protected void init() {
 			setContextMenu(new RulerContextMenuProvider(this));
 			setKeyHandler(new RulerKeyHandler(this));


### PR DESCRIPTION
With this cleanup the figure and edipart search was typified. As part of
this work it was identified that the TargetingTool documentation was
wrong. While there it was written that getExclusion set provides
editparts all its children provided a list of IFigures. Also the search
expected IFigures.

Furthermore AbstractTransferDropTargetListener delivered EditParts but
the search required IFigures. The code was fixed here was well and by
typifying the Collections it is now clearer.

@Destrolaric this would be my last commit for Issue #155 for now. 