### PR TITLE
Fix GEF plugin project setup

### DIFF
--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -35,7 +35,7 @@ Export-Package: org.eclipse.gef,
  org.eclipse.gef.ui.stackview.icons,
  org.eclipse.gef.ui.views.palette,
  org.eclipse.gef.util
-Require-Bundle: org.eclipse.draw2d;visibility:=reexport;bundle-version="[3.7.0,4.0.0)",
+Require-Bundle: org.eclipse.draw2d;visibility:=reexport;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.views;resolution:=optional;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.2.0,4.0.0)",


### PR DESCRIPTION
GEF 3.14 requires as minimum version draw2d 3.13.0. This is now fixed in GEF manifest.