### PR TITLE
Adjust shrink method of rectangles to prevent negative width/height.

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
@@ -311,6 +311,19 @@ public class RectangleTest extends BaseTestCase {
 		Insets insets = new Insets(1, 2, 3, 4);
 		assertSame(template, template.crop(insets));
 		assertEquals(1, 2, 3, 4, insets);
+		assertEquals(12, 16, 64, 26, template);
+		//
+		insets = new Insets(4, 3, 2, 1);
+		assertSame(template, template.crop(insets));
+		assertEquals(15, 20, 60, 20, template);
+		//
+		insets = new Insets(20, 0, 20, 0);
+		assertSame(template, template.crop(insets));
+		assertEquals(15, 40, 60, 0, template);
+		//
+		insets = new Insets(0, 40, 0, 40);
+		assertSame(template, template.crop(insets));
+		assertEquals(55, 40, 0, 0, template);
 	}
 
 	public void testExpandIntInt() throws Exception {
@@ -378,12 +391,22 @@ public class RectangleTest extends BaseTestCase {
 
 	public void testShrink() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 30, 40);
+		Point center = new Point(16, 22);
 		assertSame(template, template.shrink(5, 7));
 		assertEquals(6, 9, 20, 26, template);
+		assertEquals(center, template.getCenter());
 		//
 		template = new Rectangle(10, 20, 3, 4);
+		center = new Point(11, 22);
 		assertSame(template, template.shrink(-5, -7));
 		assertEquals(5, 13, 13, 18, template);
+		assertEquals(center, template.getCenter());
+		//
+		template = new Rectangle(10, 20, 10, 10);
+		center = new Point(15, 25);
+		assertSame(template, template.shrink(20, 20));
+		assertEquals(15, 25, 0, 0, template);
+		assertEquals(center, template.getCenter());
 	}
 
 	public void testTranslate() throws Exception {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -1085,16 +1085,18 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	public Rectangle shrink(Insets insets) {
 		if (insets == null)
 			return this;
-		x += insets.left;
-		y += insets.top;
-		width -= (insets.getWidth());
-		height -= (insets.getHeight());
+		shrinkLeft(insets.left);
+		shrinkTop(insets.top);
+		width = Math.max(0, width - insets.right);
+		height = Math.max(0, height - insets.bottom);
 		return this;
 	}
 
 	/**
 	 * Shrinks the sides of this Rectangle by the horizontal and vertical values
-	 * provided as input, and returns this Rectangle for convenience. The center of
+	 * provided as input, and returns this Rectangle for convenience. If the given
+	 * reduction amount of larger than the current {@link #width()} or
+	 * {@link #height()} of the rectangle, {@code 0} is used instead. The center of
 	 * this Rectangle is kept constant.
 	 * 
 	 * @param h Horizontal reduction amount
@@ -1103,10 +1105,11 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @since 2.0
 	 */
 	public Rectangle shrink(int h, int v) {
-		x += h;
-		width -= (h + h);
-		y += v;
-		height -= (v + v);
+		Point center = getCenter();
+		x = Math.min(center.x, x + h);
+		width = Math.max(0, width - 2 * h);
+		y = Math.min(center.y, y + v);
+		height = Math.max(0, height - 2 * v);
 		return this;
 	}
 


### PR DESCRIPTION
This negative value occurs when the rectangle has a border, but its height or width is smaller than the height or width of its insets. The shrink method then tries to reduce the width/height of the rectangle by the width/height of the Insets which may then load to an error.