### PR TITLE
PointList bounds not updated when using setPoint()

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointListTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointListTests.java
@@ -323,6 +323,37 @@ public class PointListTests extends BaseTestCase {
 		assertSame(boundsNew, list.getBounds());
 	}
 
+	public void testGetSmallestBounds() throws Exception {
+		PointList list = new PointList();
+		//
+		list.addPoint(10, 10);
+		list.addPoint(20, 20);
+		assertEquals(10, 10, 11, 11, list.getBounds());
+
+		list.setPoint(new Point(20, 20), 0);
+		assertEquals(20, 20, 1, 1, list.getBounds());
+		//
+		list.removeAllPoints();
+
+		list.addPoint(10, 10);
+		list.addPoint(20, 20);
+		assertEquals(10, 10, 11, 11, list.getBounds());
+
+		list.removePoint(1);
+		assertEquals(10, 10, 1, 1, list.getBounds());
+		//
+		list.removeAllPoints();
+
+		list.addPoint(10, 10);
+		assertEquals(10, 10, 1, 1, list.getBounds());
+
+		list.addPoint(0, 0);
+		assertEquals(0, 0, 11, 11, list.getBounds());
+
+		list.addPoint(20, 20);
+		assertEquals(0, 0, 21, 21, list.getBounds());
+	}
+
 	public void testTranslate() throws Exception {
 		PointList list = new PointList();
 		for (int i = 0; i < 5; i++) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PointList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PointList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -346,8 +346,7 @@ public class PointList implements java.io.Serializable, Translatable {
 		if (index < 0 || index >= size)
 			throw new IndexOutOfBoundsException("Index: " + index + //$NON-NLS-1$
 					", Size: " + size); //$NON-NLS-1$
-		if (bounds != null && !bounds.contains(pt))
-			bounds = null;
+		bounds = null;
 		points[index * 2] = pt.x;
 		points[index * 2 + 1] = pt.y;
 	}


### PR DESCRIPTION
The getBounds() method is supposed to return the minimal rectangle enclosing all points. When a point inside this PointList is updated via setPoint() and the point is contained in the current bounds, then the current rectangle has to be invalidated, s.t. getBounds() has to calculate a new, potentially smaller rectangle.

Resolves #219 