### PR TITLE
Migrate Draw2D, GEF & Zest JUnit Tests from 3 to 4

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
@@ -32,6 +32,10 @@ import org.eclipse.swt.graphics.Resource;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 public class AdvancedGraphicsTests extends BaseTestCase {
 
 	static final int LINE[] = new int[] { 5, 5, 20, 20, 35, 5, 50, 5 };
@@ -103,7 +107,8 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		assertImageEquality(100 * tests.length, 100);
 	}
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		path1 = new Path(null);
 		path1.moveTo(20, 5);
 		path1.quadTo(40, 5, 50, 25);
@@ -126,12 +131,14 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		resources.push(imageGC);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		g.dispose();
 		while (!resources.isEmpty())
 			((Resource) resources.pop()).dispose();
 	}
 
+	@Test
 	public void testAntialias() {
 		class AntialiasSettings implements Runnable {
 			private final Color color;
@@ -167,6 +174,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		}, tests);
 	}
 
+	@Test
 	public void testFillRules() {
 
 		class FillRules implements Runnable {
@@ -223,6 +231,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 	// }, tests);
 	// }
 
+	@Test
 	public void testLineJoinCap() {
 
 		class LineSettings implements Runnable {
@@ -257,11 +266,13 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		}, tests);
 	}
 
+	@Test
 	public void testLineJoinCapAA() {
 		g.setAntialias(SWT.ON);
 		testLineJoinCap();
 	}
 
+	@Test
 	public void testLineAttributes() {
 		class LineSettings implements Runnable {
 			private LineAttributes attributes;
@@ -296,6 +307,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		}, tests);
 	}
 
