### PR TITLE
[WB] Add a new getTextExtent() method to the Graphics class

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Graphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Graphics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.swt.graphics.Path;
 import org.eclipse.swt.graphics.Pattern;
 import org.eclipse.swt.graphics.TextLayout;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -760,6 +761,22 @@ public abstract class Graphics {
 	public int getTextAntialias() {
 		throwNotImplemented();
 		return SWT.DEFAULT;
+	}
+
+	/**
+	 * <p>Returns the extent of the given string. Tab expansion and carriage return
+	 * processing are performed.</p>
+	 * <p>The <em>extent</em> of a string is the width and height of the rectangular
+	 * area it would cover if drawn in a particular font (in this case, the current
+	 * font in the receiver).</p>
+	 *
+	 * @param string the string to measure
+	 * @return a dimension containing the extent of the string
+	 * @since 3.13
+	 */
+	public Dimension getTextExtent(String string) {
+		throwNotImplemented();
+		return null;
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials 
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.graphics.Transform;
 import org.eclipse.swt.widgets.Display;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -750,6 +751,15 @@ public class SWTGraphics extends Graphics {
 	 */
 	public int getTextAntialias() {
 		return ((currentState.graphicHints & TEXT_AA_MASK) >> TEXT_AA_SHIFT) - AA_WHOLE_NUMBER;
+	}
+
+	/**
+	 * @see Graphics#getTextExtent(String)
+	 */
+	public Dimension getTextExtent(String s) {
+		checkText();
+		org.eclipse.swt.graphics.Point extent = gc.textExtent(s);
+		return new Dimension(extent.x, extent.y);
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.graphics.TextStyle;
 import org.eclipse.swt.widgets.Display;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -606,6 +607,13 @@ public class ScaledGraphics extends Graphics {
 	 */
 	public int getTextAntialias() {
 		return graphics.getTextAntialias();
+	}
+
+	/**
+	 * @see Graphics#getTextExtent(String)
+	 */
+	public Dimension getTextExtent(String string) {
+		return graphics.getTextExtent(string);
 	}
 
 	/** @see Graphics#getXORMode() */


### PR DESCRIPTION
This method allows clients to dynamically calculate the width and height of a string text. This may be useful in order to e.g. determine, whether a label has to be truncated.