### PR TITLE
[JUnit] Stabilize tests on MacOS and define 5min timeout

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
@@ -13,8 +13,6 @@ package org.eclipse.draw2d.test;
 
 import java.util.Stack;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.swt.SWT;
@@ -34,11 +32,10 @@ import org.eclipse.swt.graphics.Resource;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
-public class AdvancedGraphicsTests extends TestCase {
+public class AdvancedGraphicsTests extends BaseTestCase {
 
 	static final int LINE[] = new int[] { 5, 5, 20, 20, 35, 5, 50, 5 };
 	static final int POLY[] = new int[] { 5, 5, 45, 15, 20, 30, 20, 20, 45, 35, 5, 45 };
-	private static final int PREVIEW_DELAY = 250;
 	private SWTGraphics g;
 
 	private Image image;
@@ -77,16 +74,13 @@ public class AdvancedGraphicsTests extends TestCase {
 		shell.setBounds(100, 100, 800, 600);
 		shell.open();
 		Display d = shell.getDisplay();
-		d.timerExec(PREVIEW_DELAY, new Runnable() {
+		d.asyncExec(new Runnable() {
 			public void run() {
 				if (!shell.isDisposed())
 					shell.close();
 			}
 		});
-		while (!shell.isDisposed())
-			while (!d.readAndDispatch())
-				d.sleep();
-
+		waitEventLoop(shell, 100);
 	}
 
 	private void performTestcase(Runnable painter, Runnable tests[]) {

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
@@ -123,7 +123,8 @@ public abstract class BaseTestCase extends TestCase {
 	protected void waitEventLoop(Shell shell, int timeMillis) {
 		long start = System.currentTimeMillis();
 		do {
-			while (shell.getDisplay().readAndDispatch()) {
+			// One of the events might dispose the shell...
+			while (!shell.isDisposed() && shell.getDisplay().readAndDispatch()) {
 				// dispatch all updates
 			}
 		} while (System.currentTimeMillis() - start < timeMillis);

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gef-classic.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<comparator.repo>https://download.eclipse.org/tools/gef/classic/releases/3.15.0</comparator.repo>
+		<surefire.timeout>300</surefire.timeout>
 	</properties>
 
 	<build>


### PR DESCRIPTION
It seems like the way timed jobs are executed on MacOS slightly differs from Windows and Linux. As a result, it might happen that a job is scheduled but the UI thread is never woken up again. As a result, the test case is stuck indefinitely, until it is aborted by GitHub.

To avoid this problem, add this job asynchronously. This way, the job is immediately added to the event queue. Furthermore, don't call sleep() while pumping the event queue, in order to avoid missing out on wake-up events.

To avoid issues like this in the future, specify a 5min timeout for each test bundle. Given that we share our build nodes with the other Eclipse projects, a job being stuck for 6h means that other developers might not be able to run their builds for this amount of time. So we should fail early, to free up those resources again.