+	@Test
 	public void testLineAttributesAA() {
 		g.setAntialias(SWT.ON);
 		testLineAttributes();
@@ -378,6 +390,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 	// path1.dispose();
 	// }
 
+	@Test
 	public void testPatterns() {
 
 		class SetPattern implements Runnable {

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AnchorNotificationTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AnchorNotificationTest.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.ChopboxAnchor;
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.Figure;
@@ -20,6 +17,10 @@ import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.XYAnchor;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests the notification of anchors and connection figures.
@@ -40,7 +41,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @since 3.1
  */
 
-public class AnchorNotificationTest extends TestCase {
+public class AnchorNotificationTest extends Assert {
 
 	int count;
 
@@ -81,6 +82,7 @@ public class AnchorNotificationTest extends TestCase {
 	/**
 	 * @since 3.1
 	 */
+	@Before
 	protected void setUp() {
 		Figure contents = new Figure();
 		contents.addNotify();
@@ -98,24 +100,28 @@ public class AnchorNotificationTest extends TestCase {
 		conn.setTargetAnchor(new ChopboxAnchor(end));
 	}
 
+	@Test
 	public void testMoveSource() {
 		count = 0;
 		start.translate(10, 10);
 		assertTrue(count == 1);
 	}
 
+	@Test
 	public void testMoveTarget() {
 		count = 0;
 		end.translate(1, 1);
 		assertTrue(count == 1);
 	}
 
+	@Test
 	public void testMoveTargetParent() {
 		count = 0;
 		nestedCoordinates.translate(10, 10);
 		assertTrue("Count != 1 :" + count, count == 1);
 	}
 
+	@Test
 	public void testRetargetTargetAnchor() {
 		count = 0;
 		ConnectionAnchor old = conn.getTargetAnchor();
@@ -126,6 +132,7 @@ public class AnchorNotificationTest extends TestCase {
 		conn.setTargetAnchor(old);
 	}
 
+	@Test
 	public void testRemoveConnection() {
 		count = 0;
 		conn.getParent().remove(conn);
@@ -136,6 +143,7 @@ public class AnchorNotificationTest extends TestCase {
 		assertTrue(count == 1);
 	}
 
+	@Test
 	public void testMoveEverything() {
 		count = 0;
 		commonAncestor.translate(5, 5);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
@@ -14,8 +14,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Interval;
@@ -25,20 +23,14 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
 
+import org.junit.Assert;
+
 /**
  * @author Pratik Shah
  */
-public abstract class BaseTestCase extends TestCase {
+public abstract class BaseTestCase extends Assert {
 
 	protected static final Font TAHOMA = new Font(null, "Tahoma", 8, 0);//$NON-NLS-1$
-
-	public BaseTestCase() {
-		super();
-	}
-
-	public BaseTestCase(String text) {
-		super(text);
-	}
 
 	protected boolean callBooleanMethod(Object receiver, String method) {
 		try {

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
@@ -9,26 +9,16 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.swt.widgets.Display;
 
-public class ColorConstantTest extends TestCase {
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
+@Ignore
+public class ColorConstantTest extends Assert {
 
+	@Test
 	public void test_ColorConstantInit() {
 		final Boolean result[] = new Boolean[2];
 		result[0] = Boolean.FALSE;

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ConnectionEndPointMoveTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ConnectionEndPointMoveTest.java
@@ -27,6 +27,10 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 public class ConnectionEndPointMoveTest extends BaseTestCase implements UpdateListener {
 
 	private IFigure contents;
@@ -36,13 +40,8 @@ public class ConnectionEndPointMoveTest extends BaseTestCase implements UpdateLi
 	private Rectangle lastDamaged;
 	private Rectangle origBounds;
 
-	/*
-	 * @see TestCase#setUp()
-	 */
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell(Display.getDefault());
 
 		String appName = getClass().getName();
@@ -102,6 +101,7 @@ public class ConnectionEndPointMoveTest extends BaseTestCase implements UpdateLi
 		// nothing
 	}
 
+	@Test
 	public void testConnectionDecoration() {
 		conn.setConstraint(dec, new MidpointLocator(conn, 0));
 		conn.layout();
@@ -110,13 +110,8 @@ public class ConnectionEndPointMoveTest extends BaseTestCase implements UpdateLi
 		assertTrue(lastDamaged.contains(origBounds));
 	}
 
-	/*
-	 * @see TestCase#tearDown()
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-
+	@After
+	public void tearDown() throws Exception {
 		shell.dispose();
 	}
 

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/DimensionTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/DimensionTests.java
@@ -14,8 +14,11 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.swt.graphics.Image;
 
+import org.junit.Test;
+
 public class DimensionTests extends BaseTestCase {
 
+	@Test
 	public void testGetExpanded() throws Exception {
 		Dimension d = new Dimension(3, 5);
 		assertEquals(new Dimension(6, 7), d.getExpanded(3, 2));
@@ -40,12 +43,14 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(17, 18, template1);
 	}
 
+	@Test
 	public void testGetShrinked() {
 		Dimension d = new Dimension(6, 7);
 		assertEquals(new Dimension(3, 5), d.getShrinked(3, 2));
 		assertEquals(new Dimension(3, 5), d.getShrinked(3.4, 2.7));
 	}
 
+	@Test
 	public void testConstructors() throws Exception {
 		Image image = new Image(null, getClass().getResourceAsStream("icons/recorder.gif"));
 
@@ -62,6 +67,7 @@ public class DimensionTests extends BaseTestCase {
 		image.dispose();
 	}
 
+	@Test
 	public void testEqualsObject() throws Exception {
 		Dimension testDimension = new Dimension(-7, 8);
 		assertFalse(testDimension.equals(null));
@@ -71,11 +77,13 @@ public class DimensionTests extends BaseTestCase {
 		assertFalse(testDimension.equals(new Dimension()));
 	}
 
+	@Test
 	public void testToString() throws Exception {
 		assertNotNull(new Dimension().toString());
 		assertNotNull(new Dimension(1, 2).toString());
 	}
 
+	@Test
 	public void testContains() throws Exception {
 		Dimension template = new Dimension(-7, 8);
 		assertTrue(template.contains(template));
@@ -86,28 +94,33 @@ public class DimensionTests extends BaseTestCase {
 		assertFalse(template.contains(new Dimension(10, 10)));
 	}
 
+	@Test
 	public void testContainsProper() throws Exception {
 		Dimension template = new Dimension(-7, 8);
 		assertFalse(template.containsProper(template));
 		assertTrue(template.containsProper(new Dimension(-8, -8)));
 	}
 
+	@Test
 	public void testGetArea() throws Exception {
 		assertEquals(6, new Dimension(2, 3).getArea());
 	}
 
+	@Test
 	public void testEqualsIntInt() throws Exception {
 		assertTrue(new Dimension().equals(0, 0));
 		assertTrue(new Dimension(1, -2).equals(1, -2));
 		assertFalse(new Dimension(1, -2).equals(7, -7));
 	}
 
+	@Test
 	public void testIsEmpty() throws Exception {
 		assertTrue(new Dimension().isEmpty());
 		assertTrue(new Dimension(1, -2).isEmpty());
 		assertFalse(new Dimension(3, 3).isEmpty());
 	}
 
+	@Test
 	public void testSetSize() throws Exception {
 		Dimension template = new Dimension(-7, 8);
 		Dimension testDimension = new Dimension();
@@ -115,6 +128,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(template, testDimension);
 	}
 
+	@Test
 	public void testExpand() throws Exception {
 		// check work expand(Dimension)
 		Dimension template = new Dimension(-1, 1);
@@ -134,6 +148,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(3, 10, testDimension);
 	}
 
+	@Test
 	public void testIntersect() throws Exception {
 		Dimension template = new Dimension(-7, 8);
 		Dimension testDimension = new Dimension(0, 5);
@@ -142,6 +157,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(-7, 8, template);
 	}
 
+	@Test
 	public void testNegate() throws Exception {
 		Dimension testDimension = new Dimension(1, 2);
 		assertSame(testDimension, testDimension.negate());
@@ -150,6 +166,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(1, 2, testDimension);
 	}
 
+	@Test
 	public void testScale() throws Exception {
 		// check work scale(double)
 		Dimension testDimension = new Dimension(10, 20);
@@ -161,6 +178,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(100, 100, testDimension);
 	}
 
+	@Test
 	public void testShrink() throws Exception {
 		Dimension testDimension = new Dimension(3, 5);
 		assertSame(testDimension, testDimension.shrink(1, 2));
@@ -169,12 +187,14 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(3, 3, testDimension);
 	}
 
+	@Test
 	public void testTranspose() throws Exception {
 		Dimension testDimension = new Dimension(3, 5);
 		assertSame(testDimension, testDimension.transpose());
 		assertEquals(5, 3, testDimension);
 	}
 
+	@Test
 	public void testUnion() throws Exception {
 		// check work union(Dimension)
 		Dimension template = new Dimension(-7, 8);
@@ -188,6 +208,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(5, 8, testDimension);
 	}
 
+	@Test
 	public void testGetCopy() throws Exception {
 		Dimension template = new Dimension(-7, 8);
 		Dimension testDimension = template.getCopy();
@@ -196,6 +217,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(template, testDimension);
 	}
 
+	@Test
 	public void testGetDifference() throws Exception {
 		Dimension template1 = new Dimension(17, 18);
 		Dimension template2 = new Dimension(11, 10);
@@ -208,6 +230,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(11, 10, template2);
 	}
 
+	@Test
 	public void testGetIntersected() throws Exception {
 		Dimension template1 = new Dimension(-7, 8);
 		Dimension template2 = new Dimension(0, 5);
@@ -220,6 +243,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(0, 5, template2);
 	}
 
+	@Test
 	public void testGetNegated() throws Exception {
 		Dimension template = new Dimension(-7, 8);
 		Dimension testDimension = template.getNegated();
@@ -229,6 +253,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(-7, 8, template);
 	}
 
+	@Test
 	public void testGetScaled() throws Exception {
 		Dimension template = new Dimension(10, 20);
 		Dimension testDimension = template.getScaled(0.5);
@@ -238,6 +263,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(10, 20, template);
 	}
 
+	@Test
 	public void testGetTransposed() throws Exception {
 		Dimension template = new Dimension(3, 5);
 		Dimension testDimension = template.getTransposed();
@@ -247,6 +273,7 @@ public class DimensionTests extends BaseTestCase {
 		assertEquals(3, 5, template);
 	}
 
+	@Test
 	public void testGetUnioned() throws Exception {
 		// check work getUnioned(Dimension)
 		Dimension template1 = new Dimension(-7, 8);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -11,57 +11,48 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * The main test suite for Draw2d.
  * 
  * @author Eric Bordeau
  */
-public class Draw2dTestSuite extends TestSuite {
-
-	public static Test suite() {
-		return new Draw2dTestSuite();
-	}
-
-	/**
-	 * Constructs a new Draw2dTestSuite. Add any JUnit tests to the suite here.
-	 */
-	public Draw2dTestSuite() {
-		addTest(new TestSuite(ShortestPathRoutingTest.class));
-		addTest(new TestSuite(XYLayoutTest.class));
-		// FIXME The text flow wrap test are currently unstable and therefore
-		// deactivated
-		// addTest(new TestSuite(TextFlowWrapTest.class));
-		addTest(new TestSuite(LocalOptimizerTest.class));
-		addTest(new TestSuite(AdvancedGraphicsTests.class));
-		addTest(new TestSuite(FlowBorderTests.class));
-		addTest(new TestSuite(GraphicsClipping.class));
-		addTest(new TestSuite(PaintDamageEraseTest.class));
-		addTest(new TestSuite(LayeredPaneTest.class));
-		addTest(new TestSuite(ConnectionEndPointMoveTest.class));
-		addTest(new TestSuite(ImageUtilitiesTest.class));
-		addTest(new TestSuite(LookAheadTest.class));
-		addTest(new TestSuite(TextualTests.class));
-		addTest(new TestSuite(PointTests.class));
-		addTest(new TestSuite(DimensionTests.class));
-		addTest(new TestSuite(PointListTests.class));
-		addTest(new TestSuite(PrecisionDimensionTest.class));
-		addTest(new TestSuite(PrecisionPointTest.class));
-		addTest(new TestSuite(PrecisionRectangleTest.class));
-		addTest(new TestSuite(ThumbnailTest.class));
-		addTest(new TestSuite(FigureUtilitiesTest.class));
-		addTest(new TestSuite(RectangleTest.class));
-		// addTest(new TestSuite(ColorConstantTest.class));
-		addTest(new TestSuite(RayTest.class));
-		addTest(new TestSuite(VectorTest.class));
-		addTest(new TestSuite(StraightTest.class));
-		addTest(new TestSuite(RelativeBendpointTest.class));
-		addTest(new TestSuite(GeometryTest.class));
-		addTest(new TestSuite(ScalablePolygonShapeTest.class));
-		addTest(new TestSuite(LayerTest.class));
-		addTest(new TestSuite(ShapeTest.class));
-		addTest(new TestSuite(InsetsTest.class));
-	}
+@RunWith(Suite.class) 
+@Suite.SuiteClasses({
+	ShortestPathRoutingTest.class,
+	XYLayoutTest.class,
+	TextFlowWrapTest.class,
+	LocalOptimizerTest.class,
+	AdvancedGraphicsTests.class,
+	FlowBorderTests.class,
+	GraphicsClipping.class,
+	PaintDamageEraseTest.class,
+	LayeredPaneTest.class,
+	ConnectionEndPointMoveTest.class,
+	ImageUtilitiesTest.class,
+	LookAheadTest.class,
+	TextualTests.class,
+	PointTests.class,
+	DimensionTests.class,
+	PointListTests.class,
+	PrecisionDimensionTest.class,
+	PrecisionPointTest.class,
+	PrecisionRectangleTest.class,
+	ThumbnailTest.class,
+	FigureUtilitiesTest.class,
+	RectangleTest.class,
+	ColorConstantTest.class,
+	RayTest.class,
+	VectorTest.class,
+	StraightTest.class,
+	RelativeBendpointTest.class,
+	GeometryTest.class,
+	ScalablePolygonShapeTest.class,
+	LayerTest.class,
+	ShapeTest.class,
+	InsetsTest.class
+})
+public class Draw2dTestSuite {
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FigureUtilitiesTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FigureUtilitiesTest.java
@@ -10,29 +10,16 @@
  *******************************************************************************/
 
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.IFigure;
 
-public class FigureUtilitiesTest extends TestCase {
+import org.junit.Assert;
+import org.junit.Test;
 
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
+public class FigureUtilitiesTest extends Assert {
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
+	@Test
 	public void test_findCommonAncestor_happypath() {
 		IFigure figureParent = new Figure();
 		IFigure figureChild1 = new Figure();
@@ -47,6 +34,7 @@ public class FigureUtilitiesTest extends TestCase {
 		assertTrue(figureParent == result);
 	}
 
+	@Test
 	public void test_findCommonAncestor_bugzilla130042() {
 		IFigure figureParent = new Figure();
 		IFigure figureChild = new Figure();
@@ -56,6 +44,7 @@ public class FigureUtilitiesTest extends TestCase {
 		assertTrue(figureParent == result);
 	}
 
+	@Test
 	public void test_findCommonAncestor_check_finds_nearest_ancestor() {
 		IFigure figureGrandParent = new Figure();
 		IFigure figureParent = new Figure();
@@ -69,6 +58,7 @@ public class FigureUtilitiesTest extends TestCase {
 		assertTrue(figureParent == result);
 	}
 
+	@Test
 	public void test_findCommonAncestor_parent_is_common_ancestor() {
 		IFigure figureParent = new Figure();
 		IFigure figureChild1 = new Figure();
@@ -80,6 +70,7 @@ public class FigureUtilitiesTest extends TestCase {
 		assertTrue(figureParent == result);
 	}
 
+	@Test
 	public void test_findCommonAncestor_orphaned_child() {
 		IFigure orphanFigure = new Figure();
 		IFigure figureParent = new Figure();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FlowBorderTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FlowBorderTests.java
@@ -17,11 +17,14 @@ import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.draw2d.text.TextFragmentBox;
 import org.eclipse.swt.graphics.FontMetrics;
 
+import org.junit.Test;
+
 /**
  * @since 3.1
  */
 public class FlowBorderTests extends SimpleTextTest {
 
+	@Test
 	public void testBorderedTextFlow() {
 		sentence.setBorder(new TestBorder(new Insets(5)));
 		makePageWidth("The quick", 5);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/GeometryTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/GeometryTest.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.geometry.Geometry;
 import org.eclipse.draw2d.geometry.PointList;
@@ -21,7 +19,10 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Display;
 
-public class GeometryTest extends TestCase {
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GeometryTest extends Assert {
 
 	/*
 	 * For Geometry.polygonContainsPoint tests
@@ -55,6 +56,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points inside/outside the rhomb located in top half. Excluding points
 	 * of RHOMB border - separate test present for it
 	 */
+	@Test
 	public void testTopRhombHalfPoints() {
 		assertFalse("This point is outside the rhomb", Geometry.polygonContainsPoint(RHOMB, 0, 1));
 		assertTrue("This point is inside the rhomb", Geometry.polygonContainsPoint(RHOMB, 2, 1));
@@ -65,6 +67,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points inside/outside the rhomb located in bottop half. Excluding
 	 * points of RHOMB border - separate test present for it
 	 */
+	@Test
 	public void testBottomRhombHalfPoints() {
 		assertFalse("This point is outside the rhomb", Geometry.polygonContainsPoint(RHOMB, 0, 3));
 		assertTrue("This point is inside the rhomb", Geometry.polygonContainsPoint(RHOMB, 2, 3));
@@ -75,6 +78,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points inside/outside the rhomb located on the equator. Excluding
 	 * points of RHOMB border - separate test present for it
 	 */
+	@Test
 	public void testRhombEquatorPoints() {
 		assertFalse("This point is outside the rhomb", Geometry.polygonContainsPoint(RHOMB, -1, 2));
 		assertTrue("This point is inside the rhomb", Geometry.polygonContainsPoint(RHOMB, 2, 2));
@@ -85,6 +89,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points outside the rhomb located on top horizontal tangent line.
 	 * Excluding points of RHOMB border - separate test present for it
 	 */
+	@Test
 	public void testTopRhombTangentPoints() {
 		assertFalse("This point is outside the rhomb", Geometry.polygonContainsPoint(RHOMB, 0, 0));
 		assertFalse("This point is outside the rhomb", Geometry.polygonContainsPoint(RHOMB, 4, 0));
@@ -94,6 +99,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points outside the rhomb located on bottom horizontal tangent line.
 	 * Excluding points of RHOMB border - separate test present for it
 	 */
+	@Test
 	public void testBottomRhombTangentPoints() {
 		assertFalse("This point is outside the rhomb", Geometry.polygonContainsPoint(RHOMB, 0, 4));
 		assertFalse("This point is outside the rhomb", Geometry.polygonContainsPoint(RHOMB, 4, 4));
@@ -102,6 +108,7 @@ public class GeometryTest extends TestCase {
 	/**
 	 * Testing points of RHOMB border - all vertexes + one point on the edge
 	 */
+	@Test
 	public void testRhombBorderPoints() {
 		assertTrue("This point is inside the rhomb", Geometry.polygonContainsPoint(RHOMB, 0, 2));
 		assertTrue("This point is inside the rhomb", Geometry.polygonContainsPoint(RHOMB, 0, 2));
@@ -114,6 +121,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points inside/outside the pentagon located on equator of concave.
 	 * Excluding points of CONCAVE_PENTAGON border - separate test present for it
 	 */
+	@Test
 	public void testConcavePentagonEquatorPoints() {
 		assertFalse("This point is outside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, -1, 6));
 		assertTrue("This point is inside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, 1, 6));
@@ -126,6 +134,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points outside the pentagon located on top concave tangent. Excluding
 	 * points of CONCAVE_PENTAGON border - separate test present for it
 	 */
+	@Test
 	public void testTopConcavePentagonTangentPoints() {
 		assertFalse("This point is outside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, -1, 8));
 		assertFalse("This point is outside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, 4, 8));
@@ -136,6 +145,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points inside/outside the pentagon located on bottom concave tangent.
 	 * Excluding points of CONCAVE_PENTAGON border - separate test present for it
 	 */
+	@Test
 	public void testBottomConcavePentagonTangentPoints() {
 		assertFalse("This point is outside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, -1, 4));
 		assertTrue("This point is inside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, 1, 4));
@@ -147,6 +157,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points of CONCAVE_PENTAGON border - all vertexes + points on concave
 	 * edges
 	 */
+	@Test
 	public void testConcavePentagonBorderPoints() {
 		assertTrue("This point is inside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, 0, 8));
 		assertTrue("This point is inside the pentagon", Geometry.polygonContainsPoint(CONCAVE_PENTAGON, 2, 6));
@@ -159,6 +170,7 @@ public class GeometryTest extends TestCase {
 	 * Testing points located of the horizontal line containing one of the "concave"
 	 * edges
 	 */
+	@Test
 	public void testConcaveOctagonBottomTangentPoints() {
 		assertFalse("This point is outside the octagon", Geometry.polygonContainsPoint(CONCAVE_OCTAGON, -1, 2));
 		assertTrue("This point is inside the octagon", Geometry.polygonContainsPoint(CONCAVE_OCTAGON, 0, 2));
@@ -170,6 +182,7 @@ public class GeometryTest extends TestCase {
 		assertFalse("This point is outside the octagon", Geometry.polygonContainsPoint(CONCAVE_OCTAGON, 7, 2));
 	}
 
+	@Test
 	public void testNotPolylinePoints() {
 		// Point is outside of (polyline.bounds +- tolerance) rectangle
 		assertFalse(Geometry.polylineContainsPoint(POLYLINE, 9, 5, TOLERANCE));
@@ -178,6 +191,7 @@ public class GeometryTest extends TestCase {
 		assertFalse(Geometry.polylineContainsPoint(POLYLINE, 1, 4, TOLERANCE));
 	}
 
+	@Test
 	public void testPolylinePoints() {
 		// point is close to horizontal segment
 		assertTrue(Geometry.polylineContainsPoint(POLYLINE, -1, 0, TOLERANCE));
@@ -193,6 +207,7 @@ public class GeometryTest extends TestCase {
 	 * Testing
 	 * {@link Geometry#linesIntersect(int, int, int, int, int, int, int, int)}.
 	 */
+	@Test
 	public void testLinesIntersect() {
 		// line segments collapsed to single points
 		assertTrue("Starting point on segment", Geometry.linesIntersect(0, 0, 0, 0, 0, 0, 3, 3));

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/GraphicsClipping.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/GraphicsClipping.java
@@ -11,20 +11,24 @@
 
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 
-public class GraphicsClipping extends TestCase {
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GraphicsClipping extends Assert {
 
 	private Image image;
 	private GC gc;
 	private SWTGraphics graphics;
 
+	@Test
 	public void testSimpleClip() {
 		Rectangle rect = new Rectangle(14, 21, 30, 40);
 		graphics.setClip(rect);
@@ -46,6 +50,7 @@ public class GraphicsClipping extends TestCase {
 		return graphics.getClip(new Rectangle());
 	}
 
+	@Test
 	public void testTranslatedClip() {
 		Rectangle rect = new Rectangle(14, 21, 300, 400);
 		graphics.setClip(rect);
@@ -68,6 +73,7 @@ public class GraphicsClipping extends TestCase {
 		assertEquals(gcClipping(), rect);
 	}
 
+	@Test
 	public void testZoomedClip() {
 		Rectangle rect = new Rectangle(14, 21, 300, 400);
 		graphics.setClip(rect);
@@ -80,13 +86,15 @@ public class GraphicsClipping extends TestCase {
 		assertEquals(graphicsClip(), rect);
 	}
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		image = new Image(Display.getDefault(), 800, 600);
 		gc = new GC(image);
 		graphics = new SWTGraphics(gc);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		graphics.dispose();
 		gc.dispose();
 		image.dispose();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ImageUtilitiesTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ImageUtilitiesTest.java
@@ -10,25 +10,19 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.ImageUtilities;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 /**
  * @author Pratik Shah
  */
-public class ImageUtilitiesTest extends TestCase {
+public class ImageUtilitiesTest extends Assert {
 
-	public ImageUtilitiesTest() {
-		super();
-	}
-
-	public ImageUtilitiesTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testImageRotation() {
 		Image result1 = null, result2 = null, result3 = null;
 		Image img1 = new Image(null, 80, 80);
@@ -54,6 +48,7 @@ public class ImageUtilitiesTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRotatingImagesWithDifferentDepths() {
 		Image result1 = null, result2 = null, result3 = null, result4 = null;
 		Image img1 = ImageDescriptor.createFromFile(getClass(), "icons/bits1.bmp").createImage(); //$NON-NLS-1$

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/InsetsTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/InsetsTest.java
@@ -12,12 +12,15 @@ package org.eclipse.draw2d.test;
 
 import org.eclipse.draw2d.geometry.Insets;
 
+import org.junit.Test;
+
 /**
  * @author lobas_av
  *
  */
 public class InsetsTest extends BaseTestCase {
 
+	@Test
 	public void testConstructors() throws Exception {
 		// check create object use constructor()
 		assertEquals(0, 0, 0, 0, new Insets());
@@ -32,6 +35,7 @@ public class InsetsTest extends BaseTestCase {
 		assertEquals(1, 2, 3, 4, new Insets(new Insets(1, 2, 3, 4)));
 	}
 
+	@Test
 	public void testEqualsObject() throws Exception {
 		Insets testInsets = new Insets(1, 2, 3, 4);
 		assertFalse(testInsets.equals(null));
@@ -41,32 +45,38 @@ public class InsetsTest extends BaseTestCase {
 		assertFalse(testInsets.equals(new Insets()));
 	}
 
+	@Test
 	public void testToString() throws Exception {
 		assertNotNull(new Insets().toString());
 		assertNotNull(new Insets(3).toString());
 		assertNotNull(new Insets(1, 2, 3, 4).toString());
 	}
 
+	@Test
 	public void testGetHeight() throws Exception {
 		assertEquals(11, new Insets(1, 1, 10, 5).getHeight());
 	}
 
+	@Test
 	public void testGetWidth() throws Exception {
 		assertEquals(6, new Insets(1, 1, 10, 5).getWidth());
 	}
 
+	@Test
 	public void testIsEmpty() throws Exception {
 		assertTrue(new Insets().isEmpty());
 		assertFalse(new Insets(7).isEmpty());
 		assertFalse(new Insets(1, 0, 0, 0).isEmpty());
 	}
 
+	@Test
 	public void testAddInsets() throws Exception {
 		Insets testInsets = new Insets(1, 2, 3, 4);
 		assertSame(testInsets, testInsets.add(new Insets(4, 3, 2, 1)));
 		assertEquals(5, 5, 5, 5, testInsets);
 	}
 
+	@Test
 	public void testTranspose() throws Exception {
 		int top = 1;
 		int left = 2;
@@ -77,6 +87,7 @@ public class InsetsTest extends BaseTestCase {
 		assertEquals(left, top, right, bottom, testInsets);
 	}
 
+	@Test
 	public void testGetAdded() throws Exception {
 		Insets template = new Insets(1, 2, 3, 4);
 		Insets testInsets = template.getAdded(new Insets(4, 3, 2, 1));
@@ -84,6 +95,7 @@ public class InsetsTest extends BaseTestCase {
 		assertEquals(5, 5, 5, 5, testInsets);
 	}
 
+	@Test
 	public void testGetTransposed() throws Exception {
 		int top = 1;
 		int left = 2;
@@ -95,6 +107,7 @@ public class InsetsTest extends BaseTestCase {
 		assertEquals(left, top, right, bottom, testInsets);
 	}
 
+	@Test
 	public void testGetNegated() throws Exception {
 		Insets template = new Insets(1, 2, 3, 4);
 		Insets testInsets = template.getNegated();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/IntervalTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/IntervalTest.java
@@ -12,6 +12,8 @@ package org.eclipse.draw2d.test;
 
 import org.eclipse.draw2d.geometry.Interval;
 
+import org.junit.Test;
+
 /**
  * Tests for {@link Interval} class.
  *
@@ -20,20 +22,24 @@ import org.eclipse.draw2d.geometry.Interval;
  */
 public class IntervalTest extends BaseTestCase {
 
+	@Test
 	public void testConstructor() throws Exception {
 		assertEquals(0, 0, new Interval());
 	}
 
+	@Test
 	public void testConstructorIntInt() throws Exception {
 		assertEquals(-1, 2, new Interval(-1, 2));
 	}
 
+	@Test
 	public void testConstructorInterval() throws Exception {
 		Interval template = new Interval(-1, 2);
 		assertEquals(-1, 2, new Interval(template));
 		assertEquals(-1, 2, template); // assert read only argument interval
 	}
 
+	@Test
 	public void testGetCopy() throws Exception {
 		Interval template = new Interval(-1, 2);
 		Interval testInterval = template.getCopy();
@@ -42,12 +48,14 @@ public class IntervalTest extends BaseTestCase {
 		assertEquals(template, testInterval);
 	}
 
+	@Test
 	public void testEnd() throws Exception {
 		Interval interval = new Interval(1, 2);
 		assertEquals(3, interval.end());
 		assertEquals(1, 2, interval);
 	}
 
+	@Test
 	public void testIsEmpty() throws Exception {
 		{
 			Interval interval = new Interval();
@@ -59,6 +67,7 @@ public class IntervalTest extends BaseTestCase {
 		}
 	}
 
+	@Test
 	public void testCenter() throws Exception {
 		{
 			Interval interval = new Interval(1, 2);
@@ -78,6 +87,7 @@ public class IntervalTest extends BaseTestCase {
 		}
 	}
 
+	@Test
 	public void testDistance() throws Exception {
 		Interval interval = new Interval(10, 100);
 		assertEquals(7, interval.distance(3));
@@ -87,6 +97,7 @@ public class IntervalTest extends BaseTestCase {
 		assertEquals(40, interval.distance(150));
 	}
 
+	@Test
 	public void testContains() throws Exception {
 		Interval interval = new Interval(1, 2);
 		assertFalse(interval.contains(0));
@@ -96,6 +107,7 @@ public class IntervalTest extends BaseTestCase {
 		assertFalse(interval.contains(4));
 	}
 
+	@Test
 	public void testIntersects() throws Exception {
 		{
 			// not intersects
@@ -120,6 +132,7 @@ public class IntervalTest extends BaseTestCase {
 		}
 	}
 
+	@Test
 	public void testIsLeadingOf() throws Exception {
 		Interval interval1 = new Interval(10, 20);
 		Interval interval2 = new Interval(15, 20);
@@ -127,6 +140,7 @@ public class IntervalTest extends BaseTestCase {
 		assertFalse(interval2.isLeadingOf(interval1));
 	}
 
+	@Test
 	public void testIsTrailingOf() throws Exception {
 		Interval interval1 = new Interval(10, 20);
 		Interval interval2 = new Interval(15, 20);
@@ -134,6 +148,7 @@ public class IntervalTest extends BaseTestCase {
 		assertTrue(interval2.isTrailingOf(interval1));
 	}
 
+	@Test
 	public void testGetIntersection() throws Exception {
 		// intervals intersect
 		{
@@ -157,6 +172,7 @@ public class IntervalTest extends BaseTestCase {
 		}
 	}
 
+	@Test
 	public void testGrowLeading() throws Exception {
 		// to right
 		Interval interval = new Interval(1, 2);
@@ -166,6 +182,7 @@ public class IntervalTest extends BaseTestCase {
 		assertEquals(0, 3, interval.growLeading(-1));
 	}
 
+	@Test
 	public void testGrowTrailing() throws Exception {
 		// to right
 		{
@@ -179,6 +196,7 @@ public class IntervalTest extends BaseTestCase {
 		}
 	}
 
+	@Test
 	public void testGetRightMostIntervalIndex() throws Exception {
 		Interval[] intervals = { new Interval(1, 5), new Interval(8, 1) };
 		assertEquals(-1, Interval.getRightMostIntervalIndex(intervals, 3));

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LayerTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LayerTest.java
@@ -10,14 +10,16 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Layer;
 import org.eclipse.draw2d.geometry.Rectangle;
 
-public class LayerTest extends TestCase {
+import org.junit.Assert;
+import org.junit.Test;
 
+public class LayerTest extends Assert {
+
+	@Test
 	public void testContainsPointInLayer() {
 		MyLayer layer = new MyLayer();
 		layer.setBounds(new Rectangle(0, 0, 1000, 1000));

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LayeredPaneTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LayeredPaneTest.java
@@ -9,28 +9,29 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.LayeredPane;
 
-public class LayeredPaneTest extends TestCase {
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LayeredPaneTest extends Assert {
 
 	private LayeredPane pane;
 	private IFigure fig1;
 	private IFigure fig2;
 	private IFigure fig3;
 
-	/*
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
+
 		pane = new LayeredPane();
 	}
 
+	@Test
 	public void testIndexOutOfBounds() {
 		fig1 = new Figure();
 		fig2 = new Figure();
@@ -51,11 +52,8 @@ public class LayeredPaneTest extends TestCase {
 		assertEquals(false, failed);
 	}
 
-	/*
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		pane = null;
 	}
 

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LocalOptimizerTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LocalOptimizerTest.java
@@ -20,23 +20,21 @@ import org.eclipse.draw2d.graph.Edge;
 import org.eclipse.draw2d.graph.Node;
 import org.eclipse.draw2d.graph.Rank;
 
-import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests the swapping of adjacent nodes in a directed graph. since 3.0
  * 
  */
-public class LocalOptimizerTest extends TestCase {
+public class LocalOptimizerTest extends Assert {
 
 	private DirectedGraph graph;
 	private Node a, b, c, d, e, f, g, h, i, j, k, l;
 
-	/*
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		graph = new DirectedGraph();
 
 		// create nodes and populate their ranks
@@ -61,13 +59,7 @@ public class LocalOptimizerTest extends TestCase {
 				.visit(graph);
 	}
 
-	/*
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
+	@Test
 	public void testIncomingSwapNeeded() {
 		/*
 		 * A B C D |\| \ | | X \| | |\ | E F G H
@@ -84,6 +76,7 @@ public class LocalOptimizerTest extends TestCase {
 		checkResults(new Node[][] { new Node[] { a, b, c, d }, new Node[] { e, g, f, h } });
 	}
 
+	@Test
 	public void testOutgoingSwapNeeded() {
 		/*
 		 * A BC D \ | X \|/ \ E F G H
@@ -99,6 +92,7 @@ public class LocalOptimizerTest extends TestCase {
 		checkResults(new Node[][] { new Node[] { a, b, d, c }, new Node[] { e, f, g, h } });
 	}
 
+	@Test
 	public void testIncomingOffsetSwapNeeded() {
 		/*
 		 * A B C (C should swap twice to first position) \ \ / \ X X \ / \ \
@@ -118,6 +112,7 @@ public class LocalOptimizerTest extends TestCase {
 		checkResults(new Node[][] { new Node[] { c, a, b, d }, new Node[] { e, f, g, h }, new Node[] { i, j, k, l } });
 	}
 
+	@Test
 	public void testBidirectionalSwapNeeded() {
 		/*
 		 * A B C D \ |\ \| \ E F G H (F and G should swap) X| / X | |\ I J K L

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LookAheadTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LookAheadTest.java
@@ -19,6 +19,9 @@ import org.eclipse.draw2d.text.InlineFlow;
 import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.swt.graphics.Font;
 
+import org.junit.Before;
+import org.junit.Test;
+
 /**
  * @author Pratik Shah
  * @author Randy Hudson
@@ -54,8 +57,8 @@ public class LookAheadTest extends BaseTestCase {
 		return FigureUtilities.getStringExtents(s, TIMES_ROMAN).width;
 	}
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		simpleText = new TextFlow();
 		simpleText.setFont(TIMES_ROMAN);
 		width = new int[1];
@@ -82,11 +85,13 @@ public class LookAheadTest extends BaseTestCase {
 		paragraph2.add(new TextFlow("lo")); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testContainerLeadingWord() {
 		p1inline.addLeadingWordRequirements(width);
 		assertLookaheadMatchesString(width, "brown"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBlockLeadingWord() {
 		paragraph1.addLeadingWordRequirements(width);
 		assertEquals("Blocks should have no leading word", 0, width[0]); //$NON-NLS-1$
@@ -101,38 +106,46 @@ public class LookAheadTest extends BaseTestCase {
 		return width[0];
 	}
 
+	@Test
 	public void testContextLookaheadPrecedingInline() {
 		assertEquals("Context lookahead into inline flow failed", getFollow(p1text1), getWidth("brown")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testContextLookaheadFromNested() {
 		assertEquals("Context lookahead from nested inline textflow failed", getFollow(p1text2), getWidth("jumped")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testContextLookaheadAtEndOfBlock() {
 		assertTrue("Last figure in a block should have no lookahead", getFollow(p1text3) == 0); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testContextLookaheadPastEmptyString() {
 		assertEquals("Context lookahead over empty TextFlow failed", getFollow(p2text1), getWidth("lo")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testContextChineseCharLookahead() {
 		p1text2.setText("\u7325abcdef"); //$NON-NLS-1$
 		assertTrue("Chinese characters should have no lookahead", getFollow(p1text1) == 0); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testContextHyphenLookahead() {
 		p1text2.setText("-abc"); //$NON-NLS-1$
 		assertEquals("Context lookahead should be hyphen character", getFollow(p1text1), getWidth("-")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testSingleLetter() {
 		simpleText.setText("a"); //$NON-NLS-1$
 		assertLineBreakNotFound(simpleText.addLeadingWordRequirements(width));
 		assertLookaheadMatchesString(width, "a"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSingleSpace() {
 		simpleText.setText(" "); //$NON-NLS-1$
 		assertTrue("Line break should have been found", simpleText.addLeadingWordRequirements(width)); //$NON-NLS-1$

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PaintDamageEraseTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PaintDamageEraseTest.java
@@ -24,7 +24,9 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
-import junit.framework.AssertionFailedError;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener {
 
@@ -41,6 +43,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a mixed move (x pos,y neg) with relative bounds.
 	 * 
 	 */
+	@Test
 	public void testRelativeBoundsMixedMove2() {
 		doIndividualSetup(true);
 
@@ -51,6 +54,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a mixed move (x pos,y neg) with absolute bounds.
 	 * 
 	 */
+	@Test
 	public void testAbsoluteBoundsMixedMove2() {
 		doIndividualSetup(false);
 
@@ -61,6 +65,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a mixed move (x neg,x pos) with relative bounds.
 	 * 
 	 */
+	@Test
 	public void testRelativeBoundsMixedMove() {
 		doIndividualSetup(true);
 
@@ -71,6 +76,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a mixed move (x neg, y pos) with absolute bounds.
 	 * 
 	 */
+	@Test
 	public void testAbsoluteBoundsMixedMove() {
 		doIndividualSetup(false);
 
@@ -81,6 +87,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a positive move with relative bounds.
 	 * 
 	 */
+	@Test
 	public void testRelativeBoundsPositiveMove() {
 		doIndividualSetup(true);
 
@@ -91,6 +98,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a negative move with relative bounds.
 	 * 
 	 */
+	@Test
 	public void testRelativeBoundsNegativeMove() {
 		doIndividualSetup(true);
 
@@ -101,6 +109,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a positive move with absolute bounds.
 	 * 
 	 */
+	@Test
 	public void testAbsoluteBoundsPositiveMove() {
 		doIndividualSetup(false);
 
@@ -111,6 +120,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	 * Tests a negative move with absolute bounds.
 	 * 
 	 */
+	@Test
 	public void testAbsoluteBoundsNegativeMove() {
 		doIndividualSetup(false);
 
@@ -192,13 +202,8 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 		container = null;
 	}
 
-	/*
-	 * @see TestCase#setUp()
-	 */
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		errMsg = ""; //$NON-NLS-1$
 		d = Display.getDefault();
 		shell = new Shell(d);
@@ -216,29 +221,15 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 		shell.open();
 	}
 
-	/*
-	 * @see TestCase#tearDown()
-	 */
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-
+	@After
+	public void tearDown() throws Exception {
 		doIndividualTearDown();
 
 		shell.dispose();
 
 		if (!errMsg.isEmpty()) {
-			throw new AssertionFailedError(errMsg);
+			throw new AssertionError(errMsg);
 		}
-	}
-
-	/**
-	 * Constructor for PaintDamageEraseTest.
-	 * 
-	 * @param name
-	 */
-	public PaintDamageEraseTest(String name) {
-		super(name);
 	}
 
 	@Override

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointListTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointListTests.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
-import static org.junit.Assert.assertThrows;
-
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
@@ -19,8 +17,11 @@ import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.PrecisionPoint;
 import org.eclipse.draw2d.geometry.Rectangle;
 
+import org.junit.Test;
+
 public class PointListTests extends BaseTestCase {
 
+	@Test
 	public void testIntersects() {
 		PointList points = new PointList();
 		points.addPoint(0, 0);
@@ -61,6 +62,7 @@ public class PointListTests extends BaseTestCase {
 		assertFalse(points.intersects(new Rectangle(0, 0, 1, 1)));
 	}
 
+	@Test
 	public void testAddPointGetPointInt() throws Exception {
 		PointList list = new PointList();
 		list.addPoint(10, 20);
@@ -83,6 +85,7 @@ public class PointListTests extends BaseTestCase {
 		assertThrows(IndexOutOfBoundsException.class, () -> list.getPoint(3));
 	}
 
+	@Test
 	public void testInsertPoint() throws Exception {
 		PointList list = new PointList();
 		//
@@ -105,6 +108,7 @@ public class PointListTests extends BaseTestCase {
 		assertThrows(NullPointerException.class, () -> list.insertPoint(null, 0));
 	}
 
+	@Test
 	public void testRemovePoint() throws Exception {
 		PointList list = new PointList();
 		//
@@ -135,6 +139,7 @@ public class PointListTests extends BaseTestCase {
 		assertThrows(IndexOutOfBoundsException.class, () -> list.removePoint(0));
 	}
 
+	@Test
 	public void testRemoveAllPoints() throws Exception {
 		PointList list = new PointList();
 		//
@@ -156,6 +161,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(0, list.size());
 	}
 
+	@Test
 	public void testSizeSetSize() throws Exception {
 		assertEquals(0, new PointList().size());
 		assertEquals(0, new PointList(7).size());
@@ -184,6 +190,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(0, list.size());
 	}
 
+	@Test
 	public void testToIntArray() throws Exception {
 		PointList list = new PointList(5);
 		list.addPoint(10, -20);
@@ -199,6 +206,7 @@ public class PointListTests extends BaseTestCase {
 		}
 	}
 
+	@Test
 	public void testGetCopy() throws Exception {
 		PointList list = new PointList();
 		list.addPoint(10, -20);
@@ -215,6 +223,7 @@ public class PointListTests extends BaseTestCase {
 		}
 	}
 
+	@Test
 	public void testGetFirstPoint() throws Exception {
 		PointList list = new PointList();
 		//
@@ -226,6 +235,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(10, -20, list.getFirstPoint());
 	}
 
+	@Test
 	public void testGetLastPoint() throws Exception {
 		PointList list = new PointList();
 		//
@@ -239,6 +249,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(120, 120, list.getLastPoint());
 	}
 
+	@Test
 	public void testGetMidpoint() throws Exception {
 		PointList list = new PointList();
 		list.addPoint(10, -20);
@@ -254,6 +265,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(30, 30, list.getMidpoint());
 	}
 
+	@Test
 	public void testGetPointPointInt() throws Exception {
 		PointList list = new PointList();
 		list.addPoint(10, -20);
@@ -278,6 +290,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(10, -20, point);
 	}
 
+	@Test
 	public void testSetPointPointInt() throws Exception {
 		PointList list = new PointList();
 		list.addPoint(10, -20);
@@ -307,6 +320,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(point, list.getPoint(0));
 	}
 
+	@Test
 	public void testGetBounds() throws Exception {
 		PointList list = new PointList();
 		//
@@ -323,6 +337,7 @@ public class PointListTests extends BaseTestCase {
 		assertSame(boundsNew, list.getBounds());
 	}
 
+	@Test
 	public void testGetSmallestBounds() throws Exception {
 		PointList list = new PointList();
 		//
@@ -354,6 +369,7 @@ public class PointListTests extends BaseTestCase {
 		assertEquals(0, 0, 21, 21, list.getBounds());
 	}
 
+	@Test
 	public void testTranslate() throws Exception {
 		PointList list = new PointList();
 		for (int i = 0; i < 5; i++) {

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
@@ -3,8 +3,11 @@ package org.eclipse.draw2d.test;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 
+import org.junit.Test;
+
 public class PointTests extends BaseTestCase {
 
+	@Test
 	public void testMin() {
 		assertTrue(Point.min(new Point(1, 3), new Point(2, 6)).equals(new Point(1, 3)));
 		assertTrue(Point.min(new Point(4, 8), new Point(2, 6)).equals(new Point(2, 6)));
@@ -12,6 +15,7 @@ public class PointTests extends BaseTestCase {
 		assertTrue(Point.min(new Point(4, 12), new Point(6, 10)).equals(new Point(4, 10)));
 	}
 
+	@Test
 	public void testMax() {
 		assertTrue(Point.max(new Point(1, 3), new Point(2, 6)).equals(new Point(2, 6)));
 		assertTrue(Point.max(new Point(4, 8), new Point(2, 6)).equals(new Point(4, 8)));
@@ -19,12 +23,14 @@ public class PointTests extends BaseTestCase {
 		assertTrue(Point.max(new Point(4, 12), new Point(6, 10)).equals(new Point(6, 12)));
 	}
 
+	@Test
 	public void testEquals() {
 		assertTrue(new Point(4, 7).equals(4, 7));
 		assertFalse(new Point(3, 6).equals(3, 7));
 		assertFalse(new Point(3, 6).equals(4, 6));
 	}
 
+	@Test
 	public void testDifference() {
 		Point p1 = new Point(4, 7);
 		Point p2 = new Point(2, 4);
@@ -35,6 +41,7 @@ public class PointTests extends BaseTestCase {
 		assertTrue(p2.equals(2, 4));
 	}
 
+	@Test
 	public void testTranslate() {
 		Point p1 = new Point(3, 6);
 		p1.translate(new Dimension(4711, 567));
@@ -44,37 +51,45 @@ public class PointTests extends BaseTestCase {
 		assertTrue(p1.equals(4714, 573));
 	}
 
+	@Test
 	public void testSetX() {
 		assertTrue(new Point(4711, 678).setX(3).equals(3, 678));
 	}
 
+	@Test
 	public void testSetY() {
 		assertTrue(new Point(4711, 678).setY(3).equals(4711, 3));
 	}
 
+	@Test
 	public void testSetLocation() {
 		assertTrue(new Point().setLocation(4711, 678).equals(4711, 678));
 		assertTrue(new Point().setLocation(new Point(4711, 678)).equals(4711, 678));
 	}
 
+	@Test
 	public void testConstructor() throws Exception {
 		assertEquals(0, 0, new Point());
 	}
 
+	@Test
 	public void testConstructorIntInt() throws Exception {
 		assertEquals(-1, 2, new Point(-1, 2));
 	}
 
+	@Test
 	public void testConstructorDoubleDouble() throws Exception {
 		assertEquals((int) Math.PI, (int) -Math.E, new Point(Math.PI, -Math.E));
 	}
 
+	@Test
 	public void testConstructorPoint() throws Exception {
 		Point template = new Point(-1, 2);
 		assertEquals(-1, 2, new Point(template));
 		assertEquals(-1, 2, template); // assert read only argument point
 	}
 
+	@Test
 	public void testConstructorSwtPoint() throws Exception {
 		org.eclipse.swt.graphics.Point template = new org.eclipse.swt.graphics.Point(-1, 2);
 		assertEquals(-1, 2, new Point(template));
@@ -83,12 +98,14 @@ public class PointTests extends BaseTestCase {
 		assertEquals(2, template.y);
 	}
 
+	@Test
 	public void testConstructorDimension() throws Exception {
 		Dimension dimension = new Dimension(100, 200);
 		assertEquals(100, 200, new Point(dimension));
 		assertEquals(100, 200, dimension);
 	}
 
+	@Test
 	public void testEqualsObject() throws Exception {
 		Point testPoint = new Point(-1, 2);
 		assertFalse(testPoint.equals(null));
@@ -98,6 +115,7 @@ public class PointTests extends BaseTestCase {
 		assertFalse(testPoint.equals(new Point()));
 	}
 
+	@Test
 	public void testHashCodeToString() throws Exception {
 		assertEquals(0, new Point().hashCode());
 		assertEquals((1 * 2) ^ (1 + 2), new Point(1, 2).hashCode());
@@ -106,6 +124,7 @@ public class PointTests extends BaseTestCase {
 		assertNotNull(new Point(1, 2).toString());
 	}
 
+	@Test
 	public void testGetCopy() throws Exception {
 		Point template = new Point(-1, 2);
 		Point testPoint = template.getCopy();
@@ -114,6 +133,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(template, testPoint);
 	}
 
+	@Test
 	public void testGetSwtPoint() throws Exception {
 		org.eclipse.swt.graphics.Point testPoint = new Point(-1, 2).getSWTPoint();
 		assertNotNull(testPoint);
@@ -121,12 +141,14 @@ public class PointTests extends BaseTestCase {
 		assertEquals(2, testPoint.y);
 	}
 
+	@Test
 	public void testSetLocationIntInt() throws Exception {
 		Point testPoint = new Point();
 		assertSame(testPoint, testPoint.setLocation(-1, 2));
 		assertEquals(-1, 2, testPoint);
 	}
 
+	@Test
 	public void testSetLocationPoint() throws Exception {
 		Point template = new Point(-1, 2);
 		Point testPoint = new Point();
@@ -134,22 +156,26 @@ public class PointTests extends BaseTestCase {
 		assertEquals(template, testPoint);
 	}
 
+	@Test
 	public void testGetDifferencePoint() throws Exception {
 		Dimension dimension = new Point(5, -5).getDifference(new Point(4, -4));
 		assertEquals(1, dimension.width);
 		assertEquals(-1, dimension.height);
 	}
 
+	@Test
 	public void testGetDistance2Point() throws Exception {
 		assertEquals(25, new Point(4, 7).getDistance2(new Point(1, 3)));
 		assertEquals(25, new Point(-1, -2).getDistance2(new Point(-5, 1)));
 	}
 
+	@Test
 	public void testGetDistancePoint() throws Exception {
 		assertEquals(5, new Point(4, 7).getDistance(new Point(1, 3)), 0);
 		assertEquals(5, new Point(-1, -2).getDistance(new Point(-5, 1)), 0);
 	}
 
+	@Test
 	public void testGetDistanceOrthogonal() throws Exception {
 		assertEquals(53, new Point(10, 20).getDistanceOrthogonal(new Point(51, 32)));
 		assertEquals(53, new Point(51, 32).getDistanceOrthogonal(new Point(10, 20)));
@@ -158,6 +184,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(60, new Point(10, 20).getDistanceOrthogonal(new Point(-10, -20)));
 	}
 
+	@Test
 	public void testNegate() throws Exception {
 		Point testPoint = new Point(1, 2);
 		assertSame(testPoint, testPoint.negate());
@@ -167,6 +194,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(1, 2, testPoint);
 	}
 
+	@Test
 	public void testScale() throws Exception {
 		// check work scal(double)
 		Point testPoint = new Point(10, 20);
@@ -178,12 +206,14 @@ public class PointTests extends BaseTestCase {
 		assertEquals(100, 100, testPoint);
 	}
 
+	@Test
 	public void testTranspose() throws Exception {
 		Point testPoint = new Point(3, 5);
 		assertSame(testPoint, testPoint.transpose());
 		assertEquals(5, 3, testPoint);
 	}
 
+	@Test
 	public void testGetNegated() throws Exception {
 		Point template = new Point(1, 2);
 		Point testPoint = template.getNegated();
@@ -196,6 +226,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(1, 2, testPoint);
 	}
 
+	@Test
 	public void testGetScaled() throws Exception {
 		Point template = new Point(10, 20);
 		Point testPoint = template.getScaled(0.5);
@@ -203,6 +234,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(5, 10, testPoint);
 	}
 
+	@Test
 	public void testGetTranslated() throws Exception {
 		// check work getTranslated(int, int)
 		Point template = new Point(3, 5);
@@ -223,6 +255,7 @@ public class PointTests extends BaseTestCase {
 		assertEquals(0, 0, testPoint);
 	}
 
+	@Test
 	public void testGetTransposed() throws Exception {
 		Point template = new Point(3, 5);
 		Point testPoint = template.getTransposed();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionDimensionTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionDimensionTest.java
@@ -11,20 +11,22 @@
 
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.PrecisionDimension;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * JUnit Tests for PrecisionDimension.
  * 
  * @author Anthony Hunter
  */
-public class PrecisionDimensionTest extends TestCase {
+public class PrecisionDimensionTest extends Assert {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=227977
 	 */
+	@Test
 	public void testEquals() {
 		PrecisionDimension p1 = new PrecisionDimension(0.1, 0.1);
 		PrecisionDimension p2 = new PrecisionDimension(0.2, 0.2);
@@ -34,11 +36,13 @@ public class PrecisionDimensionTest extends TestCase {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=124904
 	 */
+	@Test
 	public void testGetCopy() {
 		PrecisionDimension p1 = new PrecisionDimension(0.1, 0.1);
 		assertTrue(p1.equals(p1.getCopy()));
 	}
 
+	@Test
 	public void testExpand() {
 		PrecisionDimension p1 = new PrecisionDimension(0.1, 0.1);
 		PrecisionDimension p2 = new PrecisionDimension(0.2, 0.2);
@@ -46,6 +50,7 @@ public class PrecisionDimensionTest extends TestCase {
 		assertTrue(p2.equals(p1.getExpanded(p1)));
 	}
 
+	@Test
 	public void testShrink() {
 		PrecisionDimension p1 = new PrecisionDimension(0.1, 0.1);
 		PrecisionDimension p2 = new PrecisionDimension(0.2, 0.2);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionPointTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionPointTest.java
@@ -11,26 +11,29 @@
 
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.PrecisionPoint;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * JUnit Tests for PrecisionPoint.
  * 
  * @author Anthony Hunter
  */
-public class PrecisionPointTest extends TestCase {
+public class PrecisionPointTest extends Assert {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=227977
 	 */
+	@Test
 	public void testEquals() {
 		PrecisionPoint p1 = new PrecisionPoint(0.1, 0.1);
 		PrecisionPoint p2 = new PrecisionPoint(0.2, 0.2);
 		assertFalse(p1.equals(p2));
 	}
 
+	@Test
 	public void testTranslate() {
 		PrecisionPoint p1 = new PrecisionPoint(0.1, 0.1);
 		PrecisionPoint p2 = new PrecisionPoint(0.2, 0.2);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -11,18 +11,20 @@
 
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author sshaw
  * 
  */
-public class PrecisionRectangleTest extends TestCase {
+public class PrecisionRectangleTest extends Assert {
 
+	@Test
 	public void testShrink() {
 		Insets insets = new Insets(2, 2, 2, 2);
 
@@ -57,6 +59,7 @@ public class PrecisionRectangleTest extends TestCase {
 		assertEquals(25.92755905511811, r.preciseHeight(), 0);
 	}
 
+	@Test
 	public void testExpand() {
 		PrecisionRectangle r = new PrecisionRectangle(new Rectangle(100, 100, 250, 250));
 		PrecisionRectangle copy = r.getPreciseCopy();
@@ -66,6 +69,7 @@ public class PrecisionRectangleTest extends TestCase {
 		r.shrink(0.1, 0.1);
 	}
 
+	@Test
 	public void testUnion() {
 		PrecisionRectangle r = new PrecisionRectangle(-9.486614173228347, -34.431496062992125, 41.99055118110236,
 				25.92755905511811);
@@ -74,6 +78,7 @@ public class PrecisionRectangleTest extends TestCase {
 				100.5 + 34.431496062992125), r);
 	}
 
+	@Test
 	public void testResize() {
 		PrecisionRectangle r = new PrecisionRectangle(-9.486614173228347, -34.431496062992125, 41.99055118110236,
 				25.92755905511811);
@@ -82,6 +87,7 @@ public class PrecisionRectangleTest extends TestCase {
 				25.92755905511811 + 100.1), r);
 	}
 
+	@Test
 	public void testContains() {
 		PrecisionRectangle r = new PrecisionRectangle(-9.486614173228347, -34.431496062992125, 41.99055118110236,
 				25.92755905511811);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RayTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RayTest.java
@@ -9,10 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.Ray;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Ray's tests
@@ -20,27 +20,15 @@ import org.eclipse.draw2d.geometry.Ray;
  * @author aboyko
  * 
  */
-public class RayTest extends TestCase {
+public class RayTest extends Assert {
 
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
-
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
+	@Test
 	public void test_length() {
 		testLengthValues(3, 4, 5);
 		testLengthValues(0, Integer.MAX_VALUE, Integer.MAX_VALUE);
 	}
 
+	@Test
 	public void test_getScalarProduct() {
 		Ray a = new Ray(3, 2);
 		Ray b = new Ray(2, -2);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
@@ -16,23 +16,11 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 public class RectangleTest extends BaseTestCase {
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
+	@Test
 	public void test_creationSymmetry() {
 		Point topLeft = new Point(0, 0);
 		Point topRight = new Point(10, 0);
@@ -44,6 +32,7 @@ public class RectangleTest extends BaseTestCase {
 		assertTrue(rect1.equals(rect2));
 	}
 
+	@Test
 	public void test_creationValues() {
 
 		final Rectangle testRect = new Rectangle(10, 10, 10, 10);
@@ -59,6 +48,7 @@ public class RectangleTest extends BaseTestCase {
 		assertTrue(rect2.equals(testRect));
 	}
 
+	@Test
 	public void test_sameBehavior() {
 
 		Point p1 = new Point(0, 0);
@@ -72,34 +62,40 @@ public class RectangleTest extends BaseTestCase {
 		assertTrue(origRect.equals(newRect));
 	}
 
+	@Test
 	public void testGetExpanded() {
 		Rectangle r = new Rectangle(1, 1, 3, 5);
 		assertEquals(new Dimension(9, 9), r.getExpanded(3, 2).getSize());
 		assertEquals(new Dimension(9, 9), r.getExpanded(3.4, 2.7).getSize());
 	}
 
+	@Test
 	public void testGetShrinked() {
 		Rectangle r = new Rectangle(1, 1, 6, 7);
 		assertEquals(new Dimension(2, 3), r.getShrinked(2, 2).getSize());
 		assertEquals(new Dimension(2, 3), r.getShrinked(2.4, 2.7).getSize());
 	}
 
+	@Test
 	public void testGetTranslated() {
 		Rectangle r = new Rectangle(1, 1, 6, 7);
 		assertEquals(new Point(5, 5), r.getTranslated(4, 4).getLocation());
 		assertEquals(new Point(5, 5), r.getTranslated(4.4, 4.8).getLocation());
 	}
 
+	@Test
 	public void testContains() {
 		Rectangle r = new Rectangle(1, 1, 6, 7);
 		assertTrue(r.contains(6, 7));
 		assertTrue(r.contains(6.9, 7.9));
 	}
 
+	@Test
 	public void testConstructor() throws Exception {
 		assertEquals(0, 0, 0, 0, new Rectangle());
 	}
 
+	@Test
 	public void testConstructorPointDimension() throws Exception {
 		Point location = new Point(1, 2);
 		Dimension size = new Dimension(3, 4);
@@ -108,12 +104,14 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(3, 4, size);
 	}
 
+	@Test
 	public void testConstructorRectangle() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		assertEquals(1, 2, 3, 4, new Rectangle(template));
 		assertEquals(1, 2, 3, 4, template);
 	}
 
+	@Test
 	public void testConstructorSwtRectangle() throws Exception {
 		org.eclipse.swt.graphics.Rectangle template = new org.eclipse.swt.graphics.Rectangle(1, 2, 3, 4);
 		assertEquals(1, 2, 3, 4, new Rectangle(template));
@@ -123,10 +121,12 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(4, template.height);
 	}
 
+	@Test
 	public void testConstructorInts() throws Exception {
 		assertEquals(1, 2, 3, 4, new Rectangle(1, 2, 3, 4));
 	}
 
+	@Test
 	public void testConstructorPointPoint() throws Exception {
 		Point point1 = new Point(10, 5);
 		Point point2 = new Point(40, 30);
@@ -143,6 +143,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(15, 15, point2);
 	}
 
+	@Test
 	public void testEqualsObject() throws Exception {
 		Rectangle testRectangle = new Rectangle(10, 15, 70, 30);
 		assertFalse(testRectangle.equals(null));
@@ -152,45 +153,53 @@ public class RectangleTest extends BaseTestCase {
 		assertFalse(testRectangle.equals(new Rectangle()));
 	}
 
+	@Test
 	public void testToString() throws Exception {
 		assertNotNull(new Rectangle().toString());
 		assertNotNull(new Rectangle(1, 2, 3, 4).toString());
 	}
 
+	@Test
 	public void testGetLocation() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		assertEquals(10, 15, template.getLocation());
 		assertEquals(10, 15, 70, 30, template);
 	}
 
+	@Test
 	public void testGetSize() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		assertEquals(70, 30, template.getSize());
 		assertEquals(10, 15, 70, 30, template);
 	}
 
+	@Test
 	public void testBottom() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		assertEquals(45, template.bottom());
 		assertEquals(10, 15, 70, 30, template);
 	}
 
+	@Test
 	public void testRight() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		assertEquals(80, template.right());
 		assertEquals(10, 15, 70, 30, template);
 	}
 
+	@Test
 	public void testLeft() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		assertEquals(10, template.left());
 	}
 
+	@Test
 	public void testTop() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		assertEquals(15, template.top());
 	}
 
+	@Test
 	public void testContainsIntInt() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		//
@@ -204,6 +213,7 @@ public class RectangleTest extends BaseTestCase {
 		assertFalse(template.contains(80, 45));
 	}
 
+	@Test
 	public void testContainsPoint() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		Point point = new Point(10, 15);
@@ -219,6 +229,7 @@ public class RectangleTest extends BaseTestCase {
 		assertFalse(template.contains(new Point(80, 45)));
 	}
 
+	@Test
 	public void testIntersects() throws Exception {
 		Rectangle rectangle1 = new Rectangle(10, 15, 70, 30);
 		//
@@ -238,12 +249,14 @@ public class RectangleTest extends BaseTestCase {
 		assertFalse(rectangle1.intersects(new Rectangle(0, 0, 5, 10)));
 	}
 
+	@Test
 	public void testIsEmpty() throws Exception {
 		assertTrue(new Rectangle().isEmpty());
 		assertTrue(new Rectangle(10, 10, -3, 7).isEmpty());
 		assertFalse(new Rectangle(-10, -10, 1, 2).isEmpty());
 	}
 
+	@Test
 	public void testTouches() throws Exception {
 		Rectangle rectangle1 = new Rectangle(10, 15, 70, 30);
 		//
@@ -263,6 +276,7 @@ public class RectangleTest extends BaseTestCase {
 		assertFalse(rectangle1.touches(new Rectangle(0, 0, 5, 10)));
 	}
 
+	@Test
 	public void testSetBoundsRectangle() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		Rectangle testRectangle = new Rectangle();
@@ -271,12 +285,14 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(10, 15, 70, 30, template);
 	}
 
+	@Test
 	public void testSetBoundsInts() throws Exception {
 		Rectangle testRectangle = new Rectangle(10, 15, 70, 30);
 		assertSame(testRectangle, testRectangle.setBounds(-100, 200, 700, 800));
 		assertEquals(-100, 200, 700, 800, testRectangle);
 	}
 
+	@Test
 	public void testSetLocation() throws Exception {
 		// check work setLocation(Point)
 		Point location = new Point(10, 30);
@@ -290,6 +306,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(-100, 200, 700, 800, testRectangle);
 	}
 
+	@Test
 	public void testSetSize() throws Exception {
 		// check work setSize(Dimension)
 		Dimension size = new Dimension(110, 15);
@@ -303,6 +320,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(-100, 200, 1024, 768, testRectangle);
 	}
 
+	@Test
 	public void testCrop() throws Exception {
 		Rectangle template = new Rectangle(10, 15, 70, 30);
 		assertSame(template, template.crop(null));
@@ -326,12 +344,14 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(55, 40, 0, 0, template);
 	}
 
+	@Test
 	public void testExpandIntInt() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		assertSame(template, template.expand(2, 3));
 		assertEquals(-1, -1, 7, 10, template);
 	}
 
+	@Test
 	public void testExpandInsets() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		Insets insets = new Insets(5, 4, 3, 2);
@@ -340,6 +360,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(5, 4, 3, 2, insets);
 	}
 
+	@Test
 	public void testIntersect() throws Exception {
 		Rectangle rectangle1 = new Rectangle(10, 15, 70, 30);
 		//
@@ -364,6 +385,7 @@ public class RectangleTest extends BaseTestCase {
 		assertTrue(rectangle1.isEmpty());
 	}
 
+	@Test
 	public void testResize() throws Exception {
 		// check work resize(Dimension)
 		Rectangle template = new Rectangle(1, 2, 3, 4);
@@ -377,6 +399,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 2, 1, 1, template);
 	}
 
+	@Test
 	public void testScale() throws Exception {
 		// check work scale(double)
 		Rectangle template = new Rectangle(10, 10, 20, 20);
@@ -389,6 +412,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(5, 5, 10, 10, template);
 	}
 
+	@Test
 	public void testShrink() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 30, 40);
 		Point center = new Point(16, 22);
@@ -409,6 +433,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(center, template.getCenter());
 	}
 
+	@Test
 	public void testTranslate() throws Exception {
 		// check work translate(int, int)
 		Rectangle template = new Rectangle(1, 2, 3, 4);
@@ -423,12 +448,14 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(-3, -4, point);
 	}
 
+	@Test
 	public void testTranspose() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		assertSame(template, template.transpose());
 		assertEquals(2, 1, 4, 3, template);
 	}
 
+	@Test
 	public void testUnionDimension() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		Dimension dimension = new Dimension(-1, 7);
@@ -438,6 +465,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(-1, 7, dimension);
 	}
 
+	@Test
 	public void testUnionIntInt() throws Exception {
 		Rectangle template = new Rectangle(10, 20, 30, 40);
 		//
@@ -463,6 +491,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(0, 0, 56, 78, template);
 	}
 
+	@Test
 	public void testUnionPoint() throws Exception {
 		Rectangle template = new Rectangle(10, 20, 30, 40);
 		Point point = new Point(15, 25);
@@ -496,6 +525,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(0, 0, point);
 	}
 
+	@Test
 	public void testUnion4int() throws Exception {
 		Rectangle template = new Rectangle(10, 20, 30, 40);
 		//
@@ -509,6 +539,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(5, 7, 105, 213, template);
 	}
 
+	@Test
 	public void testUnionRectangle() throws Exception {
 		Rectangle template = new Rectangle(10, 20, 30, 40);
 		//
@@ -529,6 +560,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(10, 20, 100, 200, rectangle);
 	}
 
+	@Test
 	public void testSetX() throws Exception {
 		Rectangle rectangle = new Rectangle(1, 2, 4, 3);
 		rectangle.setX(0);
@@ -537,6 +569,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 2, 4, 3, rectangle);
 	}
 
+	@Test
 	public void testSetY() throws Exception {
 		Rectangle rectangle = new Rectangle(1, 2, 3, 4);
 		rectangle.setY(1);
@@ -545,6 +578,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 3, 3, 4, rectangle);
 	}
 
+	@Test
 	public void testSetRight() throws Exception {
 		Rectangle rectangle = new Rectangle(1, 2, 3, 4);
 		rectangle.setRight(5);
@@ -557,6 +591,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 2, 0, 4, rectangle);
 	}
 
+	@Test
 	public void testSetBottom() throws Exception {
 		Rectangle rectangle = new Rectangle(1, 2, 3, 4);
 		rectangle.setBottom(7);
@@ -569,6 +604,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 2, 3, 0, rectangle);
 	}
 
+	@Test
 	public void testShrinkLeft() throws Exception {
 		Rectangle rectangle = new Rectangle(1, 2, 10, 4);
 		rectangle.shrinkLeft(5);
@@ -579,6 +615,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(11, 2, 0, 4, rectangle);
 	}
 
+	@Test
 	public void testShrinkTop() throws Exception {
 		Rectangle rectangle = new Rectangle(1, 2, 3, 11);
 		rectangle.shrinkTop(5);
@@ -589,6 +626,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 13, 3, 0, rectangle);
 	}
 
+	@Test
 	public void testGetCopy() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		Rectangle testRectangle = template.getCopy();
@@ -597,60 +635,70 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(template, testRectangle);
 	}
 
+	@Test
 	public void testGetBottom() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(20, 40, rectangle.getBottom());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetBottomLeft() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(10, 40, rectangle.getBottomLeft());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetBottomRight() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(30, 40, rectangle.getBottomRight());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetCenter() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(20, 25, rectangle.getCenter());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetLeft() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(10, 25, rectangle.getLeft());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetRight() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(30, 25, rectangle.getRight());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetTop() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(20, 10, rectangle.getTop());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetTopLeft() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(10, 10, rectangle.getTopLeft());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetTopRight() throws Exception {
 		Rectangle rectangle = new Rectangle(10, 10, 20, 30);
 		assertEquals(30, 10, rectangle.getTopRight());
 		assertEquals(10, 10, 20, 30, rectangle);
 	}
 
+	@Test
 	public void testGetCropped() throws Exception {
 		// check work getCropped() with null Insets
 		Rectangle template = new Rectangle(10, 15, 70, 30);
@@ -668,6 +716,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 2, 3, 4, insets);
 	}
 
+	@Test
 	public void testGetExpandedIntInt() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		Rectangle testRectangle = template.getExpanded(2, 3);
@@ -676,6 +725,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(-1, -1, 7, 10, testRectangle);
 	}
 
+	@Test
 	public void testGetExpandedInsets() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		Insets insets = new Insets(5, 4, 3, 2);
@@ -686,6 +736,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(5, 4, 3, 2, insets);
 	}
 
+	@Test
 	public void testGetIntersection() throws Exception {
 		Rectangle rectangle1 = new Rectangle(10, 15, 70, 30);
 		//
@@ -723,6 +774,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(10, 15, 70, 30, rectangle1);
 	}
 
+	@Test
 	public void testGetResized() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		//
@@ -743,6 +795,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(11, 12, size);
 	}
 
+	@Test
 	public void testGetTransposed() throws Exception {
 		Rectangle template = new Rectangle(1, 2, 3, 4);
 		Rectangle testRectangle = template.getTransposed();
@@ -752,6 +805,7 @@ public class RectangleTest extends BaseTestCase {
 		assertEquals(1, 2, 3, 4, template);
 	}
 
+	@Test
 	public void testGetUnion() throws Exception {
 		Rectangle template = new Rectangle(10, 20, 30, 40);
 		//

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RelativeBendpointTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RelativeBendpointTest.java
@@ -29,12 +29,15 @@ import org.eclipse.draw2d.geometry.PrecisionPoint;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.widgets.Shell;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Romain Raugi
  */
-public class RelativeBendpointTest extends TestCase {
+public class RelativeBendpointTest extends Assert {
 
 	private static class DiagramFigure extends FreeformLayeredPane {
 		public DiagramFigure() {
@@ -86,9 +89,8 @@ public class RelativeBendpointTest extends TestCase {
 
 	private DiagramFigure diagram;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 		shell.setSize(300, 350);
 		shell.open();
@@ -99,12 +101,12 @@ public class RelativeBendpointTest extends TestCase {
 		lws.setContents(diagram);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		shell.close();
-		super.tearDown();
 	}
 
+	@Test
 	public void test237802() {
 		// first node
 		NodeFigure source = new NodeFigure();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ScalablePolygonShapeTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ScalablePolygonShapeTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.SWTGraphics;
 import org.eclipse.draw2d.ScalablePolygonShape;
@@ -23,7 +21,10 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.widgets.Display;
 
-public class ScalablePolygonShapeTest extends TestCase {
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScalablePolygonShapeTest extends Assert {
 
 	private static final int RECTANGLE_START = 1;
 
@@ -40,6 +41,7 @@ public class ScalablePolygonShapeTest extends TestCase {
 	private static final Rectangle RECTANGLE_DOUBLED_BOUNDS = new Rectangle(0, 0, RECTANGLE_END * 2 + LINE_WIDTH,
 			RECTANGLE_END * 2 + LINE_WIDTH);
 
+	@Test
 	public void testScaledPointsEquality() {
 		ScalablePolygonShape scalablePolygon = new ScalablePolygonShape();
 		scalablePolygon.setPoints(RECTANGLE_POINTS);
@@ -49,6 +51,7 @@ public class ScalablePolygonShapeTest extends TestCase {
 		checkScaledPointsNotChanged(scalablePolygon, scaledPoints);
 	}
 
+	@Test
 	public void testPointsUnchangedOnScaling() {
 		ScalablePolygonShape scalablePolygon = new ScalablePolygonShape();
 		PointList points = RECTANGLE_POINTS.getCopy();
@@ -61,6 +64,7 @@ public class ScalablePolygonShapeTest extends TestCase {
 		checkEquals(RECTANGLE_POINTS, points);
 	}
 
+	@Test
 	public void testSmallBounds() {
 		ScalablePolygonShape scalablePolygon = new ScalablePolygonShape();
 		scalablePolygon.setPoints(RECTANGLE_POINTS);
@@ -86,6 +90,7 @@ public class ScalablePolygonShapeTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testScaledPointsUpdateOnPointsChanging() {
 		ScalablePolygonShape scalablePolygon = new ScalablePolygonShape();
 		scalablePolygon.setBounds(RECTANGLE_BOUNDS);
@@ -118,6 +123,7 @@ public class ScalablePolygonShapeTest extends TestCase {
 		scaledPoints = checkScaledPointsChanged(scalablePolygon, scaledPoints, scaledPoints.size() - 1);
 	}
 
+	@Test
 	public void testScaledPointsUpdateOnBoundsChanging() {
 		ScalablePolygonShape scalablePolygon = new ScalablePolygonShape();
 		scalablePolygon.setPoints(RECTANGLE_POINTS);
@@ -134,6 +140,7 @@ public class ScalablePolygonShapeTest extends TestCase {
 		checkScaledPointsNotChanged(scalablePolygon, scaledPoints);
 	}
 
+	@Test
 	public void testScaledPointsUpdateOnSetLineWidth() {
 		ScalablePolygonShape scalablePolygon = new ScalablePolygonShape();
 		scalablePolygon.setLineWidth(LINE_WIDTH);
@@ -144,6 +151,7 @@ public class ScalablePolygonShapeTest extends TestCase {
 		checkScaledPointsChanged(scalablePolygon, scaledPoints, scaledPoints.size());
 	}
 
+	@Test
 	public void testScaling() {
 		ScalablePolygonShape scalablePolygon = new ScalablePolygonShape();
 		scalablePolygon.setPoints(RECTANGLE_POINTS);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShapeTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShapeTest.java
@@ -3,22 +3,24 @@
  */
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.Shape;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.LineAttributes;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 /**
  * @author nyssen
  * 
  */
-public class ShapeTest extends TestCase {
+public class ShapeTest extends Assert {
 
 	/**
 	 * Test case to demonstate bug #297223
 	 */
+	@Test
 	public void testLineStyleBackwardsCompatibility() {
 		LineAttributes attributes = new LineAttributes(1);
 		attributes.style = SWT.LINE_DASHDOT;
@@ -37,6 +39,7 @@ public class ShapeTest extends TestCase {
 		assertEquals(SWT.LINE_DASHDOT, shape.getLineStyle());
 	}
 
+	@Test
 	public void testLineWidthBackwardsCompatibility() {
 		LineAttributes attributes = new LineAttributes(4);
 		Shape shape = new Shape() {

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShortestPathRoutingTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShortestPathRoutingTest.java
@@ -9,16 +9,18 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.graph.Path;
 import org.eclipse.draw2d.graph.ShortestPathRouter;
 
-public class ShortestPathRoutingTest extends TestCase {
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShortestPathRoutingTest extends Assert {
 
 	private static final Point bend = new Point(620, 309);
 	private static final Point bendAEnd = new Point(264, 472);
@@ -370,19 +372,13 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertPointAbove(pathA.getPoint(1), pathB.getPoint(1));
 	}
 
-	/*
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		routing = new ShortestPathRouter();
 	}
 
-	/*
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		routing = null;
 		pathA = null;
 		pathC = null;
@@ -391,6 +387,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		rect = null;
 	}
 
+	@Test
 	public void testBendpoints() {
 		routing.addObstacle(bendTopRect.getCopy());
 		routing.addObstacle(bendBottomRect.getCopy());
@@ -408,6 +405,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertNumPoints(pathA, 3);
 	}
 
+	@Test
 	public void testBlockedPath() {
 		routing.addObstacle(blockRect1.getCopy());
 		routing.addObstacle(blockRect2.getCopy());
@@ -418,36 +416,43 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertNumPoints(pathA, 0);
 	}
 
+	@Test
 	public void testBottomLeftIntersection() {
 		doSetUp(corner2AStart, corner2AEnd, corner2BStart, corner2BEnd, corner2CStart, corner2CEnd, bl);
 		doTestBottomLeftIntersection();
 	}
 
+	@Test
 	public void testBottomLeftIntersectionCross() {
 		doSetUp(corner2BStart, corner2BEnd, corner2AStart, corner2AEndCross, corner2CStart, corner2CEnd, bl);
 		doTestBottomLeftIntersection();
 	}
 
+	@Test
 	public void testBottomLeftIntersectionCrossInverted() {
 		doSetUp(corner2BStart, corner2BEnd, corner2AStart, corner2AEndCross, corner2CEnd, corner2CStart, bl);
 		doTestBottomLeftIntersection();
 	}
 
+	@Test
 	public void testBottomLeftIntersectionInverted() {
 		doSetUp(corner2AStart, corner2AEnd, corner2BEnd, corner2BStart, corner2CStart, corner2CEnd, bl);
 		doTestBottomLeftIntersection();
 	}
 
+	@Test
 	public void testBottomRightIntersection() {
 		doSetUp(cornerAStart, cornerAEnd, cornerBStart, cornerBEnd, br);
 		doTestBottomRightIntersection();
 	}
 
+	@Test
 	public void testBottomRightIntersectionInverted() {
 		doSetUp(cornerAStart, cornerAEnd, cornerBEnd, cornerBStart, br);
 		doTestBottomRightIntersection();
 	}
 
+	@Test
 	public void testDeformed() {
 		routing.addObstacle(deformedLeft.getCopy());
 		routing.addObstacle(deformedLeftMid.getCopy());
@@ -456,6 +461,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestDeformed();
 	}
 
+	@Test
 	public void testDeformedInverted() {
 		routing.addObstacle(deformedLeft.getCopy());
 		routing.addObstacle(deformedLeftMid.getCopy());
@@ -464,6 +470,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestDeformed();
 	}
 
+	@Test
 	public void testDeltasAddObstacleIntersection() {
 		doSetUp(deltaAStart, deltaAEnd, deltaBStart, deltaBEnd, deltaRect);
 
@@ -472,6 +479,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		assertTrue("Both paths should have been solved.", routing.solve().size() == 2);
 	}
 
+	@Test
 	public void testDeltasAddObstacleNoIntersection() {
 		doSetUp(deltaAStart, deltaAEnd, deltaBStart, deltaBEnd, deltaRect);
 
@@ -480,6 +488,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertNoPathsSolved();
 	}
 
+	@Test
 	public void testDeltasAddPath() {
 		doSetUp(corner2AStart, corner2AEnd, corner2BStart, corner2BEnd, bl);
 
@@ -497,6 +506,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertPointAbove(pathC.getPoint(1), pathB.getPoint(1));
 	}
 
+	@Test
 	public void testDeltasMoveObstacleIntersection() {
 		doSetUp(deltaAStart, deltaAEnd, deltaBStart, deltaBEnd, deltaRect);
 
@@ -505,6 +515,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		assertTrue("Both paths should have been solved.", routing.solve().size() > 0);
 	}
 
+	@Test
 	public void testDeltasMoveObstacleNoIntersection() {
 		doSetUp(deltaAStart, deltaAEnd, deltaBStart, deltaBEnd, deltaRect);
 
@@ -515,6 +526,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertNoPathsSolved();
 	}
 
+	@Test
 	public void testDeltasRemoveObstacleIntersection() {
 		doSetUp(deltaAStart, deltaAEnd, deltaBStart, deltaBEnd, deltaRect);
 
@@ -523,6 +535,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		assertTrue("Both paths should have been solved.", routing.solve().size() > 0);
 	}
 
+	@Test
 	public void testDeltasRemoveObstacleNoIntersection() {
 		doSetUp(deltaAStart, deltaAEnd, deltaBStart, deltaBEnd, deltaRect);
 
@@ -532,6 +545,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertNoPathsSolved();
 	}
 
+	@Test
 	public void testDeltasRemovePath() {
 		doSetUp(corner2AStart, corner2AEnd, corner2BStart, corner2BEnd, bl);
 		Path c = new Path(corner2CStart, corner2CEnd);
@@ -541,6 +555,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertNoPathsSolved();
 	}
 
+	@Test
 	public void testOffsetShrink() {
 		routing.addObstacle(offsetRectLeft.getCopy());
 		routing.addObstacle(offsetRectRight.getCopy());
@@ -550,6 +565,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestOffsetShrink();
 	}
 
+	@Test
 	public void testQuadBendHit() {
 		routing.addObstacle(quadBendBottom.getCopy());
 		routing.addObstacle(quadBendMiddleHit.getCopy());
@@ -558,6 +574,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestQuadBendMiss(5);
 	}
 
+	@Test
 	public void testQuadBendHit2() {
 		routing.addObstacle(quadBendBottom.getCopy());
 		routing.addObstacle(quadBendMiddleHit2.getCopy());
@@ -566,6 +583,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestQuadBendMiss(5);
 	}
 
+	@Test
 	public void testQuadBendMiss() {
 		routing.addObstacle(quadBendBottom.getCopy());
 		routing.addObstacle(quadBendMiddleMiss.getCopy());
@@ -574,6 +592,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestQuadBendMiss(4);
 	}
 
+	@Test
 	public void testShortestPathOutsideOval() {
 		routing.addObstacle(ovalRect1.getCopy());
 		routing.addObstacle(ovalRect2.getCopy());
@@ -584,26 +603,31 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertNumPoints(pathA, 4);
 	}
 
+	@Test
 	public void testSideIntersectionBottom() {
 		doSetUp(sideAStart, sideAEnd, sideBStart, sideBEnd, sideBottom);
 		doTestSideIntersectionBottom();
 	}
 
+	@Test
 	public void testSideIntersectionBottomInverted() {
 		doSetUp(sideAStart, sideAEnd, sideBEnd, sideBStart, sideBottom);
 		doTestSideIntersectionBottom();
 	}
 
+	@Test
 	public void testSideIntersectionTop() {
 		doSetUp(sideAStart, sideAEnd, sideBStart, sideBEnd, sideTop);
 		doTestSideIntersectionTop();
 	}
 
+	@Test
 	public void testSideIntersectionTopInverted() {
 		doSetUp(sideAStart, sideAEnd, sideBEnd, sideBStart, sideTop);
 		doTestSideIntersectionTop();
 	}
 
+	@Test
 	public void testSubpath() {
 		routing.addObstacle(subpathLeftRect.getCopy());
 		doSetUp(subpathAStart, subpathAEnd, subpathBStart, subpathBEnd, subpathCStart, subpathCEnd, subpathDStart,
@@ -616,6 +640,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doAssertPointAbove(pathD.getPoint(3), pathC.getPoint(2));
 	}
 
+	@Test
 	public void testTangent() {
 		routing.addObstacle(tangentMiddle.getCopy());
 		routing.addObstacle(tangentRight.getCopy());
@@ -623,6 +648,7 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestTangent();
 	}
 
+	@Test
 	public void testTangentInverted() {
 		routing.addObstacle(tangentMiddle.getCopy());
 		routing.addObstacle(tangentRight.getCopy());
@@ -630,31 +656,37 @@ public class ShortestPathRoutingTest extends TestCase {
 		doTestTangent();
 	}
 
+	@Test
 	public void testTopLeftIntersection() {
 		doSetUp(cornerAStart, cornerAEnd, cornerBStart, cornerBEnd, tl);
 		doTestTopLeftIntersection();
 	}
 
+	@Test
 	public void testTopLeftIntersectionCross() {
 		doSetUp(cornerBStart, cornerAEnd, cornerAStart, cornerBEnd, tl);
 		doTestTopLeftIntersectionCross();
 	}
 
+	@Test
 	public void testTopLeftIntersectionCrossInverted() {
 		doSetUp(cornerBStart, cornerAEnd, cornerBEnd, cornerAStart, tl);
 		doTestTopLeftIntersectionCross();
 	}
 
+	@Test
 	public void testTopLeftIntersectionInverted() {
 		doSetUp(cornerAStart, cornerAEnd, cornerBEnd, cornerBStart, tl);
 		doTestTopLeftIntersection();
 	}
 
+	@Test
 	public void testTopRightIntersection() {
 		doSetUp(corner2AStart, corner2AEnd, corner2BStart, corner2BEnd, tr);
 		doTestTopRightIntersection();
 	}
 
+	@Test
 	public void testTopRightIntersectionInverted() {
 		doSetUp(corner2AStart, corner2AEnd, corner2BEnd, corner2BStart, tr);
 		doTestTopRightIntersection();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/SimpleTextTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/SimpleTextTest.java
@@ -19,6 +19,8 @@ import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 
+import org.junit.Before;
+
 /**
  * @since 3.1
  */
@@ -32,7 +34,8 @@ public class SimpleTextTest extends AbstractTextTest {
 	public TextFlow child2 = new TextFlow(PHRASE);
 	public Font font = Display.getDefault().getSystemFont();
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		flowpage.setFont(font);
 		flowpage.add(sentence);
 		flowpage.add(inline);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/StraightTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/StraightTest.java
@@ -11,18 +11,20 @@
  */
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.PrecisionPoint;
 import org.eclipse.draw2d.geometry.Straight;
 import org.eclipse.draw2d.geometry.Vector;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author Alexander Nyssen
  * 
  */
-public class StraightTest extends TestCase {
+public class StraightTest extends Assert {
 
+	@Test
 	public void test_getIntersection() {
 		// test integer precision
 		Vector p = new Vector(1, 1);
@@ -77,6 +79,7 @@ public class StraightTest extends TestCase {
 		assertTrue(s2.contains(intersection));
 	}
 
+	@Test
 	public void test_isParallelTo() {
 		Straight s1 = new Straight(new Vector(0, 0), new Vector(3, 3));
 		Straight s2 = new Straight(new Vector(0, 4), new Vector(2, 2));
@@ -87,6 +90,7 @@ public class StraightTest extends TestCase {
 		assertFalse(s1.isParallelTo(s2));
 	}
 
+	@Test
 	public void test_getAngle() {
 		Straight s1 = new Straight(new Vector(0, 0), new Vector(3, 3));
 		Straight s2 = new Straight(new Vector(0, 4), new Vector(2, 2));
@@ -97,6 +101,7 @@ public class StraightTest extends TestCase {
 		assertTrue((float) s1.getAngle(s2) == 45.0); // rounding effects
 	}
 
+	@Test
 	public void test_equals() {
 		Straight s1 = new Straight(new Vector(0, 0), new Vector(3, 3));
 		Straight s2 = new Straight(new Vector(4, 4), new Vector(2, 2));

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
@@ -20,6 +20,11 @@ import org.eclipse.draw2d.text.ParagraphTextLayout;
 import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.draw2d.text.TextFragmentBox;
 
+import org.junit.Ignore;
+import org.junit.Test;
+
+// FIXME The text flow wrap test are currently unstable and therefore deactivated
+@Ignore
 public class TextFlowWrapTest extends BaseTestCase {
 
 	// @TODO:Pratik create similar test cases for bidi...where the fragments are
@@ -253,6 +258,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		// doTest2("foobar", "foobar", "f...", new String[] {"f", TERMINATE});
 	}
 
+	@Test
 	public void testHardWrapping() {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
@@ -268,6 +274,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		runHardWrappingTests();
 	}
 
+	@Test
 	public void testSoftWrapping() {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
@@ -283,6 +290,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		runSoftWrappingTests();
 	}
 
+	@Test
 	public void testTruncatedWrapping() {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
@@ -298,6 +306,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		runTruncatedWrappingTests();
 	}
 
+	@Test
 	public void testInlineFlow() {
 		figure = new FlowPage();
 		InlineFlow inline = new InlineFlow();
@@ -329,6 +338,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		doTest2("def", "def", "defde", new String[] { "def", SAMELINE, "def", TERMINATE });
 	}
 
+	@Test
 	public void testNestedInlineFlows() {
 		figure = new FlowPage();
 		textFlow = new TextFlow();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextualTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextualTests.java
@@ -18,12 +18,15 @@ import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.draw2d.text.TextFragmentBox;
 import org.eclipse.swt.graphics.Font;
 
+import org.junit.Test;
+
 /**
  * @author Pratik Shah
  * @since 3.1
  */
 public class TextualTests extends BaseTestCase {
 
+	@Test
 	public void testLineRootBidiCommit() {
 		FlowPage block = new FlowPage();
 		InlineFlow bold = new InlineFlow();
@@ -54,6 +57,7 @@ public class TextualTests extends BaseTestCase {
 	}
 
 	// test for bug 113700
+	@Test
 	public void testGetFirstAndLastOffsetForLine() {
 		Font xlFont = new Font(null, "Tahoma", 28, 0);
 		FlowPage block = new FlowPage();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ThumbnailTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ThumbnailTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.Ellipse;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -19,20 +17,10 @@ import org.eclipse.draw2d.parts.Thumbnail;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 
-public class ThumbnailTest extends TestCase {
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
+import org.junit.Assert;
+import org.junit.Test;
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
+public class ThumbnailTest extends Assert {
 
 	class TestThumbnail extends Thumbnail {
 		public Image getThumbnailImage() {
@@ -40,6 +28,7 @@ public class ThumbnailTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void test_Thumbnail() {
 		TestThumbnail thumb = new TestThumbnail();
 		IFigure fig = new Ellipse();
@@ -51,6 +40,7 @@ public class ThumbnailTest extends TestCase {
 		assertTrue(img != null);
 	}
 
+	@Test
 	public void test_EmptyThumbnail() {
 		TestThumbnail thumb = new TestThumbnail();
 		IFigure fig = new Ellipse();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TransposerTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TransposerTest.java
@@ -16,12 +16,15 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Transposer;
 
+import org.junit.Test;
+
 /**
  * @author lobas_av
  *
  */
 public class TransposerTest extends BaseTestCase {
 
+	@Test
 	public void testState() throws Exception {
 		Transposer transposer = new Transposer();
 		// check "not enabled" new Transposer
@@ -49,6 +52,7 @@ public class TransposerTest extends BaseTestCase {
 		assertFalse(transposer.isEnabled());
 	}
 
+	@Test
 	public void testTDimension() throws Exception {
 		Dimension dimension = new Dimension(100, 200);
 		Transposer transposer = new Transposer();
@@ -68,6 +72,7 @@ public class TransposerTest extends BaseTestCase {
 		assertEquals(100, 200, dimension);
 	}
 
+	@Test
 	public void testTInsets() throws Exception {
 		Insets insets = new Insets(1, 2, 3, 4);
 		Transposer transposer = new Transposer();
@@ -87,6 +92,7 @@ public class TransposerTest extends BaseTestCase {
 		assertEquals(1, 2, 3, 4, insets);
 	}
 
+	@Test
 	public void testTPoint() throws Exception {
 		Point point = new Point(100, 200);
 		Transposer transposer = new Transposer();
@@ -106,6 +112,7 @@ public class TransposerTest extends BaseTestCase {
 		assertEquals(100, 200, point);
 	}
 
+	@Test
 	public void testTRectangle() throws Exception {
 		Rectangle rectangle = new Rectangle(1, 2, 3, 4);
 		Transposer transposer = new Transposer();

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/VectorTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/VectorTest.java
@@ -9,10 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.geometry.Vector;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Vector's tests
@@ -20,38 +20,28 @@ import org.eclipse.draw2d.geometry.Vector;
  * @author aboyko
  * 
  */
-public class VectorTest extends TestCase {
+public class VectorTest extends Assert {
 
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
-
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
+	@Test
 	public void test_getLength() {
 		testLengthValues(3, 4, 5);
 		testLengthValues(0, Integer.MAX_VALUE, Integer.MAX_VALUE);
 	}
 
+	@Test
 	public void test_getOrthoComplement() {
 		Vector a = new Vector(3, -5);
 		assertTrue(a.getOrthogonalComplement().equals(new Vector(5, 3)));
 	}
 
+	@Test
 	public void test_getDotProduct() {
 		Vector a = new Vector(3, 2);
 		Vector b = new Vector(2, -2);
 		assertTrue(a.getDotProduct(b) == 2);
 	}
 
+	@Test
 	public void test_getAngle() {
 		Vector a = new Vector(24.03809869102058, -6.868028197434448);
 		Vector b = new Vector(-24.038098691020593, 6.868028197434448);

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/XYLayoutTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/XYLayoutTest.java
@@ -9,27 +9,21 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.RectangleFigure;
 import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 
-public class XYLayoutTest extends TestCase {
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XYLayoutTest extends Assert {
 
 	protected XYLayout layout;
 	protected RectangleFigure figure;
 	protected RectangleFigure contents;
 
-	/*
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
-
+	@Test
 	public void testPreferredSize() {
 		layout = new XYLayout();
 		contents = new RectangleFigure();
@@ -43,13 +37,6 @@ public class XYLayoutTest extends TestCase {
 
 		assertEquals(100, d.width);
 		assertEquals(150, d.height);
-	}
-
-	/*
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
 	}
 
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
@@ -3,16 +3,16 @@ package org.eclipse.gef.test;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CommandStackEvent;
 import org.eclipse.gef.commands.CommandStackEventListener;
 import org.junit.Assert;
+import org.junit.Test;
 
-public class CommandStackTest extends TestCase {
+public class CommandStackTest extends Assert {
 
+	@Test
 	public void testCommandStackEventListenerNotifications() {
 		final List commandStackEvents = new ArrayList();
 

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
@@ -28,22 +28,10 @@ import org.eclipse.ui.IPropertyListener;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PartInitException;
 
-import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class DragEditPartsTrackerTest extends TestCase {
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
-
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
+public class DragEditPartsTrackerTest extends Assert {
 
 	private static class TestGraphicalEditPart extends AbstractGraphicalEditPart {
 
@@ -163,6 +151,7 @@ public class DragEditPartsTrackerTest extends TestCase {
 		}
 	};
 
+	@Test
 	public void test_createOperationSet() {
 		TestDragEditPartsTracker dept = new TestDragEditPartsTracker(new TestGraphicalEditPart());
 

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
@@ -10,28 +10,20 @@
  *******************************************************************************/
 package org.eclipse.gef.test;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * The main test suite for GEF.
  * 
  * @author Eric Bordeau
  */
-public class GEFTestSuite extends TestSuite {
-
-	public static Test suite() {
-		return new GEFTestSuite();
-	}
-
-	/**
-	 * Constructs a new GEFTestSuite. Add any JUnit tests to the suite here.
-	 */
-	public GEFTestSuite() {
-		addTest(new TestSuite(PaletteCustomizerTest.class));
-		addTest(new TestSuite(ToolUtilitiesTest.class));
-		addTest(new TestSuite(DragEditPartsTrackerTest.class));
-		addTest(new TestSuite(CommandStackTest.class));
-	}
-
+@RunWith(Suite.class) 
+@Suite.SuiteClasses({
+	PaletteCustomizerTest.class,
+	ToolUtilitiesTest.class,
+	DragEditPartsTrackerTest.class,
+	CommandStackTest.class
+})
+public class GEFTestSuite {
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/PaletteCustomizerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/PaletteCustomizerTest.java
@@ -9,9 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.gef.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.gef.palette.CombinedTemplateCreationEntry;
 import org.eclipse.gef.palette.PaletteDrawer;
 import org.eclipse.gef.palette.PaletteEntry;
@@ -22,7 +19,10 @@ import org.eclipse.gef.ui.palette.customize.PaletteDrawerFactory;
 import org.eclipse.gef.ui.palette.customize.PaletteSeparatorFactory;
 import org.eclipse.gef.ui.palette.customize.PaletteStackFactory;
 
-public class PaletteCustomizerTest extends TestCase {
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PaletteCustomizerTest extends Assert {
 
 	class TestCustomizer extends PaletteCustomizer {
 		public void revertToSaved() {
@@ -100,25 +100,12 @@ public class PaletteCustomizerTest extends TestCase {
 	}
 
 	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
-
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
-	/**
 	 * 
 	 * 1-Root 2-Drawer A 3-Tool 4-Stack A 5-Tool 6-Selection (Limited Permissions)
 	 * 8-Stack B (Full Permissions) 9-Tool 10-Drawer B
 	 * 
 	 */
+	@Test
 	public void testBottomSelection() {
 		resetBottom();
 		drawerA.setUserModificationPermission(PaletteEntry.PERMISSION_FULL_MODIFICATION);
@@ -236,6 +223,7 @@ public class PaletteCustomizerTest extends TestCase {
 	 * 1-Root 2-Drawer A 3-Tool 4-Selection 5-Tool 6-Drawer B
 	 * 
 	 */
+	@Test
 	public void testMiddleSelection() {
 		resetMiddle();
 		drawerA.setUserModificationPermission(PaletteEntry.PERMISSION_FULL_MODIFICATION);
@@ -295,6 +283,7 @@ public class PaletteCustomizerTest extends TestCase {
 	 * 1-Root 2-Drawer A 3-Tool 4-Tool 5-Drawer B 6-Stack (Full Permissions)
 	 * (Selection) 7-Tool 8-Tool 9-Drawer C
 	 */
+	@Test
 	public void testTopSelection() {
 		resetTop();
 

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/ToolUtilitiesTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/ToolUtilitiesTest.java
@@ -10,29 +10,16 @@
  *******************************************************************************/
 
 package org.eclipse.gef.test;
-
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.gef.tools.ToolUtilities;
 
-public class ToolUtilitiesTest extends TestCase {
-	/**
-	 * @see TestCase#setUp()
-	 */
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
+import org.junit.Assert;
+import org.junit.Test;
 
-	/**
-	 * @see TestCase#tearDown()
-	 */
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
+public class ToolUtilitiesTest extends Assert {
 
 	private static class TestGraphicalEditPart extends AbstractGraphicalEditPart {
 
@@ -74,6 +61,7 @@ public class ToolUtilitiesTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void test_findCommonAncestor_happypath() {
 		TestGraphicalEditPart editpartParent = new TestGraphicalEditPart();
 		TestGraphicalEditPart editpartChild1 = new TestGraphicalEditPart();
@@ -88,6 +76,7 @@ public class ToolUtilitiesTest extends TestCase {
 		assertTrue(editpartParent == result);
 	}
 
+	@Test
 	public void test_findCommonAncestor_bugzilla130042() {
 		TestGraphicalEditPart editpartParent = new TestGraphicalEditPart();
 		EditPart editpartChild = new TestGraphicalEditPart();

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphSelectionTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphSelectionTests.java
@@ -12,8 +12,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
@@ -23,13 +21,17 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 /**
  * Selection-related tests for the {@link Graph} class.
  * 
  * @author Fabian Steeg (fsteeg)
  * 
  */
-public class GraphSelectionTests extends TestCase {
+public class GraphSelectionTests extends Assert {
 
 	private static final int STYLE = SWT.NONE;
 
@@ -37,12 +39,14 @@ public class GraphSelectionTests extends TestCase {
 
 	private Graph graph;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		graph = new Graph(new Shell(), STYLE);
 		nodes = new GraphNode[] { new GraphNode(graph, STYLE), new GraphNode(graph, STYLE) };
 		new GraphConnection(graph, STYLE, nodes[0], nodes[1]);
 	}
 
+	@Test
 	public void testSetSelectionGetSelection() {
 		graph.setSelection(new GraphNode[] {});
 		assertEquals(0, graph.getSelection().size());
@@ -50,11 +54,13 @@ public class GraphSelectionTests extends TestCase {
 		assertEquals(2, graph.getSelection().size());
 	}
 
+	@Test
 	public void testSelectAllGetSelection() {
 		graph.selectAll();
 		assertEquals(2, graph.getSelection().size());
 	}
 
+	@Test
 	public void testAddSelectionListenerEventIdentity() {
 		final List selectionEvents = new ArrayList();
 		graph.addSelectionListener(setupListener(selectionEvents));
@@ -69,6 +75,7 @@ public class GraphSelectionTests extends TestCase {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=314710
 	 */
+	@Test
 	public void testSelectedNodeDisposal() {
 		graph.setSelection(nodes);
 		nodes[0].dispose();
@@ -80,6 +87,7 @@ public class GraphSelectionTests extends TestCase {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=320281
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=218148#c6
 	 */
+	@Test
 	public void testAddSelectionListenerSetSelection() {
 		final List selectionEvents = new ArrayList();
 		graph.addSelectionListener(setupListener(selectionEvents));
@@ -100,6 +108,7 @@ public class GraphSelectionTests extends TestCase {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=320281
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=322054
 	 */
+	@Test
 	public void testAddSelectionListenerSelectAll() {
 		final List selectionEvents = new ArrayList();
 		graph.addSelectionListener(setupListener(selectionEvents));
@@ -115,6 +124,7 @@ public class GraphSelectionTests extends TestCase {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=320281
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=218148#c6
 	 */
+	@Test
 	public void testAddSelectionListenerNotifyListeners() {
 		final List selectionEvents = new ArrayList();
 		graph.addSelectionListener(setupListener(selectionEvents));

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphTests.java
@@ -19,7 +19,9 @@ import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.internal.ZestRootLayer;
 
-import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * General tests for the {@link Graph} class.
@@ -27,7 +29,7 @@ import junit.framework.TestCase;
  * @author Fabian Steeg (fsteeg)
  * 
  */
-public class GraphTests extends TestCase {
+public class GraphTests extends Assert {
 
 	private static final int STYLE = SWT.NONE;
 
@@ -39,24 +41,28 @@ public class GraphTests extends TestCase {
 
 	Shell shell;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 		graph = new Graph(shell, STYLE);
 		nodes = new GraphNode[] { new GraphNode(graph, STYLE), new GraphNode(graph, STYLE) };
 		connection = new GraphConnection(graph, STYLE, nodes[0], nodes[1]);
 	}
 
+	@Test
 	public void testGraphData() {
 		graph.setData("graph data");
 		assertEquals("graph data", graph.getData());
 	}
 
+	@Test
 	public void testNodeItemData() {
 		GraphItem item = (GraphNode) graph.getNodes().get(0);
 		item.setData("node item data");
 		assertEquals("node item data", item.getData());
 	}
 
+	@Test
 	public void testConnectionItemData() {
 		GraphItem item = (GraphConnection) graph.getConnections().get(0);
 		item.setData("connection item data");
@@ -68,6 +74,7 @@ public class GraphTests extends TestCase {
 	 * 
 	 * @See https://bugs.eclipse.org/bugs/show_bug.cgi?id=361541
 	 */
+	@Test
 	public void testDisposeGraphWithDisposedNode() {
 		nodes[0].dispose(); // removes the node from the graph's nodes list
 		((List<GraphNode>) graph.getNodes()).add(nodes[0]); // but we're malicious and add it back
@@ -81,6 +88,7 @@ public class GraphTests extends TestCase {
 	 * 
 	 * @See https://bugs.eclipse.org/bugs/show_bug.cgi?id=361541
 	 */
+	@Test
 	public void testDisposeGraphWithDisposedConnection() {
 		connection.dispose();
 		((List<GraphConnection>) graph.getConnections()).add(connection);
@@ -95,6 +103,7 @@ public class GraphTests extends TestCase {
 	 * 
 	 * @See https://bugs.eclipse.org/bugs/show_bug.cgi?id=361525
 	 */
+	@Test
 	public void testUnHighlightNode() {
 		new ZestRootLayer().unHighlightNode(new Figure());
 	}
@@ -105,6 +114,7 @@ public class GraphTests extends TestCase {
 	 * 
 	 * @See https://bugs.eclipse.org/bugs/show_bug.cgi?id=361525
 	 */
+	@Test
 	public void testUnHighlightConnection() {
 		new ZestRootLayer().unHighlightConnection(new Figure());
 	}
@@ -113,6 +123,7 @@ public class GraphTests extends TestCase {
 	 * Check that Graph resources are cleaned up when parent is disposed (see
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=373191)
 	 */
+	@Test
 	public void testDisposal() {
 		GraphNode n = (GraphNode) graph.getNodes().get(0);
 		GraphConnection c = (GraphConnection) graph.getConnections().get(0);

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphViewerTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphViewerTests.java
@@ -11,9 +11,6 @@ package org.eclipse.zest.tests;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
-
 import org.eclipse.jface.util.DelegatingDragAdapter;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -31,22 +28,25 @@ import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 /**
  * Tests for the {@link GraphViewer} class.
  * 
  * @author Fabian Steeg (fsteeg)
  * 
  */
-public class GraphViewerTests extends TestCase {
+public class GraphViewerTests extends Assert {
 
 	private GraphViewer viewer;
 	private Shell shell;
 
 	/**
 	 * Set up the shell and viewer to use in the tests.
-	 * 
-	 * @see junit.framework.TestCase#setUp()
 	 */
+	@Before
 	public void setUp() {
 		shell = new Shell();
 		viewer = new GraphViewer(shell, SWT.NONE);
@@ -56,6 +56,7 @@ public class GraphViewerTests extends TestCase {
 	 * Create a drop target on a viewer's control and check disposal (see
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=200732)
 	 */
+	@Test
 	public void testDisposalWithDropTarget() {
 		new DropTarget(viewer.getGraphControl(), DND.DROP_MOVE | DND.DROP_COPY);
 		shell.dispose();
@@ -66,6 +67,7 @@ public class GraphViewerTests extends TestCase {
 	 * Create a drag source on a viewer and check disposal (see
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=334009)
 	 */
+	@Test
 	public void testDisposalWithDragSource() {
 		viewer.addDragSupport(DND.DROP_MOVE, new Transfer[] { TextTransfer.getInstance() },
 				new DelegatingDragAdapter());
@@ -77,6 +79,7 @@ public class GraphViewerTests extends TestCase {
 	 * Assert that no invalid selections with null data are produced by the viewer
 	 * (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=356449)
 	 */
+	@Test
 	public void testValidSelection() {
 		Graph graph = new Graph(shell, SWT.NONE);
 		GraphNode n1 = new GraphNode(graph, SWT.NONE);
@@ -96,6 +99,7 @@ public class GraphViewerTests extends TestCase {
 	 * Assert that listeners for post selection events are properly notified by the
 	 * viewer (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=366916)
 	 */
+	@Test
 	public void testPostSelectionListener() {
 		final List selected = new ArrayList();
 		viewer.addPostSelectionChangedListener(new ISelectionChangedListener() {

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/IFigureProviderTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/IFigureProviderTests.java
@@ -8,8 +8,6 @@
  *******************************************************************************/
 package org.eclipse.zest.tests;
 
-import junit.framework.TestCase;
-
 import org.eclipse.draw2d.BorderLayout;
 import org.eclipse.draw2d.Ellipse;
 import org.eclipse.draw2d.IFigure;
@@ -23,22 +21,25 @@ import org.eclipse.zest.core.viewers.IFigureProvider;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
 import org.eclipse.zest.core.widgets.CGraphNode;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 /**
  * Tests for the {@link IFigureProvider} class.
  * 
  * @author Fabian Steeg (fsteeg)
  * 
  */
-public class IFigureProviderTests extends TestCase {
+public class IFigureProviderTests extends Assert {
 
 	private GraphViewer viewer;
 	private Shell shell;
 
 	/**
 	 * Set up the shell and viewer to use in the tests.
-	 * 
-	 * @see junit.framework.TestCase#setUp()
 	 */
+	@Before
 	public void setUp() {
 		shell = new Shell();
 		viewer = new GraphViewer(shell, SWT.NONE);
@@ -47,6 +48,7 @@ public class IFigureProviderTests extends TestCase {
 	/**
 	 * Test with IGraphContentProvider that provides destinations only.
 	 */
+	@Test
 	public void testWithDestinationProvider() {
 		testWith(new DestinationContentProvider());
 	}
@@ -54,6 +56,7 @@ public class IFigureProviderTests extends TestCase {
 	/**
 	 * Test with IGraphContentProvider that provides sources only.
 	 */
+	@Test
 	public void testWithSourceProvider() {
 		testWith(new SourceContentProvider());
 	}
@@ -61,6 +64,7 @@ public class IFigureProviderTests extends TestCase {
 	/**
 	 * Test with IGraphContentProvider that provides destinations and sources.
 	 */
+	@Test
 	public void testWithFullProvider() {
 		testWith(new FullContentProvider());
 	}

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/ZestTestSuite.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/ZestTestSuite.java
@@ -10,23 +10,19 @@
  *******************************************************************************/
 package org.eclipse.zest.tests;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * The main test suite for Zest.
  * 
  * @author anyssen
  */
-public class ZestTestSuite extends TestSuite {
-
-	public static Test suite() {
-		return new ZestTestSuite();
-	}
-
-	public ZestTestSuite() {
-		addTest(new TestSuite(GraphTests.class));
-		addTest(new TestSuite(GraphSelectionTests.class));
-		addTest(new TestSuite(GraphViewerTests.class));
-	}
+@RunWith(Suite.class) 
+@Suite.SuiteClasses({
+	GraphTests.class,
+	GraphSelectionTests.class,
+	GraphViewerTests.class
+})
+public class ZestTestSuite {
 }


### PR DESCRIPTION
This change migrates all test cases to the latest JUnit version. With JUnit 4, annotations are used to control the execution flow. Given that the naming convention in JUnit 3 is rather fixed, a large chunk of this adaptation could be done automatically.

Normally, one would import statically import methods such as assertTrue(), assertEquals(), etc... However, those methods used to be provided by the TestCase class. In order to keep the code change to a minimum, we imitate this behavior by extending the Assert class instead.

The empty setUp() and tearDown() methods, as well as blank constructors have been removed.

Note that we only migrate to Junit4 instead of JUnit5, simply because Tycho is currently unable to execute those test suites. However, it should be much more straightforward to switch from 4 to 5 than from 3 to 4.

In short:
- Extend Assert instead of TestCase
- Annotate all tests with @Test
- Annotate disable tests/test classes with @Ignore
- Annotate setUp() method with @Before, make public
- Annotate afterEach() method with @After, make public
- Convert test suites into JUnit4 format