### PR TITLE
[JUnit] Stabilize ConnectionEndPointMoveTest via waitEventLoop method

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
@@ -23,6 +23,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Shell;
 
 /**
  * @author Pratik Shah
@@ -113,5 +114,18 @@ public abstract class BaseTestCase extends TestCase {
 	public void assertEquals(int begin, int length, Interval interval) throws Exception {
 		assertEquals(begin, interval.begin());
 		assertEquals(length, interval.length());
+	}
+
+	/**
+	 * Waits given number of milliseconds and pumps the SWT event queue.<br>
+	 * At least one events loop will be executed.
+	 */
+	protected void waitEventLoop(Shell shell, int timeMillis) {
+		long start = System.currentTimeMillis();
+		do {
+			while (shell.getDisplay().readAndDispatch()) {
+				// dispatch all updates
+			}
+		} while (System.currentTimeMillis() - start < timeMillis);
 	}
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ConnectionEndPointMoveTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ConnectionEndPointMoveTest.java
@@ -27,9 +27,7 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
-import junit.framework.TestCase;
-
-public class ConnectionEndPointMoveTest extends TestCase implements UpdateListener {
+public class ConnectionEndPointMoveTest extends BaseTestCase implements UpdateListener {
 
 	private IFigure contents;
 	private RectangleFigure dec;
@@ -124,9 +122,7 @@ public class ConnectionEndPointMoveTest extends TestCase implements UpdateListen
 
 	private void performUpdate() {
 		contents.getUpdateManager().performUpdate();
-		while (shell.getDisplay().readAndDispatch()) {
-			// dispatch all updates
-		}
+		waitEventLoop(shell, 100);
 	}
 
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PaintDamageEraseTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PaintDamageEraseTest.java
@@ -25,9 +25,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 import junit.framework.AssertionFailedError;
-import junit.framework.TestCase;
 
-public class PaintDamageEraseTest extends TestCase implements UpdateListener {
+public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener {
 
 	private FigureCanvas fc;
 	protected IFigure contents;
@@ -259,20 +258,7 @@ public class PaintDamageEraseTest extends TestCase implements UpdateListener {
 
 	private void performUpdate() {
 		container.getUpdateManager().performUpdate();
-		waitEventLoop(100);
-	}
-
-	/**
-	 * Waits given number of milliseconds and pumps the SWT event queue.<br>
-	 * At least one events loop will be executed.
-	 */
-	private void waitEventLoop(int timeMillis) {
-		long start = System.currentTimeMillis();
-		do {
-			while (shell.getDisplay().readAndDispatch()) {
-				// dispatch all updates
-			}
-		} while (System.currentTimeMillis() - start < timeMillis);
+		waitEventLoop(shell, 100);
 	}
 
 }


### PR DESCRIPTION
Use the same approach used to stabilize the PaintDamageErase tests. When pumping the SWT event loop only once, the update of the UpdateManager may have not been fully performed. In order to ensure that it has been fully processed, pump the events for an arbitrary but fixed amount of time.

For the sake of reusability, the waitEventLoop method has been moved to the BaseTestCase class. Both test cases extend this base class in order to access this method. The ConnectionEndPointMove test will pump SWT events for a total of 100ms.