### PR TITLE
Update Tycho from 3.0.4 to 4.0.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,6 +21,10 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'maven'
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.9.3
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1
       with:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dtycho-version=3.0.4
+-Dtycho-version=4.0.0


### PR DESCRIPTION
The latest Tycho release added several performance improvements related to slow proxy repositories. This should reduce the amount of time it takes to resolve the target platform.

Note that this also updates Maven to 3.9.3, as Tycho 4 requires at least 3.9.x.