### PR TITLE
Adresses #215: Fix GEF incorrect build.properties

### DIFF
--- a/org.eclipse.gef/build.properties
+++ b/org.eclipse.gef/build.properties
@@ -13,6 +13,7 @@ bin.includes = about.*,\
                plugin.xml,\
                plugin.properties,\
                icons/*.gif,\
+               css/,\
                .,\
                META-INF/
 source.. = src/


### PR DESCRIPTION
https://github.com/eclipse/gef-classic/issues/215 