### PR TITLE
Typify dirtyRegion map in UpdateListener and UpdateManager

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ConnectionEndPointMoveTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ConnectionEndPointMoveTest.java
@@ -87,7 +87,7 @@ public class ConnectionEndPointMoveTest extends BaseTestCase implements UpdateLi
 	 * .Rectangle, java.util.Map)
 	 */
 	@Override
-	public void notifyPainting(Rectangle damage, Map dirtyRegions) {
+	public void notifyPainting(Rectangle damage, Map<IFigure, Rectangle> dirtyRegions) {
 		lastDamaged = damage;
 	}
 

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PaintDamageEraseTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PaintDamageEraseTest.java
@@ -233,7 +233,7 @@ public class PaintDamageEraseTest extends BaseTestCase implements UpdateListener
 	}
 
 	@Override
-	public void notifyPainting(Rectangle damage, Map dirtyRegions) {
+	public void notifyPainting(Rectangle damage, Map<IFigure, Rectangle> dirtyRegions) {
 		lastDamaged = damage;
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -257,7 +257,7 @@ public class FigureCanvas extends Canvas {
 	 */
 	private void hook() {
 		getLightweightSystem().getUpdateManager().addUpdateListener(new UpdateListener() {
-			public void notifyPainting(Rectangle damage, java.util.Map dirtyRegions) {
+			public void notifyPainting(Rectangle damage, java.util.Map<IFigure, Rectangle> dirtyRegions) {
 			}
 
 			public void notifyValidating() {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/UpdateListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/UpdateListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ public interface UpdateListener {
 	 * @param damage       The area being painted
 	 * @param dirtyRegions a Map of figures to their dirty regions
 	 */
-	void notifyPainting(Rectangle damage, Map dirtyRegions);
+	void notifyPainting(Rectangle damage, Map<IFigure, Rectangle> dirtyRegions);
 
 	/**
 	 * Notifies the listener that the listened to object is validating.

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/UpdateManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/UpdateManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -117,7 +117,7 @@ public abstract class UpdateManager {
 	 * @param damage       the damaged rectangle
 	 * @param dirtyRegions map of dirty regions to figures
 	 */
-	protected void firePainting(Rectangle damage, Map dirtyRegions) {
+	protected void firePainting(Rectangle damage, Map<IFigure, Rectangle> dirtyRegions) {
 		UpdateListener localListeners[] = listeners;
 		for (int i = 0; i < localListeners.length; i++)
 			localListeners[i].notifyPainting(damage, dirtyRegions);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/Thumbnail.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/Thumbnail.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -516,10 +516,8 @@ public class Thumbnail extends Figure implements UpdateListener {
 
 	/** @see org.eclipse.draw2d.UpdateListener#notifyPainting(Rectangle, Map) */
 	@Override
-	public void notifyPainting(Rectangle damage, Map dirtyRegions) {
-		Iterator dirtyFigures = dirtyRegions.keySet().iterator();
-		while (dirtyFigures.hasNext()) {
-			IFigure current = (IFigure) dirtyFigures.next();
+	public void notifyPainting(Rectangle damage, Map<IFigure, Rectangle> dirtyRegions) {
+		for (IFigure current : dirtyRegions.keySet()) {
 			while (current != null) {
 				if (current == getSource()) {
 					setDirty(true);

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.UpdateListener;
 import org.eclipse.draw2d.UpdateManager;
 import org.eclipse.draw2d.geometry.Point;
@@ -81,7 +82,7 @@ public class TextTool extends SelectionTool implements StyleProvider {
 	};
 	private UpdateListener updateListener = new UpdateListener() {
 		@Override
-		public void notifyPainting(Rectangle damage, Map dirtyRegions) {
+		public void notifyPainting(Rectangle damage, Map<IFigure, Rectangle> dirtyRegions) {
 			queueCaretRefresh(false);
 		}
 


### PR DESCRIPTION
This change adjusts the notifyPainting() method in UpdateListener and the firePainting() method in UpdateManager to expect a generic map of (IFigure, Rectangle) pairs, rather than a raw map.

This should not cause errors in client code, as calling or overwriting this method can still be done using a raw map (which will create a "unchecked or unsafe operations" warning).