### PR TITLE
[Clean-up] added missing @Override annotations

### DIFF
--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/zoom/ZoomExample.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/zoom/ZoomExample.java
@@ -10,6 +10,12 @@
  *******************************************************************************/
 package org.eclipse.draw2d.examples.zoom;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
 import org.eclipse.draw2d.ButtonBorder;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.GroupBoxBorder;
@@ -22,11 +28,6 @@ import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.parts.Thumbnail;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Shell;
 
 /**
  * This class demonstrates Draw2d's zoom capabilities.
@@ -37,7 +38,7 @@ import org.eclipse.swt.widgets.Shell;
 public class ZoomExample {
 
 	private static Figure contents;
-	//private static Shell overviewShell;
+	// private static Shell overviewShell;
 
 	public static void main(String args[]) {
 		Display d = new Display();
@@ -49,7 +50,7 @@ public class ZoomExample {
 		fig.setLayoutManager(new ToolbarLayout());
 
 		final ScrollBar bar = new ScrollBar();
-		final Label l = new Label("�Zoom�"); //$NON-NLS-1$
+		final Label l = new Label("< Zoom >"); //$NON-NLS-1$
 
 		l.setBorder(new SchemeBorder(ButtonBorder.SCHEMES.BUTTON_SCROLLBAR));
 		bar.setThumb(l);
@@ -75,21 +76,20 @@ public class ZoomExample {
 
 		lws.setContents(fig);
 
-		//	overviewShell = new Shell(shell, SWT.TITLE| SWT.RESIZE | SWT.NO_REDRAW_RESIZE | SWT.NO_BACKGROUND);
-		//	overviewShell.setText("Overview Shell");
-		//	overviewShell.setLayout(new FillLayout());
-		//	LightweightSystem overviewLWS = new LightweightSystem(overviewShell);
-		//	overviewLWS.setContents(createThumbnail(getContents()));
-		//	overviewShell.setSize(200, 200);
+		// overviewShell = new Shell(shell, SWT.TITLE| SWT.RESIZE | SWT.NO_REDRAW_RESIZE
+		// | SWT.NO_BACKGROUND);
+		// overviewShell.setText("Overview Shell");
+		// overviewShell.setLayout(new FillLayout());
+		// LightweightSystem overviewLWS = new LightweightSystem(overviewShell);
+		// overviewLWS.setContents(createThumbnail(getContents()));
+		// overviewShell.setSize(200, 200);
 
 		shell.open();
-		//	overviewShell.open();
-		while (!shell.isDisposed())
-		{
-			while (!d.readAndDispatch())
-			{
+		// overviewShell.open();
+		while (!shell.isDisposed()) {
+			while (!d.readAndDispatch()) {
 				d.sleep();
-				//	overviewShell.dispose();
+				// overviewShell.dispose();
 			}
 		}
 	}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AbstractTextTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AbstractTextTest.java
@@ -29,6 +29,7 @@ public class AbstractTextTest extends BaseTestCase {
 			this.insets = insets;
 		}
 
+		@Override
 		public Insets getInsets(IFigure figure) {
 			return insets;
 		}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AdvancedGraphicsTests.java
@@ -71,6 +71,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 	private void displayImage() {
 		final Shell shell = new Shell(SWT.DIALOG_TRIM);
 		shell.addPaintListener(new PaintListener() {
+			@Override
 			public void paintControl(PaintEvent e) {
 				e.gc.drawImage(image, 0, 0);
 			}
@@ -79,6 +80,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		shell.open();
 		Display d = shell.getDisplay();
 		d.asyncExec(new Runnable() {
+			@Override
 			public void run() {
 				if (!shell.isDisposed())
 					shell.close();
@@ -151,6 +153,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 				this.color = color;
 			}
 
+			@Override
 			public void run() {
 				g.setAntialias(normal);
 				g.setTextAntialias(text);
@@ -167,6 +170,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		tests[2] = new AntialiasSettings(SWT.DEFAULT, SWT.ON, ColorConstants.black);
 		tests[3] = new AntialiasSettings(SWT.ON, SWT.DEFAULT, ColorConstants.darkGreen);
 		performTestcase(new Runnable() {
+			@Override
 			public void run() {
 				g.drawPolyline(LINE);
 				g.drawString("OWVO", 35, 20);
@@ -186,6 +190,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 				this.aa = aa;
 			}
 
+			@Override
 			public void run() {
 				g.setFillRule(rule);
 				// $TODO
@@ -200,6 +205,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		tests[1] = new FillRules(SWT.FILL_WINDING, SWT.OFF);
 		tests[2] = new FillRules(SWT.FILL_EVEN_ODD, SWT.DEFAULT);
 		performTestcase(new Runnable() {
+			@Override
 			public void run() {
 				g.fillPolygon(POLY);
 			}
@@ -245,6 +251,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 				this.style = style;
 			}
 
+			@Override
 			public void run() {
 				g.setLineCap(cap);
 				g.setLineJoin(join);
@@ -260,6 +267,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 				new LineSettings(SWT.JOIN_ROUND, SWT.CAP_SQUARE, SWT.LINE_SOLID) };
 
 		performTestcase(new Runnable() {
+			@Override
 			public void run() {
 				g.drawPolyline(LINE);
 			}
@@ -281,6 +289,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 				this.attributes = attributes;
 			}
 
+			@Override
 			public void run() {
 				g.setLineAttributes(attributes);
 			}
@@ -301,6 +310,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 						new LineAttributes(9.5f, SWT.CAP_FLAT, SWT.JOIN_ROUND, SWT.LINE_CUSTOM, dash, 5, 10)), };
 
 		performTestcase(new Runnable() {
+			@Override
 			public void run() {
 				g.drawPolyline(LINE);
 			}
@@ -402,6 +412,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 				this.fg = fg;
 			}
 
+			@Override
 			public void run() {
 				g.setBackgroundPattern(bg);
 				g.setForegroundPattern(fg);
@@ -424,6 +435,7 @@ public class AdvancedGraphicsTests extends BaseTestCase {
 		Runnable tests[] = new Runnable[1];
 		tests[0] = new SetPattern(image, gradient);
 		performTestcase(new Runnable() {
+			@Override
 			public void run() {
 				g.fillText("W", 0, 0);
 			}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AnchorNotificationTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/AnchorNotificationTest.java
@@ -53,6 +53,7 @@ public class AnchorNotificationTest extends Assert {
 		/**
 		 * @see org.eclipse.draw2d.PolylineConnection#anchorMoved(org.eclipse.draw2d.ConnectionAnchor)
 		 */
+		@Override
 		public void anchorMoved(ConnectionAnchor anchor) {
 			super.anchorMoved(anchor);
 			count++;
@@ -67,6 +68,7 @@ public class AnchorNotificationTest extends Assert {
 	private LocalCoordinates nestedCoordinates;
 
 	public class LocalCoordinates extends Figure {
+		@Override
 		protected boolean useLocalCoordinates() {
 			return true;
 		}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
@@ -25,6 +25,7 @@ public class ColorConstantTest extends Assert {
 		result[1] = Boolean.FALSE;
 
 		Thread testThread = new Thread() {
+			@Override
 			public void run() {
 				try {
 					Class.forName("org.eclipse.draw2d.ColorConstants");

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/DimensionTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/DimensionTests.java
@@ -6,13 +6,14 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Alexander Ny�en (itemis AG) - initial API and implementation
+ *     Alexander Nyßen (itemis AG) - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
+import org.eclipse.swt.graphics.Image;
+
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
-import org.eclipse.swt.graphics.Image;
 
 import org.junit.Test;
 

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LayerTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LayerTest.java
@@ -47,6 +47,7 @@ public class LayerTest extends Assert {
 
 	public class MyLayer extends Layer {
 
+		@Override
 		protected boolean useLocalCoordinates() {
 			return true;
 		}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShapeTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ShapeTest.java
@@ -26,10 +26,12 @@ public class ShapeTest extends Assert {
 		attributes.style = SWT.LINE_DASHDOT;
 		Shape shape = new Shape() {
 
+			@Override
 			protected void fillShape(Graphics graphics) {
 				// NOTHING TO DO
 			}
 
+			@Override
 			protected void outlineShape(Graphics graphics) {
 				// NOTHING TO DO
 			}
@@ -44,10 +46,12 @@ public class ShapeTest extends Assert {
 		LineAttributes attributes = new LineAttributes(4);
 		Shape shape = new Shape() {
 
+			@Override
 			protected void fillShape(Graphics graphics) {
 				// NOTHING TO DO
 			}
 
+			@Override
 			protected void outlineShape(Graphics graphics) {
 				// NOTHING TO DO
 			}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ThumbnailTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ThumbnailTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 public class ThumbnailTest extends Assert {
 
 	class TestThumbnail extends Thumbnail {
+		@Override
 		public Image getThumbnailImage() {
 			return super.getThumbnailImage();
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbsoluteBendpoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbsoluteBendpoint.java
@@ -42,6 +42,7 @@ public class AbsoluteBendpoint extends Point implements Bendpoint {
 	/**
 	 * @see org.eclipse.draw2d.Bendpoint#getLocation()
 	 */
+	@Override
 	public Point getLocation() {
 		return this;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractBackground.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractBackground.java
@@ -28,6 +28,7 @@ public class AbstractBackground extends AbstractBorder {
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return IFigure.NO_INSETS;
 	}
@@ -36,6 +37,7 @@ public class AbstractBackground extends AbstractBorder {
 	 * {@inheritDoc} By default, this method is stubbed out for backgrounds which
 	 * only paint underneath a figure.
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractBorder.java
@@ -45,6 +45,7 @@ public abstract class AbstractBorder implements Border {
 	/**
 	 * @see org.eclipse.draw2d.Border#getPreferredSize(IFigure)
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure f) {
 		return EMPTY;
 	}
@@ -52,6 +53,7 @@ public abstract class AbstractBorder implements Border {
 	/**
 	 * @see org.eclipse.draw2d.Border#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return false;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractConnectionAnchor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractConnectionAnchor.java
@@ -47,6 +47,7 @@ public abstract class AbstractConnectionAnchor extends ConnectionAnchorBase impl
 	 * @param listener Listener to be added
 	 * @see #removeAnchorListener(AnchorListener)
 	 */
+	@Override
 	public void addAnchorListener(AnchorListener listener) {
 		if (listener == null)
 			return;
@@ -62,6 +63,7 @@ public abstract class AbstractConnectionAnchor extends ConnectionAnchorBase impl
 	 * @param figure Anchor-owning Figure which has moved
 	 * @see org.eclipse.draw2d.AncestorListener#ancestorMoved(IFigure)
 	 */
+	@Override
 	public void ancestorMoved(IFigure figure) {
 		fireAnchorMoved();
 	}
@@ -69,12 +71,14 @@ public abstract class AbstractConnectionAnchor extends ConnectionAnchorBase impl
 	/**
 	 * @see org.eclipse.draw2d.AncestorListener#ancestorAdded(IFigure)
 	 */
+	@Override
 	public void ancestorAdded(IFigure ancestor) {
 	}
 
 	/**
 	 * @see org.eclipse.draw2d.AncestorListener#ancestorRemoved(IFigure)
 	 */
+	@Override
 	public void ancestorRemoved(IFigure ancestor) {
 	}
 
@@ -85,6 +89,7 @@ public abstract class AbstractConnectionAnchor extends ConnectionAnchorBase impl
 	 * @return Owner of this anchor
 	 * @see #setOwner(IFigure)
 	 */
+	@Override
 	public IFigure getOwner() {
 		return owner;
 	}
@@ -98,6 +103,7 @@ public abstract class AbstractConnectionAnchor extends ConnectionAnchorBase impl
 	 * @return The reference point of this anchor
 	 * @see org.eclipse.draw2d.ConnectionAnchor#getReferencePoint()
 	 */
+	@Override
 	public Point getReferencePoint() {
 		if (getOwner() == null)
 			return null;
@@ -116,6 +122,7 @@ public abstract class AbstractConnectionAnchor extends ConnectionAnchorBase impl
 	 * @param listener Listener to be removed from this anchors listeners list
 	 * @see #addAnchorListener(AnchorListener)
 	 */
+	@Override
 	public void removeAnchorListener(AnchorListener listener) {
 		super.removeAnchorListener(listener);
 		if (listeners.size() == 0)

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractHintLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractHintLayout.java
@@ -55,6 +55,7 @@ public abstract class AbstractHintLayout extends AbstractLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#getMinimumSize(IFigure, int, int)
 	 */
+	@Override
 	public Dimension getMinimumSize(IFigure container, int w, int h) {
 		boolean flush = cachedMinimumHint.width != w && isSensitiveHorizontally(container);
 		flush |= cachedMinimumHint.height != h && isSensitiveVertically(container);
@@ -71,6 +72,7 @@ public abstract class AbstractHintLayout extends AbstractLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#getPreferredSize(IFigure, int, int)
 	 */
+	@Override
 	public final Dimension getPreferredSize(IFigure container, int w, int h) {
 		boolean flush = cachedPreferredHint.width != w && isSensitiveHorizontally(container);
 		flush |= cachedPreferredHint.height != h && isSensitiveVertically(container);
@@ -87,6 +89,7 @@ public abstract class AbstractHintLayout extends AbstractLayout {
 	 * 
 	 * @see org.eclipse.draw2d.LayoutManager#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		minimumSize = null;
 		super.invalidate();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractImageFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractImageFigure.java
@@ -25,6 +25,7 @@ public abstract class AbstractImageFigure extends Figure implements IImageFigure
 
 	private List<ImageChangedListener> imageListeners = new ArrayList<>();
 
+	@Override
 	public final void addImageChangedListener(ImageChangedListener listener) {
 		if (listener == null) {
 			throw new IllegalArgumentException();
@@ -32,6 +33,7 @@ public abstract class AbstractImageFigure extends Figure implements IImageFigure
 		imageListeners.add(listener);
 	}
 
+	@Override
 	public final void removeImageChangedListener(ImageChangedListener listener) {
 		if (listener == null) {
 			throw new IllegalArgumentException();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractLabeledBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractLabeledBorder.java
@@ -79,6 +79,7 @@ public abstract class AbstractLabeledBorder extends AbstractBorder implements La
 	 * @param fig Figure used to calculate insets
 	 * @return The insets
 	 */
+	@Override
 	public Insets getInsets(IFigure fig) {
 		if (insets == null)
 			insets = calculateInsets(fig);
@@ -88,6 +89,7 @@ public abstract class AbstractLabeledBorder extends AbstractBorder implements La
 	/**
 	 * @see org.eclipse.draw2d.LabeledBorder#getLabel()
 	 */
+	@Override
 	public String getLabel() {
 		return label;
 	}
@@ -95,6 +97,7 @@ public abstract class AbstractLabeledBorder extends AbstractBorder implements La
 	/**
 	 * @see org.eclipse.draw2d.Border#getPreferredSize(IFigure)
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure fig) {
 		return new Dimension(getTextExtents(fig));
 	}
@@ -138,6 +141,7 @@ public abstract class AbstractLabeledBorder extends AbstractBorder implements La
 	 * 
 	 * @param font The font
 	 */
+	@Override
 	public void setFont(Font font) {
 		this.font = font;
 		invalidate();
@@ -146,6 +150,7 @@ public abstract class AbstractLabeledBorder extends AbstractBorder implements La
 	/**
 	 * @see org.eclipse.draw2d.LabeledBorder#setLabel(String)
 	 */
+	@Override
 	public void setLabel(String s) {
 		label = ((s == null) ? "" : s); //$NON-NLS-1$
 		invalidate();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractLayout.java
@@ -65,6 +65,7 @@ public abstract class AbstractLayout implements LayoutManager {
 	 * @param child The figure
 	 * @return The constraint
 	 */
+	@Override
 	public Object getConstraint(IFigure child) {
 		return null;
 	}
@@ -80,6 +81,7 @@ public abstract class AbstractLayout implements LayoutManager {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#getMinimumSize(IFigure, int, int)
 	 */
+	@Override
 	public Dimension getMinimumSize(IFigure container, int wHint, int hHint) {
 		return getPreferredSize(container, wHint, hHint);
 	}
@@ -94,6 +96,7 @@ public abstract class AbstractLayout implements LayoutManager {
 	 * @param hHint     The height hint
 	 * @return The preferred size
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure container, int wHint, int hHint) {
 		if (preferredSize == null)
 			preferredSize = calculatePreferredSize(container, wHint, hHint);
@@ -111,6 +114,7 @@ public abstract class AbstractLayout implements LayoutManager {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		preferredSize = null;
 	}
@@ -140,6 +144,7 @@ public abstract class AbstractLayout implements LayoutManager {
 	 * 
 	 * @param child The figure to remove
 	 */
+	@Override
 	public void remove(IFigure child) {
 		invalidate();
 	}
@@ -150,6 +155,7 @@ public abstract class AbstractLayout implements LayoutManager {
 	 * @param child      the child
 	 * @param constraint the child's new constraint
 	 */
+	@Override
 	public void setConstraint(IFigure child, Object constraint) {
 		invalidate(child);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractLocator.java
@@ -102,6 +102,7 @@ public abstract class AbstractLocator implements Locator {
 	 * 
 	 * @param target The figure to relocate
 	 */
+	@Override
 	public void relocate(IFigure target) {
 		Dimension prefSize = target.getPreferredSize();
 		Point center = getReferencePoint();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractPointListShape.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractPointListShape.java
@@ -25,6 +25,7 @@ public abstract class AbstractPointListShape extends Shape {
 	/**
 	 * @see org.eclipse.draw2d.IFigure#containsPoint(int, int)
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		if (!super.containsPoint(x, y)) {
 			return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractRouter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AbstractRouter.java
@@ -28,6 +28,7 @@ public abstract class AbstractRouter implements ConnectionRouter {
 	 * @return The constraint
 	 * @since 2.0
 	 */
+	@Override
 	public Object getConstraint(Connection connection) {
 		return null;
 	}
@@ -73,6 +74,7 @@ public abstract class AbstractRouter implements ConnectionRouter {
 	 * @param connection The connection to invalidate
 	 * @since 2.0
 	 */
+	@Override
 	public void invalidate(Connection connection) {
 	}
 
@@ -83,6 +85,7 @@ public abstract class AbstractRouter implements ConnectionRouter {
 	 * @param connection The connection to remove
 	 * @since 2.0
 	 */
+	@Override
 	public void remove(Connection connection) {
 	}
 
@@ -93,6 +96,7 @@ public abstract class AbstractRouter implements ConnectionRouter {
 	 * @param constraint The constraint
 	 * @since 2.0
 	 */
+	@Override
 	public void setConstraint(Connection connection, Object constraint) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AncestorHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AncestorHelper.java
@@ -83,6 +83,7 @@ class AncestorHelper implements PropertyChangeListener, FigureListener {
 	/**
 	 * @see org.eclipse.draw2d.FigureListener#figureMoved(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void figureMoved(IFigure ancestor) {
 		fireAncestorMoved(ancestor);
 	}
@@ -135,6 +136,7 @@ class AncestorHelper implements PropertyChangeListener, FigureListener {
 	/**
 	 * @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent)
 	 */
+	@Override
 	public void propertyChange(PropertyChangeEvent event) {
 		if (event.getPropertyName().equals("parent")) { //$NON-NLS-1$
 			IFigure oldParent = (IFigure) event.getOldValue();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AncestorListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AncestorListener.java
@@ -48,12 +48,15 @@ public interface AncestorListener {
 	 * An empty implementation of AncestorListener for convenience.
 	 */
 	class Stub implements AncestorListener {
+		@Override
 		public void ancestorMoved(IFigure ancestor) {
 		}
 
+		@Override
 		public void ancestorAdded(IFigure ancestor) {
 		}
 
+		@Override
 		public void ancestorRemoved(IFigure ancestor) {
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
@@ -53,11 +53,13 @@ public class Animation {
 			this.figure = figure;
 		}
 
+		@Override
 		public boolean equals(Object obj) {
 			AnimPair pair = (AnimPair) obj;
 			return pair.animator == animator && pair.figure == figure;
 		}
 
+		@Override
 		public int hashCode() {
 			return animator.hashCode() ^ figure.hashCode();
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ArrowButton.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ArrowButton.java
@@ -62,6 +62,7 @@ public class ArrowButton extends Button implements Orientable {
 	/**
 	 * @see org.eclipse.draw2d.Orientable#setDirection(int)
 	 */
+	@Override
 	public void setDirection(int value) {
 		setChildrenDirection(value);
 	}
@@ -69,6 +70,7 @@ public class ArrowButton extends Button implements Orientable {
 	/**
 	 * @see org.eclipse.draw2d.Orientable#setOrientation(int)
 	 */
+	@Override
 	public void setOrientation(int value) {
 		setChildrenOrientation(value);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ArrowLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ArrowLocator.java
@@ -39,6 +39,7 @@ public class ArrowLocator extends ConnectionLocator {
 	 * 
 	 * @param target The RotatableDecoration to relocate
 	 */
+	@Override
 	public void relocate(IFigure target) {
 		PointList points = getConnection().getPoints();
 		RotatableDecoration arrow = (RotatableDecoration) target;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AutomaticRouter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AutomaticRouter.java
@@ -41,6 +41,7 @@ public abstract class AutomaticRouter extends AbstractRouter {
 			anchor2 = conn.getTargetAnchor();
 		}
 
+		@Override
 		public boolean equals(Object object) {
 			boolean isEqual = false;
 			HashKey hashKey;
@@ -64,6 +65,7 @@ public abstract class AutomaticRouter extends AbstractRouter {
 			return anchor2;
 		}
 
+		@Override
 		public int hashCode() {
 			return anchor1.hashCode() ^ anchor2.hashCode();
 		}
@@ -124,6 +126,7 @@ public abstract class AutomaticRouter extends AbstractRouter {
 	/**
 	 * @see org.eclipse.draw2d.ConnectionRouter#remove(Connection)
 	 */
+	@Override
 	public void remove(Connection conn) {
 		if (conn.getSourceAnchor() == null || conn.getTargetAnchor() == null)
 			return;
@@ -145,6 +148,7 @@ public abstract class AutomaticRouter extends AbstractRouter {
 	 * 
 	 * @param conn The connection to route
 	 */
+	@Override
 	public void route(Connection conn) {
 		if (next() != null)
 			next().route(conn);
@@ -184,6 +188,7 @@ public abstract class AutomaticRouter extends AbstractRouter {
 	 * 
 	 * @see org.eclipse.draw2d.ConnectionRouter#setConstraint(Connection, Object)
 	 */
+	@Override
 	public void setConstraint(Connection connection, Object constraint) {
 		invalidate(connection);
 		if (next() != null)

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/BendpointConnectionRouter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/BendpointConnectionRouter.java
@@ -56,6 +56,7 @@ public class BendpointConnectionRouter extends AbstractRouter {
 	 * 
 	 * @param conn The connection to route
 	 */
+	@Override
 	public void route(Connection conn) {
 		PointList points = conn.getPoints();
 		points.removeAllPoints();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/BendpointLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/BendpointLocator.java
@@ -53,6 +53,7 @@ public class BendpointLocator extends ConnectionLocator {
 	 * @return The reference point
 	 * @since 2.0
 	 */
+	@Override
 	protected Point getReferencePoint() {
 		Point p = getConnection().getPoints().getPoint(Point.SINGLETON, getIndex());
 		getConnection().translateToAbsolute(p);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/BorderLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/BorderLayout.java
@@ -47,6 +47,7 @@ public class BorderLayout extends AbstractHintLayout {
 	 * @see org.eclipse.draw2d.AbstractHintLayout#calculateMinimumSize(IFigure, int,
 	 *      int)
 	 */
+	@Override
 	protected Dimension calculateMinimumSize(IFigure container, int wHint, int hHint) {
 		int minWHint = 0, minHHint = 0;
 		if (wHint < 0) {
@@ -107,6 +108,7 @@ public class BorderLayout extends AbstractHintLayout {
 	/**
 	 * @see AbstractLayout#calculatePreferredSize(IFigure, int, int)
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure figure, int wHint, int hHint) {
 		int minWHint = 0, minHHint = 0;
 		if (wHint < 0)
@@ -168,6 +170,7 @@ public class BorderLayout extends AbstractHintLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public void layout(IFigure container) {
 		Rectangle area = container.getClientArea();
 		Rectangle rect = new Rectangle();
@@ -220,6 +223,7 @@ public class BorderLayout extends AbstractHintLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractLayout#remove(IFigure)
 	 */
+	@Override
 	public void remove(IFigure child) {
 		if (center == child) {
 			center = null;
@@ -262,6 +266,7 @@ public class BorderLayout extends AbstractHintLayout {
 	 * 
 	 * @see org.eclipse.draw2d.AbstractLayout#setConstraint(IFigure, Object)
 	 */
+	@Override
 	public void setConstraint(IFigure child, Object constraint) {
 		remove(child);
 		super.setConstraint(child, constraint);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/BufferedGraphicsSource.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/BufferedGraphicsSource.java
@@ -41,6 +41,7 @@ class BufferedGraphicsSource implements GraphicsSource {
 	/**
 	 * @see org.eclipse.draw2d.GraphicsSource#flushGraphics(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public void flushGraphics(Rectangle region) {
 		if (inUse.isEmpty())
 			return;
@@ -76,6 +77,7 @@ class BufferedGraphicsSource implements GraphicsSource {
 	/**
 	 * @see org.eclipse.draw2d.GraphicsSource#getGraphics(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public Graphics getGraphics(Rectangle region) {
 		if (control == null || control.isDisposed())
 			return null;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Button.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Button.java
@@ -65,6 +65,7 @@ public class Button extends Clickable {
 	 * 
 	 * @since 2.0
 	 */
+	@Override
 	protected void init() {
 		super.init();
 		setBackgroundColor(ColorConstants.button);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ButtonBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ButtonBorder.java
@@ -103,6 +103,7 @@ public class ButtonBorder extends SchemeBorder {
 		 * @return The insets for this border
 		 * @since 2.0
 		 */
+		@Override
 		protected Insets calculateInsets() {
 			int br = 1 + Math.max(getShadow().length, getHighlightPressed().length);
 			int tl = Math.max(getHighlight().length, getShadowPressed().length);
@@ -127,6 +128,7 @@ public class ButtonBorder extends SchemeBorder {
 		 * @return The opaque state of this border
 		 * @since 2.0
 		 */
+		@Override
 		protected boolean calculateOpaque() {
 			if (!super.calculateOpaque())
 				return false;
@@ -218,6 +220,7 @@ public class ButtonBorder extends SchemeBorder {
 	 * @param graphics The graphics used for painting
 	 * @param insets   The insets
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 		Clickable clickable = (Clickable) figure;
 		ButtonModel model = clickable.getModel();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ButtonModel.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ButtonModel.java
@@ -467,6 +467,7 @@ public class ButtonModel {
 	}
 
 	class DefaultFiringBehavior extends ButtonStateTransitionListener {
+		@Override
 		public void released() {
 			fireActionPerformed();
 		}
@@ -479,6 +480,7 @@ public class ButtonModel {
 
 		protected Timer timer;
 
+		@Override
 		public void pressed() {
 			fireActionPerformed();
 			if (!isEnabled())
@@ -490,14 +492,17 @@ public class ButtonModel {
 			timer.scheduleAtFixedRate(runAction, INITIAL_DELAY, STEP_DELAY);
 		}
 
+		@Override
 		public void canceled() {
 			suspend();
 		}
 
+		@Override
 		public void released() {
 			suspend();
 		}
 
+		@Override
 		public void resume() {
 			timer = new Timer();
 
@@ -506,6 +511,7 @@ public class ButtonModel {
 			timer.scheduleAtFixedRate(runAction, STEP_DELAY, STEP_DELAY);
 		}
 
+		@Override
 		public void suspend() {
 			if (timer == null)
 				return;
@@ -522,8 +528,10 @@ public class ButtonModel {
 			this.timer = timer;
 		}
 
+		@Override
 		public void run() {
 			org.eclipse.swt.widgets.Display.getDefault().syncExec(new Runnable() {
+				@Override
 				public void run() {
 					if (!isEnabled())
 						timer.cancel();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/CheckBox.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/CheckBox.java
@@ -75,9 +75,11 @@ public final class CheckBox extends Toggle {
 	 * 
 	 * @since 2.0
 	 */
+	@Override
 	protected void init() {
 		super.init();
 		addChangeListener(new ChangeListener() {
+			@Override
 			public void handleStateChanged(ChangeEvent changeEvent) {
 				if (changeEvent.getPropertyName().equals(ButtonModel.SELECTED_PROPERTY))
 					handleSelectionChanged();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ChopboxAnchor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ChopboxAnchor.java
@@ -45,6 +45,7 @@ public class ChopboxAnchor extends AbstractConnectionAnchor {
 	 * @param reference The reference point
 	 * @return The anchor location
 	 */
+	@Override
 	public Point getLocation(Point reference) {
 		Rectangle r = Rectangle.SINGLETON;
 		r.setBounds(getBox());
@@ -91,6 +92,7 @@ public class ChopboxAnchor extends AbstractConnectionAnchor {
 	 * 
 	 * @return The reference point
 	 */
+	@Override
 	public Point getReferencePoint() {
 		Point ref = getBox().getCenter();
 		getOwner().translateToAbsolute(ref);
@@ -103,6 +105,7 @@ public class ChopboxAnchor extends AbstractConnectionAnchor {
 	 * @param obj the other anchor
 	 * @return <code>true</code> if equal
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof ChopboxAnchor) {
 			ChopboxAnchor other = (ChopboxAnchor) obj;
@@ -117,6 +120,7 @@ public class ChopboxAnchor extends AbstractConnectionAnchor {
 	 * 
 	 * @return the hash code.
 	 */
+	@Override
 	public int hashCode() {
 		if (getOwner() != null)
 			return getOwner().hashCode();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Clickable.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Clickable.java
@@ -162,10 +162,12 @@ public class Clickable extends Figure {
 	 */
 	protected ModelObserver createModelObserver() {
 		return new ModelObserver() {
+			@Override
 			public void actionPerformed(ActionEvent action) {
 				fireActionPerformed();
 			}
 
+			@Override
 			public void handleStateChanged(ChangeEvent change) {
 				fireStateChanged(change);
 			}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ClickableEventHandler.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ClickableEventHandler.java
@@ -15,6 +15,7 @@ class ClickableEventHandler extends MouseMotionListener.Stub
 
 	private MouseEvent lastEvent;
 
+	@Override
 	public void focusLost(FocusEvent fe) {
 		Clickable loser = (Clickable) fe.loser;
 		loser.repaint();
@@ -22,17 +23,20 @@ class ClickableEventHandler extends MouseMotionListener.Stub
 		loser.getModel().setPressed(false);
 	}
 
+	@Override
 	public void focusGained(FocusEvent fe) {
 		Clickable clickable = (Clickable) fe.gainer;
 		clickable.repaint();
 	}
 
+	@Override
 	public void figureMoved(IFigure source) {
 		if (lastEvent == null)
 			return;
 		mouseDragged(lastEvent);
 	}
 
+	@Override
 	public void handleStateChanged(ChangeEvent change) {
 		Clickable clickable = (Clickable) change.getSource();
 		if (change.getPropertyName() == ButtonModel.MOUSEOVER_PROPERTY && !clickable.isRolloverEnabled())
@@ -40,9 +44,11 @@ class ClickableEventHandler extends MouseMotionListener.Stub
 		clickable.repaint();
 	}
 
+	@Override
 	public void mouseDoubleClicked(MouseEvent me) {
 	}
 
+	@Override
 	public void mouseDragged(MouseEvent me) {
 		lastEvent = me;
 		Clickable click = (Clickable) me.getSource();
@@ -54,21 +60,25 @@ class ClickableEventHandler extends MouseMotionListener.Stub
 		}
 	}
 
+	@Override
 	public void mouseEntered(MouseEvent me) {
 		Clickable click = (Clickable) me.getSource();
 		click.getModel().setMouseOver(true);
 		click.addFigureListener(this);
 	}
 
+	@Override
 	public void mouseExited(MouseEvent me) {
 		Clickable click = (Clickable) me.getSource();
 		click.getModel().setMouseOver(false);
 		click.removeFigureListener(this);
 	}
 
+	@Override
 	public void mouseMoved(MouseEvent me) {
 	}
 
+	@Override
 	public void mousePressed(MouseEvent me) {
 		if (me.button != 1)
 			return;
@@ -81,6 +91,7 @@ class ClickableEventHandler extends MouseMotionListener.Stub
 		me.consume();
 	}
 
+	@Override
 	public void mouseReleased(MouseEvent me) {
 		if (me.button != 1)
 			return;
@@ -92,6 +103,7 @@ class ClickableEventHandler extends MouseMotionListener.Stub
 		me.consume();
 	}
 
+	@Override
 	public void keyPressed(KeyEvent ke) {
 		ButtonModel model = ((Clickable) ke.getSource()).getModel();
 		if (ke.character == ' ' || ke.character == '\r') {
@@ -100,6 +112,7 @@ class ClickableEventHandler extends MouseMotionListener.Stub
 		}
 	}
 
+	@Override
 	public void keyReleased(KeyEvent ke) {
 		ButtonModel model = ((Clickable) ke.getSource()).getModel();
 		if (ke.character == ' ' || ke.character == '\r') {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
@@ -32,6 +32,7 @@ public interface ColorConstants {
 			display = Display.getDefault();
 			final Color result[] = new Color[1];
 			display.syncExec(new Runnable() {
+				@Override
 				public void run() {
 					synchronized (result) {
 						result[0] = Display.getCurrent().getSystemColor(which);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/CompoundBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/CompoundBorder.java
@@ -63,6 +63,7 @@ public class CompoundBorder extends AbstractBorder {
 	 * @return The total insets for this border
 	 * @since 2.0
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		Insets insets = null;
 		if (inner != null)
@@ -79,6 +80,7 @@ public class CompoundBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#getPreferredSize(IFigure)
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure fig) {
 		Dimension prefSize = new Dimension(inner.getPreferredSize(fig));
 		Insets outerInsets = outer.getInsets(fig);
@@ -105,6 +107,7 @@ public class CompoundBorder extends AbstractBorder {
 	 * 
 	 * @return <code>true</code> if this border is opaque
 	 */
+	@Override
 	public boolean isOpaque() {
 		return ((inner != null) ? inner.isOpaque() : false) && ((outer != null) ? outer.isOpaque() : false);
 	}
@@ -112,6 +115,7 @@ public class CompoundBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics g, Insets insets) {
 		if (outer != null) {
 			g.pushState();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionAnchorBase.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionAnchorBase.java
@@ -28,6 +28,7 @@ public abstract class ConnectionAnchorBase implements ConnectionAnchor {
 	/**
 	 * @see org.eclipse.draw2d.ConnectionAnchor#addAnchorListener(AnchorListener)
 	 */
+	@Override
 	public void addAnchorListener(AnchorListener listener) {
 		listeners.add(listener);
 	}
@@ -35,6 +36,7 @@ public abstract class ConnectionAnchorBase implements ConnectionAnchor {
 	/**
 	 * @see org.eclipse.draw2d.ConnectionAnchor#removeAnchorListener(AnchorListener)
 	 */
+	@Override
 	public void removeAnchorListener(AnchorListener listener) {
 		listeners.remove(listener);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionEndpointLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionEndpointLocator.java
@@ -188,6 +188,7 @@ public class ConnectionEndpointLocator implements Locator {
 	 * 
 	 * @param figure The figure to relocate
 	 */
+	@Override
 	public void relocate(IFigure figure) {
 		Connection conn = getConnection();
 		Point startPoint = Point.SINGLETON;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionLayer.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionLayer.java
@@ -36,6 +36,7 @@ public class ConnectionLayer extends FreeformLayer {
 	 * @param index      Index where the figure is to be added
 	 * @since 2.0
 	 */
+	@Override
 	public void add(IFigure figure, Object constraint, int index) {
 		super.add(figure, constraint, index);
 
@@ -58,6 +59,7 @@ public class ConnectionLayer extends FreeformLayer {
 	/**
 	 * @see IFigure#paint(Graphics)
 	 */
+	@Override
 	public void paint(Graphics graphics) {
 		if (antialias != SWT.DEFAULT)
 			graphics.setAntialias(antialias);
@@ -70,6 +72,7 @@ public class ConnectionLayer extends FreeformLayer {
 	 * 
 	 * @param figure The figure to remove
 	 */
+	@Override
 	public void remove(IFigure figure) {
 		if (figure instanceof Connection)
 			((Connection) figure).setConnectionRouter(null);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionLocator.java
@@ -94,6 +94,7 @@ public class ConnectionLocator extends AbstractLocator {
 	 * @return The reference point
 	 * @since 2.0
 	 */
+	@Override
 	protected Point getReferencePoint() {
 		Point p = getLocation(getConnection().getPoints());
 		getConnection().translateToAbsolute(p);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionRouter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionRouter.java
@@ -77,6 +77,7 @@ public interface ConnectionRouter {
 		 * 
 		 * @param conn the connection to be routed
 		 */
+		@Override
 		public void route(Connection conn) {
 			PointList points = conn.getPoints();
 			points.removeAllPoints();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/DefaultRangeModel.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/DefaultRangeModel.java
@@ -41,6 +41,7 @@ public class DefaultRangeModel implements RangeModel {
 	 * @param listener the listener to be added
 	 * @since 2.0
 	 */
+	@Override
 	public void addPropertyChangeListener(PropertyChangeListener listener) {
 		propertyListeners.addPropertyChangeListener(listener);
 	}
@@ -61,6 +62,7 @@ public class DefaultRangeModel implements RangeModel {
 	/**
 	 * @return the extent
 	 */
+	@Override
 	public int getExtent() {
 		return extent;
 	}
@@ -68,6 +70,7 @@ public class DefaultRangeModel implements RangeModel {
 	/**
 	 * @return the maximum value
 	 */
+	@Override
 	public int getMaximum() {
 		return maximum;
 	}
@@ -75,6 +78,7 @@ public class DefaultRangeModel implements RangeModel {
 	/**
 	 * @return the minimum value
 	 */
+	@Override
 	public int getMinimum() {
 		return minimum;
 	}
@@ -82,6 +86,7 @@ public class DefaultRangeModel implements RangeModel {
 	/**
 	 * @return the current value
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -89,6 +94,7 @@ public class DefaultRangeModel implements RangeModel {
 	/**
 	 * @return whether the extent is between the minimum and maximum values
 	 */
+	@Override
 	public boolean isEnabled() {
 		return (getMaximum() - getMinimum()) > getExtent();
 	}
@@ -98,6 +104,7 @@ public class DefaultRangeModel implements RangeModel {
 	 * 
 	 * @param listener the listener to be removed
 	 */
+	@Override
 	public void removePropertyChangeListener(PropertyChangeListener listener) {
 		propertyListeners.removePropertyChangeListener(listener);
 	}
@@ -105,6 +112,7 @@ public class DefaultRangeModel implements RangeModel {
 	/**
 	 * @see org.eclipse.draw2d.RangeModel#setAll(int, int, int)
 	 */
+	@Override
 	public void setAll(int min, int ext, int max) {
 		int oldMin = minimum;
 		int oldExtent = extent;
@@ -127,6 +135,7 @@ public class DefaultRangeModel implements RangeModel {
 	 * 
 	 * @param extent the new extent value
 	 */
+	@Override
 	public void setExtent(int extent) {
 		if (this.extent == extent)
 			return;
@@ -142,6 +151,7 @@ public class DefaultRangeModel implements RangeModel {
 	 * 
 	 * @param maximum the new maximum value
 	 */
+	@Override
 	public void setMaximum(int maximum) {
 		if (this.maximum == maximum)
 			return;
@@ -157,6 +167,7 @@ public class DefaultRangeModel implements RangeModel {
 	 * 
 	 * @param minimum the new minumum value
 	 */
+	@Override
 	public void setMinimum(int minimum) {
 		if (this.minimum == minimum)
 			return;
@@ -174,6 +185,7 @@ public class DefaultRangeModel implements RangeModel {
 	 * 
 	 * @param value the new value
 	 */
+	@Override
 	public void setValue(int value) {
 		value = Math.max(getMinimum(), Math.min(getMaximum() - getExtent(), value));
 		if (this.value == value)
@@ -186,6 +198,7 @@ public class DefaultRangeModel implements RangeModel {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return super.toString() + " (" + minimum + ", " + maximum //$NON-NLS-2$ //$NON-NLS-1$
 				+ ", " + extent + ", " + value + ")"; //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/DeferredUpdateManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/DeferredUpdateManager.java
@@ -40,6 +40,7 @@ public class DeferredUpdateManager extends UpdateManager {
 		/**
 		 * Calls {@link DeferredUpdateManager#performUpdate()}.
 		 */
+		@Override
 		public void run() {
 			performUpdate();
 		}
@@ -99,6 +100,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	 * @param w      the width of the dirty region
 	 * @param h      the height of the dirty region
 	 */
+	@Override
 	public synchronized void addDirtyRegion(IFigure figure, int x, int y, int w, int h) {
 		if (w == 0 || h == 0 || !figure.isShowing())
 			return;
@@ -119,6 +121,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	 * 
 	 * @param f the invalid figure
 	 */
+	@Override
 	public synchronized void addInvalidFigure(IFigure f) {
 		if (invalidFigures.contains(f))
 			return;
@@ -141,6 +144,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	/**
 	 * @since 3.10
 	 */
+	@Override
 	protected void paint(GC gc) {
 		if (!validating) {
 			SWTGraphics graphics = new SWTGraphics(gc);
@@ -174,6 +178,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	 * @see #validateFigures()
 	 * @see #repairDamage()
 	 */
+	@Override
 	public synchronized void performUpdate() {
 		if (isDisposed() || updating)
 			return;
@@ -197,6 +202,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	/**
 	 * @see UpdateManager#performValidation()
 	 */
+	@Override
 	public synchronized void performValidation() {
 		if (invalidFigures.isEmpty() || validating)
 			return;
@@ -221,6 +227,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	 * 
 	 * @param exposed the exposed region
 	 */
+	@Override
 	public synchronized void performUpdate(Rectangle exposed) {
 		addDirtyRegion(root, exposed);
 		performUpdate();
@@ -304,6 +311,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	 * 
 	 * @param runnable the runnable
 	 */
+	@Override
 	public synchronized void runWithUpdate(Runnable runnable) {
 		afterUpdate = new RunnableChain(runnable, afterUpdate);
 		if (!updating)
@@ -315,6 +323,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	 * 
 	 * @param gs the graphics source
 	 */
+	@Override
 	public void setGraphicsSource(GraphicsSource gs) {
 		graphicsSource = gs;
 	}
@@ -324,6 +333,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	 * 
 	 * @param figure the root figure
 	 */
+	@Override
 	public void setRoot(IFigure figure) {
 		root = figure;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/DelegatingLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/DelegatingLayout.java
@@ -36,6 +36,7 @@ public class DelegatingLayout extends AbstractLayout {
 	 * @return the preferred size
 	 * @since 2.0
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure parent, int wHint, int hHint) {
 		Dimension d = new Dimension();
 		parent.getChildren().forEach(child -> d.union(child.getPreferredSize()));
@@ -56,6 +57,7 @@ public class DelegatingLayout extends AbstractLayout {
 	 * 
 	 * @param parent the figure whose children should be layed out
 	 */
+	@Override
 	public void layout(IFigure parent) {
 		for (IFigure child : parent.getChildren()) {
 			Locator locator = (Locator) constraints.get(child);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Ellipse.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Ellipse.java
@@ -33,6 +33,7 @@ public class Ellipse extends Shape {
 	 * @param y the y coordinate
 	 * @return <code>true</code>if the given point is contained
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		if (!super.containsPoint(x, y)) {
 			return false;
@@ -49,6 +50,7 @@ public class Ellipse extends Shape {
 	 * 
 	 * @see org.eclipse.draw2d.Shape#fillShape(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	protected void fillShape(Graphics graphics) {
 		graphics.fillOval(getOptimizedBounds());
 	}
@@ -58,6 +60,7 @@ public class Ellipse extends Shape {
 	 * 
 	 * @see org.eclipse.draw2d.Shape#outlineShape(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	protected void outlineShape(Graphics graphics) {
 		graphics.drawOval(getOptimizedBounds());
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/EllipseAnchor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/EllipseAnchor.java
@@ -40,6 +40,7 @@ public class EllipseAnchor extends AbstractConnectionAnchor {
 	 * 
 	 * @see org.eclipse.draw2d.ConnectionAnchor#getLocation(Point)
 	 */
+	@Override
 	public Point getLocation(Point reference) {
 		Rectangle r = Rectangle.SINGLETON;
 		r.setBounds(getOwner().getBounds());
@@ -73,6 +74,7 @@ public class EllipseAnchor extends AbstractConnectionAnchor {
 	 * @param o the other anchor
 	 * @return <code>true</code> if equal
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (o instanceof EllipseAnchor) {
 			EllipseAnchor other = (EllipseAnchor) o;
@@ -87,6 +89,7 @@ public class EllipseAnchor extends AbstractConnectionAnchor {
 	 * 
 	 * @return the hash code.
 	 */
+	@Override
 	public int hashCode() {
 		if (getOwner() != null)
 			return getOwner().hashCode();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/EventDispatcher.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/EventDispatcher.java
@@ -33,6 +33,7 @@ public abstract class EventDispatcher {
 	 */
 	public abstract static class AccessibilityDispatcher implements AccessibleControlListener, AccessibleListener {
 		/** @see AccessibleControlListener#getChild(AccessibleControlEvent) */
+		@Override
 		public void getChild(AccessibleControlEvent e) {
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/EventListenerList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/EventListenerList.java
@@ -65,6 +65,7 @@ public final class EventListenerList {
 			this.type = type;
 		}
 
+		@Override
 		public T next() {
 			@SuppressWarnings("unchecked") // check is performed in hasNext
 			T result = (T) items[index + 1];
@@ -72,6 +73,7 @@ public final class EventListenerList {
 			return result;
 		}
 
+		@Override
 		public boolean hasNext() {
 			if (items == null)
 				return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ExclusionSearch.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ExclusionSearch.java
@@ -35,6 +35,7 @@ public class ExclusionSearch implements TreeSearch {
 	/**
 	 * @see org.eclipse.draw2d.TreeSearch#accept(IFigure)
 	 */
+	@Override
 	public boolean accept(IFigure figure) {
 		// Prune is called before accept, so there is no reason to check the
 		// collection again.
@@ -46,6 +47,7 @@ public class ExclusionSearch implements TreeSearch {
 	 * 
 	 * @see org.eclipse.draw2d.TreeSearch#prune(IFigure)
 	 */
+	@Override
 	public boolean prune(IFigure f) {
 		return c.contains(f);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FanRouter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FanRouter.java
@@ -40,6 +40,7 @@ public class FanRouter extends AutomaticRouter {
 	 * @param points the colliding points
 	 * @param index  the index
 	 */
+	@Override
 	protected void handleCollision(PointList points, int index) {
 		Point start = points.getFirstPoint();
 		Point end = points.getLastPoint();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -423,6 +423,7 @@ public class Figure implements IFigure {
 	 * @param y The Y coordinate
 	 * @return The deepest descendant for which isMouseEventTarget() returns true
 	 */
+	@Override
 	public IFigure findMouseEventTargetAt(int x, int y) {
 		if (!containsPoint(x, y))
 			return null;
@@ -1002,6 +1003,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#internalGetEventDispatcher()
 	 */
+	@Override
 	public EventDispatcher internalGetEventDispatcher() {
 		if (getParent() != null)
 			return getParent().internalGetEventDispatcher();
@@ -1011,6 +1013,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#intersects(Rectangle)
 	 */
+	@Override
 	public boolean intersects(Rectangle rect) {
 		return getBounds().intersects(rect);
 	}
@@ -1018,6 +1021,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		if (layoutManager != null)
 			layoutManager.invalidate();
@@ -1027,6 +1031,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#invalidateTree()
 	 */
+	@Override
 	public void invalidateTree() {
 		invalidate();
 		for (Iterator iter = children.iterator(); iter.hasNext();) {
@@ -1038,6 +1043,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#isCoordinateSystem()
 	 */
+	@Override
 	public boolean isCoordinateSystem() {
 		return useLocalCoordinates();
 	}
@@ -1045,6 +1051,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#isEnabled()
 	 */
+	@Override
 	public boolean isEnabled() {
 		return (flags & FLAG_ENABLED) != 0;
 	}
@@ -1052,6 +1059,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#isFocusTraversable()
 	 */
+	@Override
 	public boolean isFocusTraversable() {
 		return (flags & FLAG_FOCUS_TRAVERSABLE) != 0;
 	}
@@ -1072,6 +1080,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see org.eclipse.draw2d.IFigure#isMirrored()
 	 */
+	@Override
 	public boolean isMirrored() {
 		if (getParent() != null)
 			return getParent().isMirrored();
@@ -1081,6 +1090,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return (flags & FLAG_OPAQUE) != 0;
 	}
@@ -1088,6 +1098,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#isRequestFocusEnabled()
 	 */
+	@Override
 	public boolean isRequestFocusEnabled() {
 		return (flags & FLAG_FOCUSABLE) != 0;
 	}
@@ -1095,6 +1106,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#isShowing()
 	 */
+	@Override
 	public boolean isShowing() {
 		return isVisible() && (getParent() == null || getParent().isShowing());
 	}
@@ -1124,6 +1136,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#isVisible()
 	 */
+	@Override
 	public boolean isVisible() {
 		return getFlag(FLAG_VISIBLE);
 	}
@@ -1146,6 +1159,7 @@ public class Figure implements IFigure {
 	 * @see #paintClientArea(Graphics)
 	 * @see #paintBorder(Graphics)
 	 */
+	@Override
 	public void paint(Graphics graphics) {
 		if (getLocalBackgroundColor() != null)
 			graphics.setBackgroundColor(getLocalBackgroundColor());
@@ -1295,6 +1309,7 @@ public class Figure implements IFigure {
 	 * 
 	 * @param figure The Figure to remove
 	 */
+	@Override
 	public void remove(IFigure figure) {
 		if ((figure.getParent() != this))
 			throw new IllegalArgumentException("Figure is not a child"); //$NON-NLS-1$
@@ -1325,6 +1340,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removeAncestorListener(AncestorListener)
 	 */
+	@Override
 	public void removeAncestorListener(AncestorListener listener) {
 		if (ancestorHelper != null) {
 			ancestorHelper.removeAncestorListener(listener);
@@ -1338,6 +1354,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removeCoordinateListener(CoordinateListener)
 	 */
+	@Override
 	public void removeCoordinateListener(CoordinateListener listener) {
 		eventListeners.removeListener(CoordinateListener.class, listener);
 	}
@@ -1345,6 +1362,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removeFigureListener(FigureListener)
 	 */
+	@Override
 	public void removeFigureListener(FigureListener listener) {
 		eventListeners.removeListener(FigureListener.class, listener);
 	}
@@ -1352,6 +1370,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removeFocusListener(FocusListener)
 	 */
+	@Override
 	public void removeFocusListener(FocusListener listener) {
 		eventListeners.removeListener(FocusListener.class, listener);
 	}
@@ -1359,6 +1378,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removeKeyListener(KeyListener)
 	 */
+	@Override
 	public void removeKeyListener(KeyListener listener) {
 		eventListeners.removeListener(KeyListener.class, listener);
 	}
@@ -1369,6 +1389,7 @@ public class Figure implements IFigure {
 	 * @since 3.1
 	 * @param listener the listener being removed
 	 */
+	@Override
 	public void removeLayoutListener(LayoutListener listener) {
 		if (layoutManager instanceof LayoutNotifier) {
 			LayoutNotifier notifier = (LayoutNotifier) layoutManager;
@@ -1395,6 +1416,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removeMouseListener(MouseListener)
 	 */
+	@Override
 	public void removeMouseListener(MouseListener listener) {
 		eventListeners.removeListener(MouseListener.class, listener);
 	}
@@ -1402,6 +1424,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removeMouseMotionListener(MouseMotionListener)
 	 */
+	@Override
 	public void removeMouseMotionListener(MouseMotionListener listener) {
 		eventListeners.removeListener(MouseMotionListener.class, listener);
 	}
@@ -1409,6 +1432,7 @@ public class Figure implements IFigure {
 	/**
 	 * Called prior to this figure's removal from its parent
 	 */
+	@Override
 	public void removeNotify() {
 		children.forEach(IFigure::removeNotify);
 		if (internalGetEventDispatcher() != null)
@@ -1419,6 +1443,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removePropertyChangeListener(PropertyChangeListener)
 	 */
+	@Override
 	public void removePropertyChangeListener(PropertyChangeListener listener) {
 		if (propertyListeners == null)
 			return;
@@ -1428,6 +1453,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#removePropertyChangeListener(String, PropertyChangeListener)
 	 */
+	@Override
 	public void removePropertyChangeListener(String property, PropertyChangeListener listener) {
 		if (propertyListeners == null)
 			return;
@@ -1437,6 +1463,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#repaint(Rectangle)
 	 */
+	@Override
 	public final void repaint(Rectangle rect) {
 		repaint(rect.x, rect.y, rect.width, rect.height);
 	}
@@ -1444,6 +1471,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#repaint(int, int, int, int)
 	 */
+	@Override
 	public void repaint(int x, int y, int w, int h) {
 		if (isVisible())
 			getUpdateManager().addDirtyRegion(this, x, y, w, h);
@@ -1452,6 +1480,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#repaint()
 	 */
+	@Override
 	public void repaint() {
 		repaint(getBounds());
 	}
@@ -1459,6 +1488,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#requestFocus()
 	 */
+	@Override
 	public final void requestFocus() {
 		if (!isRequestFocusEnabled() || hasFocus())
 			return;
@@ -1471,6 +1501,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#revalidate()
 	 */
+	@Override
 	public void revalidate() {
 		invalidate();
 		if (getParent() == null || isValidationRoot())
@@ -1482,6 +1513,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setBackgroundColor(Color)
 	 */
+	@Override
 	public void setBackgroundColor(Color bg) {
 		// Set background color to bg unless in high contrast mode.
 		// In that case, get the color from system
@@ -1506,6 +1538,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setBorder(Border)
 	 */
+	@Override
 	public void setBorder(Border border) {
 		this.border = border;
 		revalidate();
@@ -1524,6 +1557,7 @@ public class Figure implements IFigure {
 	 * @param rect The new bounds
 	 * @since 2.0
 	 */
+	@Override
 	public void setBounds(Rectangle rect) {
 		int x = bounds.x, y = bounds.y;
 
@@ -1593,6 +1627,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setConstraint(IFigure, Object)
 	 */
+	@Override
 	public void setConstraint(IFigure child, Object constraint) {
 		if (child.getParent() != this)
 			throw new IllegalArgumentException("Figure must be a child"); //$NON-NLS-1$
@@ -1609,6 +1644,7 @@ public class Figure implements IFigure {
 	 * @param clippingStrategy
 	 * @since 3.6
 	 */
+	@Override
 	public void setClippingStrategy(IClippingStrategy clippingStrategy) {
 		this.clippingStrategy = clippingStrategy;
 	}
@@ -1616,6 +1652,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setCursor(Cursor)
 	 */
+	@Override
 	public void setCursor(Cursor cursor) {
 		if (this.cursor == cursor)
 			return;
@@ -1628,6 +1665,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setEnabled(boolean)
 	 */
+	@Override
 	public void setEnabled(boolean value) {
 		if (isEnabled() == value)
 			return;
@@ -1651,6 +1689,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setFocusTraversable(boolean)
 	 */
+	@Override
 	public void setFocusTraversable(boolean focusTraversable) {
 		if (isFocusTraversable() == focusTraversable)
 			return;
@@ -1660,6 +1699,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setFont(Font)
 	 */
+	@Override
 	public void setFont(Font f) {
 		if (font != f) {
 			font = f;
@@ -1671,6 +1711,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setForegroundColor(Color)
 	 */
+	@Override
 	public void setForegroundColor(Color fg) {
 		// Set foreground color to fg unless in high contrast mode.
 		// In that case, get the color from system
@@ -1695,6 +1736,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setLayoutManager(LayoutManager)
 	 */
+	@Override
 	public void setLayoutManager(LayoutManager manager) {
 		if (layoutManager instanceof LayoutNotifier)
 			((LayoutNotifier) layoutManager).realLayout = manager;
@@ -1706,6 +1748,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setLocation(Point)
 	 */
+	@Override
 	public void setLocation(Point p) {
 		if (getLocation().equals(p))
 			return;
@@ -1717,6 +1760,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setMaximumSize(Dimension)
 	 */
+	@Override
 	public void setMaximumSize(Dimension d) {
 		if (maxSize != null && maxSize.equals(d))
 			return;
@@ -1727,6 +1771,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setMinimumSize(Dimension)
 	 */
+	@Override
 	public void setMinimumSize(Dimension d) {
 		if (minSize != null && minSize.equals(d))
 			return;
@@ -1737,6 +1782,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setOpaque(boolean)
 	 */
+	@Override
 	public void setOpaque(boolean opaque) {
 		if (isOpaque() == opaque)
 			return;
@@ -1747,6 +1793,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setParent(IFigure)
 	 */
+	@Override
 	public void setParent(IFigure p) {
 		IFigure oldParent = parent;
 		parent = p;
@@ -1756,6 +1803,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setPreferredSize(Dimension)
 	 */
+	@Override
 	public void setPreferredSize(Dimension size) {
 		if (prefSize != null && prefSize.equals(size))
 			return;
@@ -1778,6 +1826,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setRequestFocusEnabled(boolean)
 	 */
+	@Override
 	public void setRequestFocusEnabled(boolean requestFocusEnabled) {
 		if (isRequestFocusEnabled() == requestFocusEnabled)
 			return;
@@ -1787,6 +1836,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setSize(Dimension)
 	 */
+	@Override
 	public final void setSize(Dimension d) {
 		setSize(d.width, d.height);
 	}
@@ -1794,6 +1844,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setSize(int, int)
 	 */
+	@Override
 	public void setSize(int w, int h) {
 		Rectangle bounds = getBounds();
 		if (bounds.width == w && bounds.height == h)
@@ -1806,6 +1857,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setToolTip(IFigure)
 	 */
+	@Override
 	public void setToolTip(IFigure f) {
 		if (toolTip == f)
 			return;
@@ -1826,6 +1878,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#setVisible(boolean)
 	 */
+	@Override
 	public void setVisible(boolean visible) {
 		boolean currentVisibility = isVisible();
 		if (visible == currentVisibility)
@@ -1841,6 +1894,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#translate(int, int)
 	 */
+	@Override
 	public final void translate(int x, int y) {
 		primTranslate(x, y);
 		fireFigureMoved();
@@ -1849,6 +1903,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#translateFromParent(Translatable)
 	 */
+	@Override
 	public void translateFromParent(Translatable t) {
 		if (useLocalCoordinates())
 			t.performTranslate(-getBounds().x - getInsets().left, -getBounds().y - getInsets().top);
@@ -1857,6 +1912,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#translateToAbsolute(Translatable)
 	 */
+	@Override
 	public final void translateToAbsolute(Translatable t) {
 		if (getParent() != null) {
 			getParent().translateToParent(t);
@@ -1867,6 +1923,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#translateToParent(Translatable)
 	 */
+	@Override
 	public void translateToParent(Translatable t) {
 		if (useLocalCoordinates())
 			t.performTranslate(getBounds().x + getInsets().left, getBounds().y + getInsets().top);
@@ -1875,6 +1932,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#translateToRelative(Translatable)
 	 */
+	@Override
 	public final void translateToRelative(Translatable t) {
 		if (getParent() != null) {
 			getParent().translateToRelative(t);
@@ -1896,6 +1954,7 @@ public class Figure implements IFigure {
 	/**
 	 * @see IFigure#validate()
 	 */
+	@Override
 	public void validate() {
 		if (isValid())
 			return;
@@ -1921,6 +1980,7 @@ public class Figure implements IFigure {
 		 * 
 		 * @see TreeSearch#accept(IFigure)
 		 */
+		@Override
 		public boolean accept(IFigure f) {
 			return true;
 		}
@@ -1930,6 +1990,7 @@ public class Figure implements IFigure {
 		 * 
 		 * @see TreeSearch#prune(IFigure)
 		 */
+		@Override
 		public boolean prune(IFigure f) {
 			return false;
 		}
@@ -1945,24 +2006,28 @@ public class Figure implements IFigure {
 			listeners.add(listener);
 		}
 
+		@Override
 		public Object getConstraint(IFigure child) {
 			if (realLayout != null)
 				return realLayout.getConstraint(child);
 			return null;
 		}
 
+		@Override
 		public Dimension getMinimumSize(IFigure container, int wHint, int hHint) {
 			if (realLayout != null)
 				return realLayout.getMinimumSize(container, wHint, hHint);
 			return null;
 		}
 
+		@Override
 		public Dimension getPreferredSize(IFigure container, int wHint, int hHint) {
 			if (realLayout != null)
 				return realLayout.getPreferredSize(container, wHint, hHint);
 			return null;
 		}
 
+		@Override
 		public void invalidate() {
 			listeners.forEach(listener -> listener.invalidate(Figure.this));
 
@@ -1970,6 +2035,7 @@ public class Figure implements IFigure {
 				realLayout.invalidate();
 		}
 
+		@Override
 		public void layout(IFigure container) {
 			boolean consumed = false;
 			for (LayoutListener listener : listeners) {
@@ -1981,12 +2047,14 @@ public class Figure implements IFigure {
 			listeners.forEach(listener -> listener.postLayout(container));
 		}
 
+		@Override
 		public void remove(IFigure child) {
 			listeners.forEach(listener -> listener.remove(child));
 			if (realLayout != null)
 				realLayout.remove(child);
 		}
 
+		@Override
 		public void setConstraint(IFigure child, Object constraint) {
 			listeners.forEach(listener -> listener.setConstraint(child, constraint));
 			if (realLayout != null)
@@ -2056,21 +2124,27 @@ public class Figure implements IFigure {
 	 * An UpdateManager that does nothing.
 	 */
 	protected static final UpdateManager NO_MANAGER = new UpdateManager() {
+		@Override
 		public void addDirtyRegion(IFigure figure, int x, int y, int w, int h) {
 		}
 
+		@Override
 		public void addInvalidFigure(IFigure f) {
 		}
 
+		@Override
 		public void performUpdate() {
 		}
 
+		@Override
 		public void performUpdate(Rectangle region) {
 		}
 
+		@Override
 		public void setRoot(IFigure root) {
 		}
 
+		@Override
 		public void setGraphicsSource(GraphicsSource gs) {
 		}
 	};

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.draw2d;
 
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 import org.eclipse.swt.SWT;
@@ -79,24 +78,20 @@ public class FigureCanvas extends Canvas {
 	private int hBarOffset;
 	private int vBarOffset;
 
-	private PropertyChangeListener horizontalChangeListener = new PropertyChangeListener() {
-		public void propertyChange(PropertyChangeEvent event) {
-			RangeModel model = getViewport().getHorizontalRangeModel();
-			hBarOffset = Math.max(0, -model.getMinimum());
-			getHorizontalBar().setValues(model.getValue() + hBarOffset, model.getMinimum() + hBarOffset,
-					model.getMaximum() + hBarOffset, model.getExtent(), Math.max(1, model.getExtent() / 20),
-					Math.max(1, model.getExtent() * 3 / 4));
-		}
+	private final PropertyChangeListener horizontalChangeListener = event -> {
+		RangeModel model = getViewport().getHorizontalRangeModel();
+		hBarOffset = Math.max(0, -model.getMinimum());
+		getHorizontalBar().setValues(model.getValue() + hBarOffset, model.getMinimum() + hBarOffset,
+				model.getMaximum() + hBarOffset, model.getExtent(), Math.max(1, model.getExtent() / 20),
+				Math.max(1, model.getExtent() * 3 / 4));
 	};
 
-	private PropertyChangeListener verticalChangeListener = new PropertyChangeListener() {
-		public void propertyChange(PropertyChangeEvent event) {
-			RangeModel model = getViewport().getVerticalRangeModel();
-			vBarOffset = Math.max(0, -model.getMinimum());
-			getVerticalBar().setValues(model.getValue() + vBarOffset, model.getMinimum() + vBarOffset,
-					model.getMaximum() + vBarOffset, model.getExtent(), Math.max(1, model.getExtent() / 20),
-					Math.max(1, model.getExtent() * 3 / 4));
-		}
+	private final PropertyChangeListener verticalChangeListener = event -> {
+		RangeModel model = getViewport().getVerticalRangeModel();
+		vBarOffset = Math.max(0, -model.getMinimum());
+		getVerticalBar().setValues(model.getValue() + vBarOffset, model.getMinimum() + vBarOffset,
+				model.getMaximum() + vBarOffset, model.getExtent(), Math.max(1, model.getExtent() / 20),
+				Math.max(1, model.getExtent() * 3 / 4));
 	};
 
 	private final LightweightSystem lws;
@@ -104,7 +99,7 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Creates a new FigureCanvas with the given parent and the
 	 * {@link #DEFAULT_STYLES}.
-	 * 
+	 *
 	 * @param parent the parent
 	 */
 	public FigureCanvas(Composite parent) {
@@ -114,7 +109,7 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Constructor which applies the default styles plus any optional styles
 	 * indicated.
-	 * 
+	 *
 	 * @param parent the parent composite
 	 * @param style  see the class javadoc for optional styles
 	 * @since 3.1
@@ -126,7 +121,7 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Constructor which uses the given styles verbatim. Certain styles must be used
 	 * with this class. Refer to the class javadoc for more details.
-	 * 
+	 *
 	 * @param style  see the class javadoc for <b>required</b> and optional styles
 	 * @param parent the parent composite
 	 * @since 3.4
@@ -138,7 +133,7 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Constructs a new FigureCanvas with the given parent and LightweightSystem,
 	 * using the {@link #DEFAULT_STYLES}.
-	 * 
+	 *
 	 * @param parent the parent
 	 * @param lws    the LightweightSystem
 	 */
@@ -150,7 +145,7 @@ public class FigureCanvas extends Canvas {
 	 * Constructor taking a lightweight system and SWT style, which is used
 	 * verbatim. Certain styles must be used with this class. Refer to the class
 	 * javadoc for more details.
-	 * 
+	 *
 	 * @param style  see the class javadoc for <b>required</b> and optional styles
 	 * @param parent the parent composite
 	 * @param lws    the LightweightSystem
@@ -167,7 +162,7 @@ public class FigureCanvas extends Canvas {
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param parent the parent composite
 	 * @param style  look at class javadoc for valid styles
 	 * @param lws    the lightweight system
@@ -178,26 +173,31 @@ public class FigureCanvas extends Canvas {
 	}
 
 	private static int checkStyle(int style) {
-		if ((style & REQUIRED_STYLES) != REQUIRED_STYLES)
+		if ((style & REQUIRED_STYLES) != REQUIRED_STYLES) {
 			throw new IllegalArgumentException("Required style missing on FigureCanvas"); //$NON-NLS-1$
-		if ((style & ~ACCEPTED_STYLES) != 0)
+		}
+		if ((style & ~ACCEPTED_STYLES) != 0) {
 			throw new IllegalArgumentException("Invalid style being set on FigureCanvas"); //$NON-NLS-1$
+		}
 		return style;
 	}
 
 	/**
 	 * @see org.eclipse.swt.widgets.Composite#computeSize(int, int, boolean)
 	 */
+	@Override
 	public org.eclipse.swt.graphics.Point computeSize(int wHint, int hHint, boolean changed) {
 		// TODO Still doesn't handle scrollbar cases, such as when a constrained
 		// width
 		// would require a horizontal scrollbar, and therefore additional
 		// height.
 		int borderSize = computeTrim(0, 0, 0, 0).x * -2;
-		if (wHint >= 0)
+		if (wHint >= 0) {
 			wHint = Math.max(0, wHint - borderSize);
-		if (hHint >= 0)
+		}
+		if (hHint >= 0) {
 			hHint = Math.max(0, hHint - borderSize);
+		}
 		Dimension size = getLightweightSystem().getRootFigure().getPreferredSize(wHint, hHint).getExpanded(borderSize,
 				borderSize);
 		size.union(new Dimension(wHint, hHint));
@@ -214,9 +214,11 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * @see org.eclipse.swt.widgets.Control#getFont()
 	 */
+	@Override
 	public Font getFont() {
-		if (font == null)
+		if (font == null) {
 			font = super.getFont();
+		}
 		return font;
 	}
 
@@ -243,12 +245,13 @@ public class FigureCanvas extends Canvas {
 
 	/**
 	 * Returns the Viewport. If it's <code>null</code>, a new one is created.
-	 * 
+	 *
 	 * @return the viewport
 	 */
 	public Viewport getViewport() {
-		if (viewport == null)
+		if (viewport == null) {
 			setViewport(new Viewport(true));
+		}
 		return viewport;
 	}
 
@@ -257,22 +260,27 @@ public class FigureCanvas extends Canvas {
 	 */
 	private void hook() {
 		getLightweightSystem().getUpdateManager().addUpdateListener(new UpdateListener() {
+			@Override
 			public void notifyPainting(Rectangle damage, java.util.Map<IFigure, Rectangle> dirtyRegions) {
 			}
 
+			@Override
 			public void notifyValidating() {
-				if (!isDisposed())
+				if (!isDisposed()) {
 					layoutViewport();
+				}
 			}
 		});
 
 		getHorizontalBar().addSelectionListener(new SelectionAdapter() {
+			@Override
 			public void widgetSelected(SelectionEvent event) {
 				scrollToX(getHorizontalBar().getSelection() - hBarOffset);
 			}
 		});
 
 		getVerticalBar().addSelectionListener(new SelectionAdapter() {
+			@Override
 			public void widgetSelected(SelectionEvent event) {
 				scrollToY(getVerticalBar().getSelection() - vBarOffset);
 			}
@@ -296,10 +304,12 @@ public class FigureCanvas extends Canvas {
 				computeTrim(0, 0, 0, 0).height);
 		getLightweightSystem().setIgnoreResize(true);
 		try {
-			if (getHorizontalBar().getVisible() != result.showH)
+			if (getHorizontalBar().getVisible() != result.showH) {
 				getHorizontalBar().setVisible(result.showH);
-			if (getVerticalBar().getVisible() != result.showV)
+			}
+			if (getVerticalBar().getVisible() != result.showV) {
 				getVerticalBar().setVisible(result.showV);
+			}
 			Rectangle r = new Rectangle(getClientArea());
 			r.setLocation(0, 0);
 			getLightweightSystem().getRootFigure().setBounds(r);
@@ -310,7 +320,7 @@ public class FigureCanvas extends Canvas {
 
 	/**
 	 * Scrolls in an animated way to the new x and y location.
-	 * 
+	 *
 	 * @param x the x coordinate to scroll to
 	 * @param y the y coordinate to scroll to
 	 */
@@ -324,8 +334,9 @@ public class FigureCanvas extends Canvas {
 		int dx = x - oldX;
 		int dy = y - oldY;
 
-		if (dx == 0 && dy == 0)
+		if (dx == 0 && dy == 0) {
 			return; // Nothing to do.
+		}
 
 		Dimension viewingArea = getViewport().getClientArea().getSize();
 
@@ -354,32 +365,34 @@ public class FigureCanvas extends Canvas {
 	 * only consists of a vertical or horizontal scroll, a call will be made to
 	 * {@link #scrollToY(int)} or {@link #scrollToX(int)}, respectively, to increase
 	 * performance.
-	 * 
+	 *
 	 * @param x the x coordinate to scroll to
 	 * @param y the y coordinate to scroll to
 	 */
 	public void scrollTo(int x, int y) {
 		x = verifyScrollBarOffset(getViewport().getHorizontalRangeModel(), x);
 		y = verifyScrollBarOffset(getViewport().getVerticalRangeModel(), y);
-		if (x == getViewport().getViewLocation().x)
+		if (x == getViewport().getViewLocation().x) {
 			scrollToY(y);
-		else if (y == getViewport().getViewLocation().y)
+		} else if (y == getViewport().getViewLocation().y) {
 			scrollToX(x);
-		else
+		} else {
 			getViewport().setViewLocation(x, y);
+		}
 	}
 
 	/**
 	 * Scrolls the contents horizontally so that they are offset by
 	 * <code>hOffset</code>.
-	 * 
+	 *
 	 * @param hOffset the new horizontal offset
 	 */
 	public void scrollToX(int hOffset) {
 		hOffset = verifyScrollBarOffset(getViewport().getHorizontalRangeModel(), hOffset);
 		int hOffsetOld = getViewport().getViewLocation().x;
-		if (hOffset == hOffsetOld)
+		if (hOffset == hOffsetOld) {
 			return;
+		}
 		int dx = -hOffset + hOffsetOld;
 
 		Rectangle clientArea = getViewport().getBounds().getCropped(getViewport().getInsets());
@@ -390,9 +403,10 @@ public class FigureCanvas extends Canvas {
 		if (dx < 0) { // Moving left?
 			blit.translate(-dx, 0); // Move blit area to the right
 			expose.x = dest.x + blit.width;
-		} else
+		} else {
 			// Moving right
 			dest.x += dx; // Move expose area to the right
+		}
 
 		// fix for bug 41111
 		Control[] children = getChildren();
@@ -404,11 +418,13 @@ public class FigureCanvas extends Canvas {
 		}
 		scroll(dest.x, dest.y, blit.x, blit.y, blit.width, blit.height, true);
 		for (int i = 0; i < children.length; i++) {
-			if (children[i].isDisposed())
+			if (children[i].isDisposed()) {
 				continue;
+			}
 			org.eclipse.swt.graphics.Rectangle bounds = children[i].getBounds();
-			if (manualMove[i])
+			if (manualMove[i]) {
 				children[i].setBounds(bounds.x + dx, bounds.y, bounds.width, bounds.height);
+			}
 		}
 
 		getViewport().setIgnoreScroll(true);
@@ -420,14 +436,15 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Scrolls the contents vertically so that they are offset by
 	 * <code>vOffset</code>.
-	 * 
+	 *
 	 * @param vOffset the new vertical offset
 	 */
 	public void scrollToY(int vOffset) {
 		vOffset = verifyScrollBarOffset(getViewport().getVerticalRangeModel(), vOffset);
 		int vOffsetOld = getViewport().getViewLocation().y;
-		if (vOffset == vOffsetOld)
+		if (vOffset == vOffsetOld) {
 			return;
+		}
 		int dy = -vOffset + vOffsetOld;
 
 		Rectangle clientArea = getViewport().getBounds().getCropped(getViewport().getInsets());
@@ -438,9 +455,10 @@ public class FigureCanvas extends Canvas {
 		if (dy < 0) { // Moving up?
 			blit.translate(0, -dy); // Move blit area down
 			expose.y = dest.y + blit.height; // Move expose area down
-		} else
+		} else {
 			// Moving down
 			dest.y += dy;
+		}
 
 		// fix for bug 41111
 		Control[] children = getChildren();
@@ -452,11 +470,13 @@ public class FigureCanvas extends Canvas {
 		}
 		scroll(dest.x, dest.y, blit.x, blit.y, blit.width, blit.height, true);
 		for (int i = 0; i < children.length; i++) {
-			if (children[i].isDisposed())
+			if (children[i].isDisposed()) {
 				continue;
+			}
 			org.eclipse.swt.graphics.Rectangle bounds = children[i].getBounds();
-			if (manualMove[i])
+			if (manualMove[i]) {
 				children[i].setBounds(bounds.x, bounds.y + dy, bounds.width, bounds.height);
+			}
 		}
 
 		getViewport().setIgnoreScroll(true);
@@ -467,7 +487,7 @@ public class FigureCanvas extends Canvas {
 
 	/**
 	 * Sets the given border on the LightweightSystem's root figure.
-	 * 
+	 *
 	 * @param border The new border
 	 */
 	public void setBorder(Border border) {
@@ -476,7 +496,7 @@ public class FigureCanvas extends Canvas {
 
 	/**
 	 * Sets the contents of the {@link Viewport}.
-	 * 
+	 *
 	 * @param figure the new contents
 	 */
 	public void setContents(IFigure figure) {
@@ -486,6 +506,7 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * @see org.eclipse.swt.widgets.Control#setFont(org.eclipse.swt.graphics.Font)
 	 */
+	@Override
 	public void setFont(Font font) {
 		this.font = font;
 		super.setFont(font);
@@ -494,7 +515,7 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Sets the horizontal scrollbar visibility. Possible values are
 	 * {@link #AUTOMATIC}, {@link #ALWAYS}, and {@link #NEVER}.
-	 * 
+	 *
 	 * @param v the new visibility
 	 */
 	public void setHorizontalScrollBarVisibility(int v) {
@@ -505,7 +526,7 @@ public class FigureCanvas extends Canvas {
 	 * Sets both the horizontal and vertical scrollbar visibility to the given
 	 * value. Possible values are {@link #AUTOMATIC}, {@link #ALWAYS}, and
 	 * {@link #NEVER}.
-	 * 
+	 *
 	 * @param both the new visibility
 	 */
 	public void setScrollBarVisibility(int both) {
@@ -516,7 +537,7 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Sets the vertical scrollbar visibility. Possible values are
 	 * {@link #AUTOMATIC}, {@link #ALWAYS}, and {@link #NEVER}.
-	 * 
+	 *
 	 * @param v the new visibility
 	 */
 	public void setVerticalScrollBarVisibility(int v) {
@@ -526,12 +547,13 @@ public class FigureCanvas extends Canvas {
 	/**
 	 * Sets the Viewport. The given Viewport must use "fake" scrolling. That is, it
 	 * must be constructed using <code>new Viewport(true)</code>.
-	 * 
+	 *
 	 * @param vp the new viewport
 	 */
 	public void setViewport(Viewport vp) {
-		if (viewport != null)
+		if (viewport != null) {
 			unhookViewport();
+		}
 		viewport = vp;
 		lws.setContents(viewport);
 		hookViewport();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FlowLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FlowLayout.java
@@ -104,6 +104,7 @@ public class FlowLayout extends OrderedLayout {
 	 * @see org.eclipse.draw2d.AbstractLayout#calculatePreferredSize(IFigure, int,
 	 *      int)
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure container, int wHint, int hHint) {
 		// Subtract out the insets from the hints
 		if (wHint > -1)
@@ -187,6 +188,7 @@ public class FlowLayout extends OrderedLayout {
 	 * 
 	 * @see org.eclipse.draw2d.OrderedLayout#getDefaultOrientation()
 	 */
+	@Override
 	protected int getDefaultOrientation() {
 		return PositionConstants.HORIZONTAL;
 	}
@@ -253,6 +255,7 @@ public class FlowLayout extends OrderedLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractHintLayout#isSensitiveHorizontally(IFigure)
 	 */
+	@Override
 	protected boolean isSensitiveHorizontally(IFigure parent) {
 		return isHorizontal();
 	}
@@ -260,6 +263,7 @@ public class FlowLayout extends OrderedLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractHintLayout#isSensitiveVertically(IFigure)
 	 */
+	@Override
 	protected boolean isSensitiveVertically(IFigure parent) {
 		return !isHorizontal();
 	}
@@ -269,6 +273,7 @@ public class FlowLayout extends OrderedLayout {
 	 * 
 	 * @see org.eclipse.draw2d.OrderedLayout#isStretchMinorAxis()
 	 */
+	@Override
 	public boolean isStretchMinorAxis() {
 		return fill;
 	}
@@ -276,6 +281,7 @@ public class FlowLayout extends OrderedLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public void layout(IFigure parent) {
 		data = new WorkingData();
 		Rectangle relativeArea = parent.getClientArea();
@@ -424,6 +430,7 @@ public class FlowLayout extends OrderedLayout {
 	 * 
 	 * @see org.eclipse.draw2d.OrderedLayout#setStretchMinorAxis(boolean)
 	 */
+	@Override
 	public void setStretchMinorAxis(boolean value) {
 		fill = value;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FocusBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FocusBorder.java
@@ -26,6 +26,7 @@ public class FocusBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#getInsets(IFigure)
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return new Insets(1);
 	}
@@ -33,6 +34,7 @@ public class FocusBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -42,6 +44,7 @@ public class FocusBorder extends AbstractBorder {
 	 * 
 	 * @see org.eclipse.draw2d.Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 		tempRect.setBounds(getPaintRectangle(figure, insets));
 		tempRect.width--;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FocusListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FocusListener.java
@@ -36,12 +36,14 @@ public interface FocusListener {
 		/**
 		 * @see org.eclipse.draw2d.FocusListener#focusGained(FocusEvent)
 		 */
+		@Override
 		public void focusGained(FocusEvent fe) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.FocusListener#focusLost(FocusEvent)
 		 */
+		@Override
 		public void focusLost(FocusEvent fe) {
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FrameBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FrameBorder.java
@@ -75,6 +75,7 @@ public class FrameBorder extends CompoundBorder implements LabeledBorder {
 	/**
 	 * @return the label for this border
 	 */
+	@Override
 	public String getLabel() {
 		return getLabeledBorder().getLabel();
 	}
@@ -84,6 +85,7 @@ public class FrameBorder extends CompoundBorder implements LabeledBorder {
 	 * 
 	 * @param label the label
 	 */
+	@Override
 	public void setLabel(String label) {
 		getLabeledBorder().setLabel(label);
 	}
@@ -93,6 +95,7 @@ public class FrameBorder extends CompoundBorder implements LabeledBorder {
 	 * 
 	 * @param font the font
 	 */
+	@Override
 	public void setFont(Font font) {
 		getLabeledBorder().setFont(font);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformHelper.java
@@ -16,6 +16,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 class FreeformHelper implements FreeformListener {
 
 	class ChildTracker implements FigureListener {
+		@Override
 		public void figureMoved(IFigure source) {
 			invalidate();
 		}
@@ -70,6 +71,7 @@ class FreeformHelper implements FreeformListener {
 			host.revalidate();
 	}
 
+	@Override
 	public void notifyFreeformExtentChanged() {
 		// A childs freeform extent has changed, therefore this extent must be
 		// recalculated

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformLayer.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformLayer.java
@@ -22,6 +22,7 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	/**
 	 * @see IFigure#add(IFigure, Object, int)
 	 */
+	@Override
 	public void add(IFigure child, Object constraint, int index) {
 		super.add(child, constraint, index);
 		helper.hookChild(child);
@@ -30,6 +31,7 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#addFreeformListener(FreeformListener)
 	 */
+	@Override
 	public void addFreeformListener(FreeformListener listener) {
 		addListener(FreeformListener.class, listener);
 	}
@@ -37,6 +39,7 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#fireExtentChanged()
 	 */
+	@Override
 	public void fireExtentChanged() {
 		getListenersIterable(FreeformListener.class).forEach(lst -> lst.notifyFreeformExtentChanged());
 	}
@@ -46,12 +49,14 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	 * 
 	 * @see Figure#fireMoved()
 	 */
+	@Override
 	protected void fireMoved() {
 	}
 
 	/**
 	 * @see FreeformFigure#getFreeformExtent()
 	 */
+	@Override
 	public Rectangle getFreeformExtent() {
 		return helper.getFreeformExtent();
 	}
@@ -59,6 +64,7 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	/**
 	 * @see Figure#primTranslate(int, int)
 	 */
+	@Override
 	public void primTranslate(int dx, int dy) {
 		bounds.x += dx;
 		bounds.y += dy;
@@ -67,6 +73,7 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	/**
 	 * @see IFigure#remove(IFigure)
 	 */
+	@Override
 	public void remove(IFigure child) {
 		helper.unhookChild(child);
 		super.remove(child);
@@ -75,6 +82,7 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#removeFreeformListener(FreeformListener)
 	 */
+	@Override
 	public void removeFreeformListener(FreeformListener listener) {
 		removeListener(FreeformListener.class, listener);
 	}
@@ -82,6 +90,7 @@ public class FreeformLayer extends Layer implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#setFreeformBounds(Rectangle)
 	 */
+	@Override
 	public void setFreeformBounds(Rectangle bounds) {
 		helper.setFreeformBounds(bounds);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformLayeredPane.java
@@ -29,6 +29,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see IFigure#add(IFigure, Object, int)
 	 */
+	@Override
 	public void add(IFigure child, Object constraint, int index) {
 		super.add(child, constraint, index);
 		helper.hookChild(child);
@@ -37,6 +38,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#addFreeformListener(FreeformListener)
 	 */
+	@Override
 	public void addFreeformListener(FreeformListener listener) {
 		addListener(FreeformListener.class, listener);
 	}
@@ -44,6 +46,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#fireExtentChanged()
 	 */
+	@Override
 	public void fireExtentChanged() {
 		getListenersIterable(FreeformListener.class).forEach(lst -> lst.notifyFreeformExtentChanged());
 	}
@@ -53,6 +56,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	 * 
 	 * @see Figure#fireMoved()
 	 */
+	@Override
 	protected void fireMoved() {
 	}
 
@@ -68,6 +72,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#getFreeformExtent()
 	 */
+	@Override
 	public Rectangle getFreeformExtent() {
 		return helper.getFreeformExtent();
 	}
@@ -75,6 +80,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see Figure#primTranslate(int, int)
 	 */
+	@Override
 	protected void primTranslate(int dx, int dy) {
 		bounds.x += dx;
 		bounds.y += dy;
@@ -83,6 +89,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see IFigure#remove(IFigure)
 	 */
+	@Override
 	public void remove(IFigure child) {
 		helper.unhookChild(child);
 		super.remove(child);
@@ -91,6 +98,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#removeFreeformListener(FreeformListener)
 	 */
+	@Override
 	public void removeFreeformListener(FreeformListener listener) {
 		removeListener(FreeformListener.class, listener);
 	}
@@ -98,6 +106,7 @@ public class FreeformLayeredPane extends LayeredPane implements FreeformFigure {
 	/**
 	 * @see FreeformFigure#setFreeformBounds(Rectangle)
 	 */
+	@Override
 	public void setFreeformBounds(Rectangle bounds) {
 		helper.setFreeformBounds(bounds);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
@@ -20,6 +20,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 public class FreeformViewport extends Viewport {
 
 	class FreeformViewportLayout extends ViewportLayout {
+		@Override
 		protected Dimension calculatePreferredSize(IFigure parent, int wHint, int hHint) {
 			getContents().validate();
 			wHint = Math.max(0, wHint);
@@ -28,14 +29,17 @@ public class FreeformViewport extends Viewport {
 					.union(wHint - 1, hHint - 1).getSize();
 		}
 
+		@Override
 		protected boolean isSensitiveHorizontally(IFigure parent) {
 			return true;
 		}
 
+		@Override
 		protected boolean isSensitiveVertically(IFigure parent) {
 			return true;
 		}
 
+		@Override
 		public void layout(IFigure figure) {
 			// Do nothing, contents updates itself.
 		}
@@ -58,6 +62,7 @@ public class FreeformViewport extends Viewport {
 	 * 
 	 * @see Viewport#readjustScrollBars()
 	 */
+	@Override
 	protected void readjustScrollBars() {
 		if (getContents() == null)
 			return;
@@ -78,6 +83,7 @@ public class FreeformViewport extends Viewport {
 	 * 
 	 * @see Figure#useLocalCoordinates()
 	 */
+	@Override
 	protected boolean useLocalCoordinates() {
 		return true;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/GhostImageFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/GhostImageFigure.java
@@ -76,6 +76,7 @@ public class GhostImageFigure extends Figure {
 	/**
 	 * @see Figure#paintFigure(Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		Image feedbackImage = new Image(Display.getCurrent(), ghostImageData);
 		graphics.setAlpha(alpha);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/GridData.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/GridData.java
@@ -403,6 +403,7 @@ public final class GridData {
 		return string.substring(index + 1, string.length());
 	}
 
+	@Override
 	public String toString() {
 
 		String hAlign = ""; //$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/GridLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/GridLayout.java
@@ -180,6 +180,7 @@ public class GridLayout extends AbstractHintLayout {
 	 * @see org.eclipse.draw2d.AbstractLayout#calculatePreferredSize(org.eclipse.
 	 * draw2d.IFigure, int, int)
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure container, int wHint, int hHint) {
 		// Remove the size of the border from the wHint and hHint in case a size
 		// different to the preferred size is used
@@ -213,6 +214,7 @@ public class GridLayout extends AbstractHintLayout {
 	 * 
 	 * @see org.eclipse.draw2d.LayoutManager#layout(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void layout(IFigure container) {
 		// initChildren( container);
 		Rectangle rect = container.getClientArea();
@@ -731,6 +733,7 @@ public class GridLayout extends AbstractHintLayout {
 	 * @see
 	 * org.eclipse.draw2d.LayoutManager#getConstraint(org.eclipse.draw2d.IFigure )
 	 */
+	@Override
 	public Object getConstraint(IFigure child) {
 		return constraints.get(child);
 	}
@@ -741,6 +744,7 @@ public class GridLayout extends AbstractHintLayout {
 	 * 
 	 * @see LayoutManager#setConstraint(IFigure, Object)
 	 */
+	@Override
 	public void setConstraint(IFigure figure, Object newConstraint) {
 		super.setConstraint(figure, newConstraint);
 		if (newConstraint != null) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/GroupBoxBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/GroupBoxBorder.java
@@ -47,6 +47,7 @@ public class GroupBoxBorder extends AbstractLabeledBorder {
 	 * @return the Insets for this GroupBoxBorder.
 	 * @since 2.0
 	 */
+	@Override
 	protected Insets calculateInsets(IFigure figure) {
 		int height = getTextExtents(figure).height;
 		return new Insets(height);
@@ -55,6 +56,7 @@ public class GroupBoxBorder extends AbstractLabeledBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#getPreferredSize(IFigure)
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure fig) {
 		Dimension textSize = getTextExtents(fig);
 		return textSize.getCopy().expand(textSize.height * 2, 0);
@@ -63,6 +65,7 @@ public class GroupBoxBorder extends AbstractLabeledBorder {
 	/**
 	 * @see Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics g, Insets insets) {
 		tempRect.setBounds(getPaintRectangle(figure, insets));
 		Rectangle r = tempRect;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
@@ -42,6 +42,7 @@ public interface IFigure {
 			super(0, 0, 0, 0);
 		}
 
+		@Override
 		public boolean isEmpty() {
 			return true;
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ImageFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ImageFigure.java
@@ -67,6 +67,7 @@ public class ImageFigure extends AbstractImageFigure {
 	/**
 	 * @return The Image that this Figure displays
 	 */
+	@Override
 	public Image getImage() {
 		return img;
 	}
@@ -77,6 +78,7 @@ public class ImageFigure extends AbstractImageFigure {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#getPreferredSize(int, int)
 	 */
+	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
 		if (getInsets() == NO_INSETS)
 			return size;
@@ -87,6 +89,7 @@ public class ImageFigure extends AbstractImageFigure {
 	/**
 	 * @see org.eclipse.draw2d.Figure#paintFigure(Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		super.paintFigure(graphics);
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/KeyListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/KeyListener.java
@@ -37,12 +37,14 @@ public interface KeyListener {
 		/**
 		 * @see org.eclipse.draw2d.KeyListener#keyPressed(KeyEvent)
 		 */
+		@Override
 		public void keyPressed(KeyEvent ke) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.KeyListener#keyReleased(KeyEvent)
 		 */
+		@Override
 		public void keyReleased(KeyEvent ke) {
 		}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
@@ -303,6 +303,7 @@ public class Label extends Figure implements PositionConstants {
 	/**
 	 * @see IFigure#getMinimumSize(int, int)
 	 */
+	@Override
 	public Dimension getMinimumSize(int w, int h) {
 		if (minSize != null)
 			return minSize;
@@ -321,6 +322,7 @@ public class Label extends Figure implements PositionConstants {
 	/**
 	 * @see IFigure#getPreferredSize(int, int)
 	 */
+	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
 		if (prefSize == null) {
 			prefSize = calculateLabelSize(getTextSize());
@@ -461,6 +463,7 @@ public class Label extends Figure implements PositionConstants {
 	/**
 	 * @see IFigure#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		prefSize = null;
 		minSize = null;
@@ -485,6 +488,7 @@ public class Label extends Figure implements PositionConstants {
 	/**
 	 * @see Figure#paintFigure(Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		if (isOpaque())
 			super.paintFigure(graphics);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Layer.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Layer.java
@@ -45,6 +45,7 @@ public class Layer extends Figure {
 	 * 
 	 * @see IFigure#findFigureAt(int, int, TreeSearch)
 	 */
+	@Override
 	public IFigure findFigureAt(int x, int y, TreeSearch search) {
 		if (!isEnabled())
 			return null;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LayeredPane.java
@@ -39,6 +39,7 @@ public class LayeredPane extends Layer {
 	 * @param index    the index where the layer should be added
 	 * @since 2.0
 	 */
+	@Override
 	public void add(IFigure figure, Object layerKey, int index) {
 		if (index == -1)
 			index = layerKeys.size();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LayoutAnimator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LayoutAnimator.java
@@ -56,6 +56,7 @@ public class LayoutAnimator extends Animator implements LayoutListener {
 	 * @return the current state
 	 * @since 3.2
 	 */
+	@Override
 	protected Object getCurrentState(IFigure container) {
 		Map<IFigure, Rectangle> locations = new HashMap<>();
 		container.getChildren().forEach(child -> locations.put(child, child.getBounds().getCopy()));
@@ -77,6 +78,7 @@ public class LayoutAnimator extends Animator implements LayoutListener {
 	 * 
 	 * @see LayoutListener#invalidate(IFigure)
 	 */
+	@Override
 	public final void invalidate(IFigure container) {
 		if (Animation.isInitialRecording())
 			Animation.hookAnimator(container, this);
@@ -87,6 +89,7 @@ public class LayoutAnimator extends Animator implements LayoutListener {
 	 * 
 	 * @see org.eclipse.draw2d.LayoutListener#layout(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public final boolean layout(IFigure container) {
 		if (Animation.isAnimating())
 			return Animation.hookPlayback(container, this);
@@ -98,6 +101,7 @@ public class LayoutAnimator extends Animator implements LayoutListener {
 	 * 
 	 * @see Animator#playback(IFigure)
 	 */
+	@Override
 	protected boolean playback(IFigure container) {
 		Map initial = (Map) Animation.getInitialState(this, container);
 		Map ending = (Map) Animation.getFinalState(this, container);
@@ -129,6 +133,7 @@ public class LayoutAnimator extends Animator implements LayoutListener {
 	 * 
 	 * @see LayoutListener#postLayout(IFigure)
 	 */
+	@Override
 	public final void postLayout(IFigure container) {
 		if (Animation.isFinalRecording())
 			Animation.hookNeedsCapture(container, this);
@@ -139,6 +144,7 @@ public class LayoutAnimator extends Animator implements LayoutListener {
 	 * 
 	 * @see LayoutListener#remove(IFigure)
 	 */
+	@Override
 	public final void remove(IFigure child) {
 	}
 
@@ -147,6 +153,7 @@ public class LayoutAnimator extends Animator implements LayoutListener {
 	 * 
 	 * @see LayoutListener#setConstraint(IFigure, Object)
 	 */
+	@Override
 	public final void setConstraint(IFigure child, Object constraint) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LayoutListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LayoutListener.java
@@ -36,6 +36,7 @@ public interface LayoutListener {
 		 * 
 		 * @see LayoutListener#invalidate(IFigure)
 		 */
+		@Override
 		public void invalidate(IFigure container) {
 		}
 
@@ -44,6 +45,7 @@ public interface LayoutListener {
 		 * 
 		 * @see LayoutListener#layout(IFigure)
 		 */
+		@Override
 		public boolean layout(IFigure container) {
 			return false;
 		}
@@ -53,6 +55,7 @@ public interface LayoutListener {
 		 * 
 		 * @see LayoutListener#postLayout(IFigure)
 		 */
+		@Override
 		public void postLayout(IFigure container) {
 		}
 
@@ -61,6 +64,7 @@ public interface LayoutListener {
 		 * 
 		 * @see LayoutListener#remove(IFigure)
 		 */
+		@Override
 		public void remove(IFigure child) {
 		}
 
@@ -69,6 +73,7 @@ public interface LayoutListener {
 		 * 
 		 * @see LayoutListener#setConstraint(IFigure, java.lang.Object)
 		 */
+		@Override
 		public void setConstraint(IFigure child, Object constraint) {
 		}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LightweightSystem.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LightweightSystem.java
@@ -100,11 +100,13 @@ public class LightweightSystem {
 		canvas.addListener(SWT.MouseWheel, handler);
 
 		canvas.addControlListener(new ControlAdapter() {
+			@Override
 			public void controlResized(ControlEvent e) {
 				LightweightSystem.this.controlResized();
 			}
 		});
 		canvas.addListener(SWT.Paint, new Listener() {
+			@Override
 			public void handleEvent(Event e) {
 				LightweightSystem.this.paint(e.gc);
 			}
@@ -286,6 +288,7 @@ public class LightweightSystem {
 	 */
 	protected class RootFigure extends Figure {
 		/** @see IFigure#getBackgroundColor() */
+		@Override
 		public Color getBackgroundColor() {
 			if (bgColor != null)
 				return bgColor;
@@ -295,6 +298,7 @@ public class LightweightSystem {
 		}
 
 		/** @see IFigure#getFont() */
+		@Override
 		public Font getFont() {
 			if (font != null)
 				return font;
@@ -304,6 +308,7 @@ public class LightweightSystem {
 		}
 
 		/** @see IFigure#getForegroundColor() */
+		@Override
 		public Color getForegroundColor() {
 			if (fgColor != null)
 				return fgColor;
@@ -313,11 +318,13 @@ public class LightweightSystem {
 		}
 
 		/** @see IFigure#getUpdateManager() */
+		@Override
 		public UpdateManager getUpdateManager() {
 			return LightweightSystem.this.getUpdateManager();
 		}
 
 		/** @see IFigure#internalGetEventDispatcher() */
+		@Override
 		public EventDispatcher internalGetEventDispatcher() {
 			return getEventDispatcher();
 		}
@@ -325,11 +332,13 @@ public class LightweightSystem {
 		/**
 		 * @see IFigure#isMirrored()
 		 */
+		@Override
 		public boolean isMirrored() {
 			return (LightweightSystem.this.canvas.getStyle() & SWT.MIRRORED) != 0;
 		}
 
 		/** @see Figure#isShowing() */
+		@Override
 		public boolean isShowing() {
 			return true;
 		}
@@ -342,16 +351,19 @@ public class LightweightSystem {
 	protected class EventHandler implements MouseMoveListener, MouseListener, AccessibleControlListener, KeyListener,
 			TraverseListener, FocusListener, AccessibleListener, MouseTrackListener, Listener, DisposeListener {
 		/** @see FocusListener#focusGained(FocusEvent) */
+		@Override
 		public void focusGained(FocusEvent e) {
 			getEventDispatcher().dispatchFocusGained(e);
 		}
 
 		/** @see FocusListener#focusLost(FocusEvent) */
+		@Override
 		public void focusLost(FocusEvent e) {
 			getEventDispatcher().dispatchFocusLost(e);
 		}
 
 		/** @see AccessibleControlListener#getChild(AccessibleControlEvent) */
+		@Override
 		public void getChild(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -360,6 +372,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getChildAtPoint(AccessibleControlEvent) */
+		@Override
 		public void getChildAtPoint(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -368,6 +381,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getChildCount(AccessibleControlEvent) */
+		@Override
 		public void getChildCount(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -376,6 +390,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getChildren(AccessibleControlEvent) */
+		@Override
 		public void getChildren(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -384,6 +399,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getDefaultAction(AccessibleControlEvent) */
+		@Override
 		public void getDefaultAction(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -392,6 +408,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleListener#getDescription(AccessibleEvent) */
+		@Override
 		public void getDescription(AccessibleEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -400,6 +417,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getFocus(AccessibleControlEvent) */
+		@Override
 		public void getFocus(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -408,6 +426,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleListener#getHelp(AccessibleEvent) */
+		@Override
 		public void getHelp(AccessibleEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -416,6 +435,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleListener#getKeyboardShortcut(AccessibleEvent) */
+		@Override
 		public void getKeyboardShortcut(AccessibleEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -424,6 +444,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getLocation(AccessibleControlEvent) */
+		@Override
 		public void getLocation(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -432,6 +453,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleListener#getName(AccessibleEvent) */
+		@Override
 		public void getName(AccessibleEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -440,6 +462,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getRole(AccessibleControlEvent) */
+		@Override
 		public void getRole(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -448,6 +471,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getSelection(AccessibleControlEvent) */
+		@Override
 		public void getSelection(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -456,6 +480,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getState(AccessibleControlEvent) */
+		@Override
 		public void getState(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -464,6 +489,7 @@ public class LightweightSystem {
 		}
 
 		/** @see AccessibleControlListener#getValue(AccessibleControlEvent) */
+		@Override
 		public void getValue(AccessibleControlEvent e) {
 			EventDispatcher.AccessibilityDispatcher ad;
 			ad = getEventDispatcher().getAccessibilityDispatcher();
@@ -475,6 +501,7 @@ public class LightweightSystem {
 		 * @see Listener#handleEvent(org.eclipse.swt.widgets.Event)
 		 * @since 3.1
 		 */
+		@Override
 		public void handleEvent(Event event) {
 			// Mouse wheel events
 			if (event.type == SWT.MouseWheel)
@@ -482,16 +509,19 @@ public class LightweightSystem {
 		}
 
 		/** @see KeyListener#keyPressed(KeyEvent) */
+		@Override
 		public void keyPressed(KeyEvent e) {
 			getEventDispatcher().dispatchKeyPressed(e);
 		}
 
 		/** @see KeyListener#keyReleased(KeyEvent) */
+		@Override
 		public void keyReleased(KeyEvent e) {
 			getEventDispatcher().dispatchKeyReleased(e);
 		}
 
 		/** @see TraverseListener#keyTraversed(TraverseEvent) */
+		@Override
 		public void keyTraversed(TraverseEvent e) {
 			/*
 			 * Doit is almost always false by default for Canvases with KeyListeners. Set to
@@ -502,41 +532,49 @@ public class LightweightSystem {
 		}
 
 		/** @see MouseListener#mouseDoubleClick(MouseEvent) */
+		@Override
 		public void mouseDoubleClick(MouseEvent e) {
 			getEventDispatcher().dispatchMouseDoubleClicked(e);
 		}
 
 		/** @see MouseListener#mouseDown(MouseEvent) */
+		@Override
 		public void mouseDown(MouseEvent e) {
 			getEventDispatcher().dispatchMousePressed(e);
 		}
 
 		/** @see MouseTrackListener#mouseEnter(MouseEvent) */
+		@Override
 		public void mouseEnter(MouseEvent e) {
 			getEventDispatcher().dispatchMouseEntered(e);
 		}
 
 		/** @see MouseTrackListener#mouseExit(MouseEvent) */
+		@Override
 		public void mouseExit(MouseEvent e) {
 			getEventDispatcher().dispatchMouseExited(e);
 		}
 
 		/** @see MouseTrackListener#mouseHover(MouseEvent) */
+		@Override
 		public void mouseHover(MouseEvent e) {
 			getEventDispatcher().dispatchMouseHover(e);
 		}
 
 		/** @see MouseMoveListener#mouseMove(MouseEvent) */
+		@Override
 		public void mouseMove(MouseEvent e) {
 			getEventDispatcher().dispatchMouseMoved(e);
 		}
 
 		/** @see MouseListener#mouseUp(MouseEvent) */
+		@Override
 		public void mouseUp(MouseEvent e) {
 			getEventDispatcher().dispatchMouseReleased(e);
 		}
 
 		/** @see DisposeListener#widgetDisposed(DisposeEvent) */
+		@Override
 		public void widgetDisposed(DisposeEvent e) {
 			getUpdateManager().dispose();
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LineBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LineBorder.java
@@ -94,6 +94,7 @@ public class LineBorder extends AbstractBorder {
 	 * @param figure The figure this border belongs to
 	 * @return This border's insets
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return new Insets(getWidth());
 	}
@@ -113,6 +114,7 @@ public class LineBorder extends AbstractBorder {
 	 * 
 	 * @return <code>true</code> since this border is opaque
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -120,6 +122,7 @@ public class LineBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 		tempRect.setBounds(getPaintRectangle(figure, insets));
 		if (getWidth() % 2 == 1) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ManhattanConnectionRouter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ManhattanConnectionRouter.java
@@ -42,6 +42,7 @@ public final class ManhattanConnectionRouter extends AbstractRouter {
 	/**
 	 * @see ConnectionRouter#invalidate(Connection)
 	 */
+	@Override
 	public void invalidate(Connection connection) {
 		removeReservedLines(connection);
 	}
@@ -235,6 +236,7 @@ public final class ManhattanConnectionRouter extends AbstractRouter {
 	/**
 	 * @see ConnectionRouter#remove(Connection)
 	 */
+	@Override
 	public void remove(Connection connection) {
 		removeReservedLines(connection);
 	}
@@ -274,6 +276,7 @@ public final class ManhattanConnectionRouter extends AbstractRouter {
 	/**
 	 * @see ConnectionRouter#route(Connection)
 	 */
+	@Override
 	public void route(Connection conn) {
 		if ((conn.getSourceAnchor() == null) || (conn.getTargetAnchor() == null))
 			return;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/MarginBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/MarginBorder.java
@@ -58,6 +58,7 @@ public class MarginBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#getInsets(IFigure)
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return insets;
 	}
@@ -67,6 +68,7 @@ public class MarginBorder extends AbstractBorder {
 	 * 
 	 * @see org.eclipse.draw2d.Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/MidpointLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/MidpointLocator.java
@@ -54,6 +54,7 @@ public class MidpointLocator extends ConnectionLocator {
 	 * @return the reference point
 	 * @since 2.0
 	 */
+	@Override
 	protected Point getReferencePoint() {
 		Connection conn = getConnection();
 		Point p = Point.SINGLETON;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseEvent.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseEvent.java
@@ -78,6 +78,7 @@ public class MouseEvent extends InputEvent {
 	/**
 	 * @see Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "MouseEvent(" + x + ',' + y + ") to Figure: " + source;//$NON-NLS-2$//$NON-NLS-1$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseListener.java
@@ -45,18 +45,21 @@ public interface MouseListener {
 		/**
 		 * @see org.eclipse.draw2d.MouseListener#mousePressed(MouseEvent)
 		 */
+		@Override
 		public void mousePressed(MouseEvent me) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.MouseListener#mouseReleased(MouseEvent)
 		 */
+		@Override
 		public void mouseReleased(MouseEvent me) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.MouseListener#mouseDoubleClicked(MouseEvent)
 		 */
+		@Override
 		public void mouseDoubleClicked(MouseEvent me) {
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseMotionListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseMotionListener.java
@@ -58,30 +58,35 @@ public interface MouseMotionListener {
 		/**
 		 * @see org.eclipse.draw2d.MouseMotionListener#mouseDragged(MouseEvent)
 		 */
+		@Override
 		public void mouseDragged(MouseEvent me) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.MouseMotionListener#mouseEntered(MouseEvent)
 		 */
+		@Override
 		public void mouseEntered(MouseEvent me) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.MouseMotionListener#mouseExited(MouseEvent)
 		 */
+		@Override
 		public void mouseExited(MouseEvent me) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.MouseMotionListener#mouseMoved(MouseEvent)
 		 */
+		@Override
 		public void mouseMoved(MouseEvent me) {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.MouseMotionListener#mouseHover(MouseEvent)
 		 */
+		@Override
 		public void mouseHover(MouseEvent me) {
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
@@ -42,6 +42,7 @@ public final class NativeGraphicsSource implements GraphicsSource {
 	 * 
 	 * @see GraphicsSource#getGraphics(Rectangle)
 	 */
+	@Override
 	public Graphics getGraphics(Rectangle r) {
 		canvas.redraw(r.x, r.y, r.width, r.height, false);
 
@@ -61,6 +62,7 @@ public final class NativeGraphicsSource implements GraphicsSource {
 	 * 
 	 * @see GraphicsSource#flushGraphics(Rectangle)
 	 */
+	@Override
 	public void flushGraphics(Rectangle region) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Panel.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Panel.java
@@ -27,6 +27,7 @@ public class Panel extends Figure {
 	 * @return the opaque state of this figure
 	 * @since 2.0
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Polygon.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Polygon.java
@@ -30,12 +30,14 @@ public class Polygon extends Polyline {
 	 * @param y the Y coordinate
 	 * @return whether the point (x,y) is contained in this polygon
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		if (!getBounds().contains(x, y))
 			return false;
 		return shapeContainsPoint(x, y) || childrenContainsPoint(x, y);
 	}
 
+	@Override
 	protected boolean shapeContainsPoint(int x, int y) {
 		return Geometry.polygonContainsPoint(points, x, y);
 	}
@@ -46,6 +48,7 @@ public class Polygon extends Polyline {
 	 * @param g the Graphics object
 	 * @since 2.0
 	 */
+	@Override
 	protected void fillShape(Graphics g) {
 		g.fillPolygon(getPoints());
 	}
@@ -56,6 +59,7 @@ public class Polygon extends Polyline {
 	 * @param g the Graphics object
 	 * @since 2.0
 	 */
+	@Override
 	protected void outlineShape(Graphics g) {
 		g.drawPolygon(getPoints());
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PolygonDecoration.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PolygonDecoration.java
@@ -59,6 +59,7 @@ public class PolygonDecoration extends Polygon implements RotatableDecoration {
 	/**
 	 * @see org.eclipse.draw2d.IFigure#getBackgroundColor()
 	 */
+	@Override
 	public Color getLocalBackgroundColor() {
 		if (super.getLocalBackgroundColor() == null)
 			return getForegroundColor();
@@ -71,6 +72,7 @@ public class PolygonDecoration extends Polygon implements RotatableDecoration {
 	 * @return the points in this PolygonDecoration
 	 * @since 2.0
 	 */
+	@Override
 	public PointList getPoints() {
 		if (points == null) {
 			points = new PointList();
@@ -85,6 +87,7 @@ public class PolygonDecoration extends Polygon implements RotatableDecoration {
 	 * 
 	 * @param p the new location
 	 */
+	@Override
 	public void setLocation(Point p) {
 		points = null;
 		bounds = null;
@@ -128,6 +131,7 @@ public class PolygonDecoration extends Polygon implements RotatableDecoration {
 	 * 
 	 * @param ref the reference point
 	 */
+	@Override
 	public void setReferencePoint(Point ref) {
 		Point pt = Point.SINGLETON;
 		pt.setLocation(ref);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PolygonShape.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PolygonShape.java
@@ -24,11 +24,13 @@ import org.eclipse.draw2d.geometry.Point;
  */
 public class PolygonShape extends AbstractPointListShape {
 
+	@Override
 	protected boolean shapeContainsPoint(int x, int y) {
 		Point location = getLocation();
 		return Geometry.polygonContainsPoint(points, x - location.x, y - location.y);
 	}
 
+	@Override
 	protected void fillShape(Graphics graphics) {
 		graphics.pushState();
 		graphics.translate(getLocation());
@@ -36,6 +38,7 @@ public class PolygonShape extends AbstractPointListShape {
 		graphics.popState();
 	}
 
+	@Override
 	protected void outlineShape(Graphics graphics) {
 		graphics.pushState();
 		graphics.translate(getLocation());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Polyline.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Polyline.java
@@ -39,6 +39,7 @@ public class Polyline extends AbstractPointListShape {
 	/**
 	 * @see org.eclipse.draw2d.IFigure#containsPoint(int, int)
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		int tolerance = (int) Math.max(getLineWidthFloat() / 2.0f, this.tolerance);
 		LINEBOUNDS.setBounds(getBounds());
@@ -48,6 +49,7 @@ public class Polyline extends AbstractPointListShape {
 		return shapeContainsPoint(x, y) || childrenContainsPoint(x, y);
 	}
 
+	@Override
 	protected boolean shapeContainsPoint(int x, int y) {
 		return Geometry.polylineContainsPoint(points, x, y, tolerance);
 	}
@@ -57,12 +59,14 @@ public class Polyline extends AbstractPointListShape {
 	 * 
 	 * @see org.eclipse.draw2d.Shape#fillShape(Graphics)
 	 */
+	@Override
 	protected void fillShape(Graphics g) {
 	}
 
 	/**
 	 * @see org.eclipse.draw2d.IFigure#getBounds()
 	 */
+	@Override
 	public Rectangle getBounds() {
 		if (bounds == null) {
 			int expand = (int) (getLineWidthFloat() / 2.0f);
@@ -74,6 +78,7 @@ public class Polyline extends AbstractPointListShape {
 	/**
 	 * @return <code>false</code> because Polyline's aren't filled
 	 */
+	@Override
 	public boolean isOpaque() {
 		return false;
 	}
@@ -81,6 +86,7 @@ public class Polyline extends AbstractPointListShape {
 	/**
 	 * @see Shape#outlineShape(Graphics)
 	 */
+	@Override
 	protected void outlineShape(Graphics g) {
 		g.drawPolyline(points);
 	}
@@ -88,6 +94,7 @@ public class Polyline extends AbstractPointListShape {
 	/**
 	 * @see Figure#primTranslate(int, int)
 	 */
+	@Override
 	public void primTranslate(int x, int y) {
 	}
 
@@ -96,6 +103,7 @@ public class Polyline extends AbstractPointListShape {
 	 * 
 	 * @since 2.0
 	 */
+	@Override
 	public void removeAllPoints() {
 		super.removeAllPoints();
 		bounds = null;
@@ -104,6 +112,7 @@ public class Polyline extends AbstractPointListShape {
 	/**
 	 * @see org.eclipse.draw2d.Shape#setLineWidth(int)
 	 */
+	@Override
 	public void setLineWidth(int w) {
 		if (getLineWidthFloat() == w) {
 			return;
@@ -124,6 +133,7 @@ public class Polyline extends AbstractPointListShape {
 	 * @param points new set of points
 	 * @since 2.0
 	 */
+	@Override
 	public void setPoints(PointList points) {
 		super.setPoints(points);
 		firePropertyChange(Connection.PROPERTY_POINTS, null, points);
@@ -138,6 +148,7 @@ public class Polyline extends AbstractPointListShape {
 		this.tolerance = tolerance;
 	}
 
+	@Override
 	public void repaint() {
 		bounds = null;
 		super.repaint();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineConnection.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineConnection.java
@@ -47,6 +47,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @see Figure#addNotify()
 	 */
+	@Override
 	public void addNotify() {
 		super.addNotify();
 		hookSourceAnchor();
@@ -73,6 +74,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @param anchor the anchor that moved
 	 */
+	@Override
 	public void anchorMoved(ConnectionAnchor anchor) {
 		revalidate();
 	}
@@ -99,6 +101,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @return this connection's router
 	 */
+	@Override
 	public ConnectionRouter getConnectionRouter() {
 		if (connectionRouter instanceof RoutingNotifier)
 			return ((RoutingNotifier) connectionRouter).realRouter;
@@ -111,6 +114,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @return the connection's routing constraint
 	 */
+	@Override
 	public Object getRoutingConstraint() {
 		if (getConnectionRouter() != null)
 			return getConnectionRouter().getConstraint(this);
@@ -121,6 +125,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	/**
 	 * @return the anchor at the start of this polyline connection (may be null)
 	 */
+	@Override
 	public ConnectionAnchor getSourceAnchor() {
 		return startAnchor;
 	}
@@ -135,6 +140,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	/**
 	 * @return the anchor at the end of this polyline connection (may be null)
 	 */
+	@Override
 	public ConnectionAnchor getTargetAnchor() {
 		return endAnchor;
 	}
@@ -163,6 +169,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * connection router is used to route this, after which it is laid out. It also
 	 * fires a moved method.
 	 */
+	@Override
 	public void layout() {
 		if (getSourceAnchor() != null && getTargetAnchor() != null)
 			connectionRouter.route(this);
@@ -186,6 +193,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @since 2.0
 	 */
+	@Override
 	public void removeNotify() {
 		unhookSourceAnchor();
 		unhookTargetAnchor();
@@ -211,6 +219,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	/**
 	 * @see IFigure#revalidate()
 	 */
+	@Override
 	public void revalidate() {
 		super.revalidate();
 		connectionRouter.invalidate(this);
@@ -222,6 +231,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @param cr the connection router
 	 */
+	@Override
 	public void setConnectionRouter(ConnectionRouter cr) {
 		if (cr == null)
 			cr = ConnectionRouter.NULL;
@@ -242,6 +252,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @param cons the constraint
 	 */
+	@Override
 	public void setRoutingConstraint(Object cons) {
 		if (connectionRouter != null)
 			connectionRouter.setConstraint(this, cons);
@@ -253,6 +264,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @param anchor the new source anchor
 	 */
+	@Override
 	public void setSourceAnchor(ConnectionAnchor anchor) {
 		if (anchor == startAnchor)
 			return;
@@ -287,6 +299,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * 
 	 * @param anchor the new target anchor
 	 */
+	@Override
 	public void setTargetAnchor(ConnectionAnchor anchor) {
 		if (anchor == endAnchor)
 			return;
@@ -334,10 +347,12 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 			listeners.add(listener);
 		}
 
+		@Override
 		public Object getConstraint(Connection connection) {
 			return realRouter.getConstraint(connection);
 		}
 
+		@Override
 		public void invalidate(Connection connection) {
 			for (int i = 0; i < listeners.size(); i++)
 				((RoutingListener) listeners.get(i)).invalidate(connection);
@@ -345,6 +360,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 			realRouter.invalidate(connection);
 		}
 
+		@Override
 		public void route(Connection connection) {
 			boolean consumed = false;
 			for (int i = 0; i < listeners.size(); i++)
@@ -357,12 +373,14 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 				((RoutingListener) listeners.get(i)).postRoute(connection);
 		}
 
+		@Override
 		public void remove(Connection connection) {
 			for (int i = 0; i < listeners.size(); i++)
 				((RoutingListener) listeners.get(i)).remove(connection);
 			realRouter.remove(connection);
 		}
 
+		@Override
 		public void setConstraint(Connection connection, Object constraint) {
 			for (int i = 0; i < listeners.size(); i++)
 				((RoutingListener) listeners.get(i)).setConstraint(connection, constraint);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineDecoration.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineDecoration.java
@@ -47,6 +47,7 @@ public class PolylineDecoration extends Polyline implements RotatableDecoration 
 	/**
 	 * @see Polyline#getPoints()
 	 */
+	@Override
 	public PointList getPoints() {
 		if (points == null) {
 			points = new PointList();
@@ -59,6 +60,7 @@ public class PolylineDecoration extends Polyline implements RotatableDecoration 
 	/**
 	 * @see IFigure#setLocation(Point)
 	 */
+	@Override
 	public void setLocation(Point p) {
 		points = null;
 		bounds = null;
@@ -99,6 +101,7 @@ public class PolylineDecoration extends Polyline implements RotatableDecoration 
 	/**
 	 * @see RotatableDecoration#setReferencePoint(Point)
 	 */
+	@Override
 	public void setReferencePoint(Point ref) {
 		Point pt = Point.SINGLETON;
 		pt.setLocation(ref);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineShape.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineShape.java
@@ -30,14 +30,17 @@ public class PolylineShape extends AbstractPointListShape {
 	 * @return true if the distance between specified point and closest segment of
 	 *         this PolyLine is less then {@link PolylineShape#tolerance}
 	 */
+	@Override
 	protected boolean shapeContainsPoint(int x, int y) {
 		Point location = getLocation();
 		return Geometry.polylineContainsPoint(points, x - location.x, y - location.y, tolerance);
 	}
 
+	@Override
 	protected void fillShape(Graphics graphics) {
 	}
 
+	@Override
 	protected void outlineShape(Graphics graphics) {
 		graphics.pushState();
 		graphics.translate(getLocation());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintFigureOperation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintFigureOperation.java
@@ -80,6 +80,7 @@ public class PrintFigureOperation extends PrintOperation {
 	 *         otherwise
 	 * @see org.eclipse.draw2d.PrintOperation#getGraphicsOrientation()
 	 */
+	@Override
 	int getGraphicsOrientation() {
 		return getPrintSource().isMirrored() ? SWT.RIGHT_TO_LEFT : SWT.LEFT_TO_RIGHT;
 	}
@@ -106,6 +107,7 @@ public class PrintFigureOperation extends PrintOperation {
 	/**
 	 * @see org.eclipse.draw2d.PrintOperation#preparePrintSource()
 	 */
+	@Override
 	protected void preparePrintSource() {
 		oldBGColor = getPrintSource().getLocalBackgroundColor();
 		getPrintSource().setBackgroundColor(ColorConstants.white);
@@ -116,6 +118,7 @@ public class PrintFigureOperation extends PrintOperation {
 	 * 
 	 * @see org.eclipse.draw2d.PrintOperation#printPages()
 	 */
+	@Override
 	protected void printPages() {
 		Graphics graphics = getFreshPrinterGraphics();
 		IFigure figure = getPrintSource();
@@ -144,6 +147,7 @@ public class PrintFigureOperation extends PrintOperation {
 	/**
 	 * @see org.eclipse.draw2d.PrintOperation#restorePrintSource()
 	 */
+	@Override
 	protected void restorePrintSource() {
 		getPrintSource().setBackgroundColor(oldBGColor);
 		oldBGColor = null;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PrinterGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PrinterGraphics.java
@@ -44,6 +44,7 @@ public class PrinterGraphics extends ScaledGraphics {
 		printer = p;
 	}
 
+	@Override
 	Font createFont(FontData data) {
 		return new Font(printer, data);
 	}
@@ -61,6 +62,7 @@ public class PrinterGraphics extends ScaledGraphics {
 	/**
 	 * @see org.eclipse.draw2d.ScaledGraphics#dispose()
 	 */
+	@Override
 	public void dispose() {
 		super.dispose();
 
@@ -77,6 +79,7 @@ public class PrinterGraphics extends ScaledGraphics {
 	/**
 	 * @see org.eclipse.draw2d.Graphics#drawImage(Image, int, int)
 	 */
+	@Override
 	public void drawImage(Image srcImage, int x, int y) {
 		super.drawImage(printerImage(srcImage), x, y);
 	}
@@ -84,10 +87,12 @@ public class PrinterGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#drawImage(Image, int, int, int, int, int, int, int, int)
 	 */
+	@Override
 	public void drawImage(Image srcImage, int sx, int sy, int sw, int sh, int tx, int ty, int tw, int th) {
 		super.drawImage(printerImage(srcImage), sx, sy, sw, sh, tx, ty, tw, th);
 	}
 
+	@Override
 	int zoomFontHeight(int height) {
 		return (int) (height * zoom * Display.getCurrent().getDPI().y / printer.getDPI().y + 0.0000001);
 	}
@@ -95,6 +100,7 @@ public class PrinterGraphics extends ScaledGraphics {
 	/**
 	 * @see org.eclipse.draw2d.ScaledGraphics#zoomLineWidth(float)
 	 */
+	@Override
 	float zoomLineWidth(float w) {
 		return (float) (w * zoom);
 	}
@@ -104,6 +110,7 @@ public class PrinterGraphics extends ScaledGraphics {
 	 * 
 	 * @see org.eclipse.draw2d.ScaledGraphics#setLineAttributes(org.eclipse.swt.graphics.LineAttributes)
 	 */
+	@Override
 	public void setLineAttributes(LineAttributes attributes) {
 		if (attributes.style == SWT.LINE_CUSTOM && attributes.dash != null && attributes.dash.length > 0) {
 			float[] newDashes = new float[attributes.dash.length];

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PuristicScrollPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PuristicScrollPane.java
@@ -46,6 +46,7 @@ public class PuristicScrollPane extends ScrollPane {
 		/**
 		 * @see org.eclipse.draw2d.ScrollBar#createDefaultDownButton()
 		 */
+		@Override
 		protected Clickable createDefaultDownButton() {
 			Clickable buttonDown = super.createDefaultDownButton();
 			buttonDown.setBorder(null);
@@ -56,6 +57,7 @@ public class PuristicScrollPane extends ScrollPane {
 		/**
 		 * @see org.eclipse.draw2d.ScrollBar#createDefaultThumb()
 		 */
+		@Override
 		protected IFigure createDefaultThumb() {
 			return null;
 		}
@@ -63,6 +65,7 @@ public class PuristicScrollPane extends ScrollPane {
 		/**
 		 * @see org.eclipse.draw2d.ScrollBar#createDefaultUpButton()
 		 */
+		@Override
 		protected Clickable createDefaultUpButton() {
 			Clickable buttonUp = super.createDefaultUpButton();
 			buttonUp.setBorder(null);
@@ -73,6 +76,7 @@ public class PuristicScrollPane extends ScrollPane {
 		/**
 		 * @see org.eclipse.draw2d.ScrollBar#createPageDown()
 		 */
+		@Override
 		protected Clickable createPageDown() {
 			return null;
 		}
@@ -80,6 +84,7 @@ public class PuristicScrollPane extends ScrollPane {
 		/**
 		 * @see org.eclipse.draw2d.ScrollBar#createPageUp()
 		 */
+		@Override
 		protected Clickable createPageUp() {
 			return null;
 		}
@@ -87,6 +92,7 @@ public class PuristicScrollPane extends ScrollPane {
 		/**
 		 * @see PropertyChangeListener#propertyChange(java.beans. PropertyChangeEvent )
 		 */
+		@Override
 		public void propertyChange(PropertyChangeEvent event) {
 			if (event.getSource() instanceof RangeModel) {
 				getButtonDown().setVisible(getValue() != getMaximum() - getExtent());
@@ -100,6 +106,7 @@ public class PuristicScrollPane extends ScrollPane {
 	public PuristicScrollPane() {
 		// layout to ensure, viewport gets complete client area
 		setLayoutManager(new ScrollPaneLayout() {
+			@Override
 			public void layout(IFigure parent) {
 				// scroll panes are layouted normally
 				super.layout(parent);
@@ -114,6 +121,7 @@ public class PuristicScrollPane extends ScrollPane {
 	/**
 	 * @see org.eclipse.draw2d.ScrollPane#createVerticalScrollBar()
 	 */
+	@Override
 	protected void createVerticalScrollBar() {
 		PuristicScrollBar verticalScrollBar = new PuristicScrollBar(false);
 		setVerticalScrollBar(verticalScrollBar);
@@ -122,6 +130,7 @@ public class PuristicScrollPane extends ScrollPane {
 	/**
 	 * @see org.eclipse.draw2d.ScrollPane#createHorizontalScrollBar()
 	 */
+	@Override
 	protected void createHorizontalScrollBar() {
 		PuristicScrollBar horizontalScrollBar = new PuristicScrollBar(true);
 		setHorizontalScrollBar(horizontalScrollBar);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RectangleFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RectangleFigure.java
@@ -25,6 +25,7 @@ public class RectangleFigure extends Shape {
 	/**
 	 * @see Shape#fillShape(Graphics)
 	 */
+	@Override
 	protected void fillShape(Graphics graphics) {
 		graphics.fillRectangle(getBounds());
 	}
@@ -32,6 +33,7 @@ public class RectangleFigure extends Shape {
 	/**
 	 * @see Shape#outlineShape(Graphics)
 	 */
+	@Override
 	protected void outlineShape(Graphics graphics) {
 		float lineInset = Math.max(1.0f, getLineWidthFloat()) / 2.0f;
 		int inset1 = (int) Math.floor(lineInset);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RelativeBendpoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RelativeBendpoint.java
@@ -61,6 +61,7 @@ public class RelativeBendpoint implements Bendpoint {
 	 * @return This Bendpoint's new location
 	 * @since 2.0
 	 */
+	@Override
 	public Point getLocation() {
 		PrecisionPoint a1 = new PrecisionPoint(getConnection().getSourceAnchor().getReferencePoint());
 		PrecisionPoint a2 = new PrecisionPoint(getConnection().getTargetAnchor().getReferencePoint());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RelativeLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RelativeLocator.java
@@ -117,6 +117,7 @@ public class RelativeLocator implements Locator {
 	 * 
 	 * @see org.eclipse.draw2d.Locator#relocate(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void relocate(IFigure target) {
 		IFigure reference = getReferenceFigure();
 		Rectangle targetBounds = new PrecisionRectangle(getReferenceBox().getResized(-1, -1));

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RotatableDecoration.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RotatableDecoration.java
@@ -22,6 +22,7 @@ public interface RotatableDecoration extends IFigure {
 	 * 
 	 * @param p The location
 	 */
+	@Override
 	void setLocation(Point p);
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RoundedRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RoundedRectangle.java
@@ -35,6 +35,7 @@ public class RoundedRectangle extends Shape {
 	/**
 	 * @see Shape#fillShape(Graphics)
 	 */
+	@Override
 	protected void fillShape(Graphics graphics) {
 		graphics.fillRoundRectangle(getBounds(), corner.width, corner.height);
 	}
@@ -42,6 +43,7 @@ public class RoundedRectangle extends Shape {
 	/**
 	 * @see Shape#outlineShape(Graphics)
 	 */
+	@Override
 	protected void outlineShape(Graphics graphics) {
 		float lineInset = Math.max(1.0f, getLineWidthFloat()) / 2.0f;
 		int inset1 = (int) Math.floor(lineInset);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RoutingAnimator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RoutingAnimator.java
@@ -45,6 +45,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see Animator#playbackStarting(IFigure)
 	 */
+	@Override
 	public void playbackStarting(IFigure connection) {
 		reconcileStates((Connection) connection);
 	}
@@ -56,6 +57,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see Animator#getCurrentState(IFigure)
 	 */
+	@Override
 	protected Object getCurrentState(IFigure connection) {
 		return ((Connection) connection).getPoints().getCopy();
 	}
@@ -75,6 +77,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see RoutingListener#invalidate(Connection)
 	 */
+	@Override
 	public final void invalidate(Connection conn) {
 		if (Animation.isInitialRecording())
 			Animation.hookAnimator(conn, this);
@@ -85,6 +88,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see Animator#playback(IFigure)
 	 */
+	@Override
 	protected boolean playback(IFigure figure) {
 		Connection conn = (Connection) figure;
 
@@ -117,6 +121,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see RoutingListener#postRoute(Connection)
 	 */
+	@Override
 	public final void postRoute(Connection connection) {
 		if (Animation.isFinalRecording())
 			Animation.hookNeedsCapture(connection, this);
@@ -190,6 +195,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see RoutingListener#remove(Connection)
 	 */
+	@Override
 	public final void remove(Connection connection) {
 	}
 
@@ -198,6 +204,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see RoutingListener#route(Connection)
 	 */
+	@Override
 	public final boolean route(Connection conn) {
 		return Animation.isAnimating() && Animation.hookPlayback(conn, this);
 	}
@@ -207,6 +214,7 @@ public class RoutingAnimator extends Animator implements RoutingListener {
 	 * 
 	 * @see RoutingListener#setConstraint(Connection, Object)
 	 */
+	@Override
 	public final void setConstraint(Connection connection, Object constraint) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RoutingListener.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RoutingListener.java
@@ -72,19 +72,24 @@ public interface RoutingListener {
 	 * @since 3.2
 	 */
 	class Stub implements RoutingListener {
+		@Override
 		public void invalidate(Connection connection) {
 		}
 
+		@Override
 		public void postRoute(Connection connection) {
 		}
 
+		@Override
 		public void remove(Connection connection) {
 		}
 
+		@Override
 		public boolean route(Connection connection) {
 			return false;
 		}
 
+		@Override
 		public void setConstraint(Connection connection, Object constraint) {
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTEventDispatcher.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTEventDispatcher.java
@@ -58,58 +58,72 @@ public class SWTEventDispatcher extends EventDispatcher {
 	 */
 	protected class FigureAccessibilityDispatcher extends AccessibilityDispatcher {
 		/** @see AccessibleControlListener#getChildAtPoint(AccessibleControlEvent) */
+		@Override
 		public void getChildAtPoint(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getChildCount(AccessibleControlEvent) */
+		@Override
 		public void getChildCount(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getChildren(AccessibleControlEvent) */
+		@Override
 		public void getChildren(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getDefaultAction(AccessibleControlEvent) */
+		@Override
 		public void getDefaultAction(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleListener#getDescription(AccessibleEvent) */
+		@Override
 		public void getDescription(AccessibleEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getFocus(AccessibleControlEvent) */
+		@Override
 		public void getFocus(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleListener#getHelp(AccessibleEvent) */
+		@Override
 		public void getHelp(AccessibleEvent e) {
 		}
 
 		/** @see AccessibleListener#getKeyboardShortcut(AccessibleEvent) */
+		@Override
 		public void getKeyboardShortcut(AccessibleEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getLocation(AccessibleControlEvent) */
+		@Override
 		public void getLocation(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleListener#getName(AccessibleEvent) */
+		@Override
 		public void getName(AccessibleEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getRole(AccessibleControlEvent) */
+		@Override
 		public void getRole(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getSelection(AccessibleControlEvent) */
+		@Override
 		public void getSelection(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getState(AccessibleControlEvent) */
+		@Override
 		public void getState(AccessibleControlEvent e) {
 		}
 
 		/** @see AccessibleControlListener#getValue(AccessibleControlEvent) */
+		@Override
 		public void getValue(AccessibleControlEvent e) {
 		}
 	}
@@ -117,6 +131,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchFocusGained(org.eclipse.swt.events.FocusEvent)
 	 */
+	@Override
 	public void dispatchFocusGained(org.eclipse.swt.events.FocusEvent e) {
 		IFigure currentFocusOwner = getFocusTraverseManager().getCurrentFocusOwner();
 
@@ -132,6 +147,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchFocusLost(org.eclipse.swt.events.FocusEvent)
 	 */
+	@Override
 	public void dispatchFocusLost(org.eclipse.swt.events.FocusEvent e) {
 		setFocus(null);
 	}
@@ -139,6 +155,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchKeyPressed(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	public void dispatchKeyPressed(org.eclipse.swt.events.KeyEvent e) {
 		if (focusOwner != null) {
 			KeyEvent event = new KeyEvent(this, focusOwner, e);
@@ -149,6 +166,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchKeyReleased(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	public void dispatchKeyReleased(org.eclipse.swt.events.KeyEvent e) {
 		if (focusOwner != null) {
 			KeyEvent event = new KeyEvent(this, focusOwner, e);
@@ -159,6 +177,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchKeyTraversed(TraverseEvent)
 	 */
+	@Override
 	public void dispatchKeyTraversed(TraverseEvent e) {
 		if (!figureTraverse)
 			return;
@@ -178,6 +197,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseHover(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseHover(org.eclipse.swt.events.MouseEvent me) {
 		receive(me);
 		if (mouseTarget != null)
@@ -199,6 +219,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseDoubleClicked(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseDoubleClicked(org.eclipse.swt.events.MouseEvent me) {
 		receive(me);
 		if (mouseTarget != null)
@@ -208,6 +229,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseEntered(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseEntered(org.eclipse.swt.events.MouseEvent me) {
 		receive(me);
 	}
@@ -215,6 +237,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseExited(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseExited(org.eclipse.swt.events.MouseEvent me) {
 		setHoverSource(null, me);
 		if (mouseTarget != null) {
@@ -228,6 +251,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMousePressed(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMousePressed(org.eclipse.swt.events.MouseEvent me) {
 		receive(me);
 		if (mouseTarget != null) {
@@ -240,6 +264,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseMoved(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseMoved(org.eclipse.swt.events.MouseEvent me) {
 		receive(me);
 		if (mouseTarget != null) {
@@ -253,6 +278,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseReleased(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseReleased(org.eclipse.swt.events.MouseEvent me) {
 		receive(me);
 		if (mouseTarget != null) {
@@ -265,6 +291,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#getAccessibilityDispatcher()
 	 */
+	@Override
 	protected AccessibilityDispatcher getAccessibilityDispatcher() {
 		return null;
 	}
@@ -322,6 +349,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	 * @see EventDispatcher#getFocusOwner()
 	 * @since 3.6
 	 */
+	@Override
 	public IFigure getFocusOwner() {
 		return focusOwner;
 	}
@@ -349,6 +377,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#isCaptured()
 	 */
+	@Override
 	public boolean isCaptured() {
 		return captured;
 	}
@@ -381,6 +410,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#releaseCapture()
 	 */
+	@Override
 	protected void releaseCapture() {
 		captured = false;
 	}
@@ -388,6 +418,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#requestFocus(IFigure)
 	 */
+	@Override
 	public void requestFocus(IFigure fig) {
 		setFocus(fig);
 	}
@@ -395,6 +426,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#requestRemoveFocus(IFigure)
 	 */
+	@Override
 	public void requestRemoveFocus(IFigure fig) {
 		if (getFocusOwner() == fig)
 			setFocus(null);
@@ -410,6 +442,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#setCapture(IFigure)
 	 */
+	@Override
 	protected void setCapture(IFigure figure) {
 		captured = true;
 		mouseTarget = figure;
@@ -418,6 +451,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#setControl(Control)
 	 */
+	@Override
 	public void setControl(Control c) {
 		if (c == control)
 			return;
@@ -425,6 +459,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 			throw new RuntimeException("Can not set control again once it has been set"); //$NON-NLS-1$
 		if (c != null)
 			c.addDisposeListener(new org.eclipse.swt.events.DisposeListener() {
+				@Override
 				public void widgetDisposed(DisposeEvent e) {
 					if (toolTipHelper != null)
 						toolTipHelper.dispose();
@@ -525,6 +560,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#setRoot(IFigure)
 	 */
+	@Override
 	public void setRoot(IFigure figure) {
 		root = figure;
 	}
@@ -532,6 +568,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	/**
 	 * @see EventDispatcher#updateCursor()
 	 */
+	@Override
 	protected void updateCursor() {
 		Cursor newCursor = null;
 		if (cursorTarget != null)

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
@@ -109,6 +109,7 @@ public class SWTGraphics extends Graphics {
 			bottom = rect.bottom();
 		}
 
+		@Override
 		public Rectangle getBoundingBox(Rectangle rect) {
 			rect.x = (int) left;
 			rect.y = (int) top;
@@ -117,10 +118,12 @@ public class SWTGraphics extends Graphics {
 			return rect;
 		}
 
+		@Override
 		public Clipping getCopy() {
 			return new RectangleClipping(left, top, right, bottom);
 		}
 
+		@Override
 		public void intersect(int left, int top, final int right, final int bottom) {
 			this.left = Math.max(this.left, left);
 			this.right = Math.min(this.right, right);
@@ -133,6 +136,7 @@ public class SWTGraphics extends Graphics {
 			}
 		}
 
+		@Override
 		public void scale(float horz, float vert) {
 			left /= horz;
 			right /= horz;
@@ -140,6 +144,7 @@ public class SWTGraphics extends Graphics {
 			bottom /= vert;
 		}
 
+		@Override
 		public void setOn(GC gc, int translateX, int translateY) {
 			int xInt = (int) Math.floor(left);
 			int yInt = (int) Math.floor(top);
@@ -147,6 +152,7 @@ public class SWTGraphics extends Graphics {
 					(int) Math.ceil(bottom) - yInt);
 		}
 
+		@Override
 		public void translate(float dx, float dy) {
 			left += dx;
 			right += dx;
@@ -166,6 +172,7 @@ public class SWTGraphics extends Graphics {
 
 		Pattern fgPattern;
 
+		@Override
 		public Object clone() throws CloneNotSupportedException {
 			State clone = (State) super.clone();
 			clone.lineAttributes = SWTGraphics.clone(clone.lineAttributes);
@@ -349,6 +356,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#clipRect(Rectangle)
 	 */
+	@Override
 	public void clipRect(Rectangle rect) {
 		if (currentState.relativeClip == null) {
 			throw new IllegalStateException("The current clipping area does not " + //$NON-NLS-1$
@@ -363,6 +371,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#dispose()
 	 */
+	@Override
 	public void dispose() {
 		while (stackPointer > 0) {
 			popState();
@@ -376,6 +385,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawArc(int, int, int, int, int, int)
 	 */
+	@Override
 	public void drawArc(int x, int y, int width, int height, int offset, int length) {
 		checkPaint();
 		gc.drawArc(x + translateX, y + translateY, width, height, offset, length);
@@ -384,6 +394,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawFocus(int, int, int, int)
 	 */
+	@Override
 	public void drawFocus(int x, int y, int w, int h) {
 		checkPaint();
 		gc.drawFocus(x + translateX, y + translateY, w + 1, h + 1);
@@ -392,6 +403,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawImage(Image, int, int)
 	 */
+	@Override
 	public void drawImage(Image srcImage, int x, int y) {
 		checkGC();
 		gc.drawImage(srcImage, x + translateX, y + translateY);
@@ -400,6 +412,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawImage(Image, int, int, int, int, int, int, int, int)
 	 */
+	@Override
 	public void drawImage(Image srcImage, int x1, int y1, int w1, int h1, int x2, int y2, int w2, int h2) {
 		checkGC();
 		gc.drawImage(srcImage, x1, y1, w1, h1, x2 + translateX, y2 + translateY, w2, h2);
@@ -408,6 +421,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawLine(int, int, int, int)
 	 */
+	@Override
 	public void drawLine(int x1, int y1, int x2, int y2) {
 		checkPaint();
 		gc.drawLine(x1 + translateX, y1 + translateY, x2 + translateX, y2 + translateY);
@@ -416,6 +430,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawOval(int, int, int, int)
 	 */
+	@Override
 	public void drawOval(int x, int y, int width, int height) {
 		checkPaint();
 		gc.drawOval(x + translateX, y + translateY, width, height);
@@ -428,6 +443,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#drawPath(Path)
 	 */
+	@Override
 	public void drawPath(Path path) {
 		checkPaint();
 		initTransform(false);
@@ -437,6 +453,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawPoint(int, int)
 	 */
+	@Override
 	public void drawPoint(int x, int y) {
 		checkPaint();
 		gc.drawPoint(x + translateX, y + translateY);
@@ -445,6 +462,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawPolygon(int[])
 	 */
+	@Override
 	public void drawPolygon(int[] points) {
 		checkPaint();
 		try {
@@ -458,6 +476,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawPolygon(PointList)
 	 */
+	@Override
 	public void drawPolygon(PointList points) {
 		drawPolygon(points.toIntArray());
 	}
@@ -465,6 +484,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawPolyline(int[])
 	 */
+	@Override
 	public void drawPolyline(int[] points) {
 		checkPaint();
 		try {
@@ -478,6 +498,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawPolyline(PointList)
 	 */
+	@Override
 	public void drawPolyline(PointList points) {
 		drawPolyline(points.toIntArray());
 	}
@@ -485,6 +506,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawRectangle(int, int, int, int)
 	 */
+	@Override
 	public void drawRectangle(int x, int y, int width, int height) {
 		checkPaint();
 		gc.drawRectangle(x + translateX, y + translateY, width, height);
@@ -493,6 +515,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawRoundRectangle(Rectangle, int, int)
 	 */
+	@Override
 	public void drawRoundRectangle(Rectangle r, int arcWidth, int arcHeight) {
 		checkPaint();
 		gc.drawRoundRectangle(r.x + translateX, r.y + translateY, r.width, r.height, arcWidth, arcHeight);
@@ -501,6 +524,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawString(String, int, int)
 	 */
+	@Override
 	public void drawString(String s, int x, int y) {
 		checkText();
 		gc.drawString(s, x + translateX, y + translateY, true);
@@ -509,6 +533,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawText(String, int, int)
 	 */
+	@Override
 	public void drawText(String s, int x, int y) {
 		checkText();
 		gc.drawText(s, x + translateX, y + translateY, true);
@@ -517,6 +542,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawTextLayout(TextLayout, int, int, int, int, Color, Color)
 	 */
+	@Override
 	public void drawTextLayout(TextLayout layout, int x, int y, int selectionStart, int selectionEnd,
 			Color selectionForeground, Color selectionBackground) {
 		// $TODO probably just call checkPaint since Font and BG color don't
@@ -529,6 +555,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillArc(int, int, int, int, int, int)
 	 */
+	@Override
 	public void fillArc(int x, int y, int width, int height, int offset, int length) {
 		checkFill();
 		gc.fillArc(x + translateX, y + translateY, width, height, offset, length);
@@ -537,6 +564,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillGradient(int, int, int, int, boolean)
 	 */
+	@Override
 	public void fillGradient(int x, int y, int w, int h, boolean vertical) {
 		checkPaint();
 		gc.fillGradientRectangle(x + translateX, y + translateY, w, h, vertical);
@@ -545,6 +573,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillOval(int, int, int, int)
 	 */
+	@Override
 	public void fillOval(int x, int y, int width, int height) {
 		checkFill();
 		gc.fillOval(x + translateX, y + translateY, width, height);
@@ -557,6 +586,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#fillPath(Path)
 	 */
+	@Override
 	public void fillPath(Path path) {
 		checkFill();
 		initTransform(false);
@@ -566,6 +596,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillPolygon(int[])
 	 */
+	@Override
 	public void fillPolygon(int[] points) {
 		checkFill();
 		try {
@@ -579,6 +610,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillPolygon(PointList)
 	 */
+	@Override
 	public void fillPolygon(PointList points) {
 		fillPolygon(points.toIntArray());
 	}
@@ -586,6 +618,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillRectangle(int, int, int, int)
 	 */
+	@Override
 	public void fillRectangle(int x, int y, int width, int height) {
 		checkFill();
 		gc.fillRectangle(x + translateX, y + translateY, width, height);
@@ -594,6 +627,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillRoundRectangle(Rectangle, int, int)
 	 */
+	@Override
 	public void fillRoundRectangle(Rectangle r, int arcWidth, int arcHeight) {
 		checkFill();
 		gc.fillRoundRectangle(r.x + translateX, r.y + translateY, r.width, r.height, arcWidth, arcHeight);
@@ -602,6 +636,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillString(String, int, int)
 	 */
+	@Override
 	public void fillString(String s, int x, int y) {
 		checkText();
 		gc.drawString(s, x + translateX, y + translateY, false);
@@ -610,6 +645,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillText(String, int, int)
 	 */
+	@Override
 	public void fillText(String s, int x, int y) {
 		checkText();
 		gc.drawText(s, x + translateX, y + translateY, false);
@@ -618,6 +654,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getAlpha()
 	 */
+	@Override
 	public int getAlpha() {
 		return currentState.alpha;
 	}
@@ -625,10 +662,12 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getAntialias()
 	 */
+	@Override
 	public int getAntialias() {
 		return ((currentState.graphicHints & AA_MASK) >> AA_SHIFT) - AA_WHOLE_NUMBER;
 	}
 
+	@Override
 	public boolean getAdvanced() {
 		return (currentState.graphicHints & ADVANCED_GRAPHICS_MASK) != 0;
 	}
@@ -636,6 +675,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getBackgroundColor()
 	 */
+	@Override
 	public Color getBackgroundColor() {
 		return currentState.bgColor;
 	}
@@ -643,6 +683,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getClip(Rectangle)
 	 */
+	@Override
 	public Rectangle getClip(Rectangle rect) {
 		if (currentState.relativeClip != null) {
 			currentState.relativeClip.getBoundingBox(rect);
@@ -655,6 +696,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getFillRule()
 	 */
+	@Override
 	public int getFillRule() {
 		return ((currentState.graphicHints & FILL_RULE_MASK) >> FILL_RULE_SHIFT) - FILL_RULE_WHOLE_NUMBER;
 	}
@@ -662,6 +704,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getFont()
 	 */
+	@Override
 	public Font getFont() {
 		return currentState.font;
 	}
@@ -669,6 +712,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getFontMetrics()
 	 */
+	@Override
 	public FontMetrics getFontMetrics() {
 		checkText();
 		return gc.getFontMetrics();
@@ -677,6 +721,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getForegroundColor()
 	 */
+	@Override
 	public Color getForegroundColor() {
 		return currentState.fgColor;
 	}
@@ -684,6 +729,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getInterpolation()
 	 */
+	@Override
 	public int getInterpolation() {
 		return ((currentState.graphicHints & INTERPOLATION_MASK) >> INTERPOLATION_SHIFT) - INTERPOLATION_WHOLE_NUMBER;
 	}
@@ -698,6 +744,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getLineCap()
 	 */
+	@Override
 	public int getLineCap() {
 		return currentState.lineAttributes.cap;
 	}
@@ -705,6 +752,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getLineJoin()
 	 */
+	@Override
 	public int getLineJoin() {
 		return currentState.lineAttributes.join;
 	}
@@ -712,6 +760,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getLineStyle()
 	 */
+	@Override
 	public int getLineStyle() {
 		return currentState.lineAttributes.style;
 	}
@@ -719,14 +768,17 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getLineWidth()
 	 */
+	@Override
 	public int getLineWidth() {
 		return (int) currentState.lineAttributes.width;
 	}
 
+	@Override
 	public float getLineWidthFloat() {
 		return currentState.lineAttributes.width;
 	}
 
+	@Override
 	public float getLineMiterLimit() {
 		return currentState.lineAttributes.miterLimit;
 	}
@@ -748,6 +800,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getTextAntialias()
 	 */
+	@Override
 	public int getTextAntialias() {
 		return ((currentState.graphicHints & TEXT_AA_MASK) >> TEXT_AA_SHIFT) - AA_WHOLE_NUMBER;
 	}
@@ -755,6 +808,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#getXORMode()
 	 */
+	@Override
 	public boolean getXORMode() {
 		return (currentState.graphicHints & XOR_MASK) != 0;
 	}
@@ -797,6 +851,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#popState()
 	 */
+	@Override
 	public void popState() {
 		stackPointer--;
 		restoreState((State) stack.get(stackPointer));
@@ -805,6 +860,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#pushState()
 	 */
+	@Override
 	public void pushState() {
 		if (currentState.relativeClip == null) {
 			throw new IllegalStateException("The clipping has been modified in" + //$NON-NLS-1$
@@ -873,6 +929,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#restoreState()
 	 */
+	@Override
 	public void restoreState() {
 		restoreState((State) stack.get(stackPointer - 1));
 	}
@@ -926,6 +983,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#rotate(float)
 	 */
+	@Override
 	public void rotate(float degrees) {
 		// Flush clipping, patter, etc., before applying transform
 		checkGC();
@@ -941,6 +999,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#scale(double)
 	 */
+	@Override
 	public void scale(double factor) {
 		scale((float) factor, (float) factor);
 	}
@@ -952,6 +1011,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see org.eclipse.draw2d.Graphics#scale(float, float)
 	 */
+	@Override
 	public void scale(float horizontal, float vertical) {
 		// Flush any clipping before scaling
 		checkGC();
@@ -987,6 +1047,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#setAlpha(int)
 	 */
+	@Override
 	public void setAlpha(int alpha) {
 		currentState.graphicHints |= ADVANCED_GRAPHICS_MASK;
 		if (currentState.alpha != alpha)
@@ -1000,11 +1061,13 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#setAntialias(int)
 	 */
+	@Override
 	public void setAntialias(int value) {
 		currentState.graphicHints &= ~AA_MASK;
 		currentState.graphicHints |= ADVANCED_GRAPHICS_MASK | (value + AA_WHOLE_NUMBER) << AA_SHIFT;
 	}
 
+	@Override
 	public void setAdvanced(boolean value) {
 		if (value) {
 			currentState.graphicHints |= ADVANCED_GRAPHICS_MASK;
@@ -1016,6 +1079,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setBackgroundColor(Color)
 	 */
+	@Override
 	public void setBackgroundColor(Color color) {
 		currentState.bgColor = color;
 		if (currentState.bgPattern != null) {
@@ -1028,6 +1092,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setBackgroundPattern(Pattern)
 	 */
+	@Override
 	public void setBackgroundPattern(Pattern pattern) {
 		currentState.graphicHints |= ADVANCED_GRAPHICS_MASK;
 		if (currentState.bgPattern == pattern) {
@@ -1048,6 +1113,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#setClip(Path)
 	 */
+	@Override
 	public void setClip(Path path) {
 		initTransform(false);
 		if (((appliedState.graphicHints ^ currentState.graphicHints) & FILL_RULE_MASK) != 0) {
@@ -1069,6 +1135,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see org.eclipse.draw2d.Graphics#clipPath(org.eclipse.swt.graphics.Path)
 	 */
+	@Override
 	public void clipPath(Path path) {
 		initTransform(false);
 		if (((appliedState.graphicHints ^ currentState.graphicHints) & FILL_RULE_MASK) != 0) {
@@ -1096,6 +1163,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setClip(Rectangle)
 	 */
+	@Override
 	public void setClip(Rectangle rect) {
 		currentState.relativeClip = new RectangleClipping(rect);
 	}
@@ -1103,6 +1171,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setFillRule(int)
 	 */
+	@Override
 	public void setFillRule(int rule) {
 		currentState.graphicHints &= ~FILL_RULE_MASK;
 		currentState.graphicHints |= (rule + FILL_RULE_WHOLE_NUMBER) << FILL_RULE_SHIFT;
@@ -1111,6 +1180,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setFont(Font)
 	 */
+	@Override
 	public void setFont(Font f) {
 		currentState.font = f;
 	}
@@ -1118,6 +1188,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setForegroundColor(Color)
 	 */
+	@Override
 	public void setForegroundColor(Color color) {
 		currentState.fgColor = color;
 		if (currentState.fgPattern != null) {
@@ -1130,6 +1201,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setForegroundPattern(Pattern)
 	 */
+	@Override
 	public void setForegroundPattern(Pattern pattern) {
 		currentState.graphicHints |= ADVANCED_GRAPHICS_MASK;
 		if (currentState.fgPattern == pattern) {
@@ -1154,6 +1226,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#setInterpolation(int)
 	 */
+	@Override
 	public void setInterpolation(int interpolation) {
 		// values range [-1, 3]
 		currentState.graphicHints &= ~INTERPOLATION_MASK;
@@ -1161,6 +1234,7 @@ public class SWTGraphics extends Graphics {
 				| (interpolation + INTERPOLATION_WHOLE_NUMBER) << INTERPOLATION_SHIFT;
 	}
 
+	@Override
 	public void setLineAttributes(LineAttributes lineAttributes) {
 		copyLineAttributes(currentState.lineAttributes, lineAttributes);
 	}
@@ -1168,6 +1242,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineCap(int)
 	 */
+	@Override
 	public void setLineCap(int value) {
 		currentState.lineAttributes.cap = value;
 	}
@@ -1175,6 +1250,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineDash(int[])
 	 */
+	@Override
 	public void setLineDash(int[] dashes) {
 		float[] fArray = null;
 		if (dashes != null) {
@@ -1190,6 +1266,7 @@ public class SWTGraphics extends Graphics {
 	 * @param value
 	 * @since 3.5
 	 */
+	@Override
 	public void setLineDash(float[] value) {
 		if (value != null) {
 			// validate dash values
@@ -1210,6 +1287,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @since 3.5
 	 */
+	@Override
 	public void setLineDashOffset(float value) {
 		currentState.lineAttributes.dashOffset = value;
 	}
@@ -1217,6 +1295,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineJoin(int)
 	 */
+	@Override
 	public void setLineJoin(int value) {
 		currentState.lineAttributes.join = value;
 	}
@@ -1224,6 +1303,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineStyle(int)
 	 */
+	@Override
 	public void setLineStyle(int value) {
 		currentState.lineAttributes.style = value;
 	}
@@ -1231,14 +1311,17 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineWidth(int)
 	 */
+	@Override
 	public void setLineWidth(int width) {
 		currentState.lineAttributes.width = width;
 	}
 
+	@Override
 	public void setLineWidthFloat(float value) {
 		currentState.lineAttributes.width = value;
 	}
 
+	@Override
 	public void setLineMiterLimit(float value) {
 		currentState.lineAttributes.miterLimit = value;
 	}
@@ -1250,6 +1333,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#setTextAntialias(int)
 	 */
+	@Override
 	public void setTextAntialias(int value) {
 		currentState.graphicHints &= ~TEXT_AA_MASK;
 		currentState.graphicHints |= ADVANCED_GRAPHICS_MASK | (value + AA_WHOLE_NUMBER) << TEXT_AA_SHIFT;
@@ -1258,6 +1342,7 @@ public class SWTGraphics extends Graphics {
 	/**
 	 * @see Graphics#setXORMode(boolean)
 	 */
+	@Override
 	public void setXORMode(boolean xor) {
 		currentState.graphicHints &= ~XOR_MASK;
 		if (xor) {
@@ -1272,6 +1357,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#shear(float, float)
 	 */
+	@Override
 	public void shear(float horz, float vert) {
 		// Flush any clipping changes before shearing
 		checkGC();
@@ -1295,6 +1381,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#translate(int, int)
 	 */
+	@Override
 	public void translate(int dx, int dy) {
 		if (dx == 0 && dy == 0)
 			return;
@@ -1320,6 +1407,7 @@ public class SWTGraphics extends Graphics {
 	 * 
 	 * @see Graphics#translate(float, float)
 	 */
+	@Override
 	public void translate(float dx, float dy) {
 		initTransform(true);
 		checkGC();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
@@ -55,6 +55,7 @@ public class ScalableFreeformLayeredPane extends FreeformLayeredPane implements 
 	/**
 	 * @see org.eclipse.draw2d.IFigure#isCoordinateSystem()
 	 */
+	@Override
 	public boolean isCoordinateSystem() {
 		return true;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalablePolygonShape.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalablePolygonShape.java
@@ -29,11 +29,13 @@ public class ScalablePolygonShape extends AbstractPointListShape {
 
 	private PointList scaledPoints;
 
+	@Override
 	protected boolean shapeContainsPoint(int x, int y) {
 		Point location = getLocation();
 		return Geometry.polygonContainsPoint(getScaledPoints(), x - location.x, y - location.y);
 	}
 
+	@Override
 	protected void fillShape(Graphics graphics) {
 		graphics.pushState();
 		graphics.translate(getLocation());
@@ -41,6 +43,7 @@ public class ScalablePolygonShape extends AbstractPointListShape {
 		graphics.popState();
 	}
 
+	@Override
 	protected void outlineShape(Graphics graphics) {
 		graphics.pushState();
 		graphics.translate(getLocation());
@@ -86,51 +89,61 @@ public class ScalablePolygonShape extends AbstractPointListShape {
 		return scaledPoints = new PointList(pointsArray);
 	}
 
+	@Override
 	public void addPoint(Point pt) {
 		scaledPoints = null;
 		super.addPoint(pt);
 	}
 
+	@Override
 	public void insertPoint(Point pt, int index) {
 		scaledPoints = null;
 		super.insertPoint(pt, index);
 	}
 
+	@Override
 	public void removeAllPoints() {
 		scaledPoints = null;
 		super.removeAllPoints();
 	}
 
+	@Override
 	public void removePoint(int index) {
 		scaledPoints = null;
 		super.removePoint(index);
 	}
 
+	@Override
 	public void setStart(Point start) {
 		scaledPoints = null;
 		super.setStart(start);
 	}
 
+	@Override
 	public void setEnd(Point end) {
 		scaledPoints = null;
 		super.setEnd(end);
 	}
 
+	@Override
 	public void setPoint(Point pt, int index) {
 		scaledPoints = null;
 		super.setPoint(pt, index);
 	}
 
+	@Override
 	public void setPoints(PointList points) {
 		scaledPoints = null;
 		super.setPoints(points);
 	}
 
+	@Override
 	public void setBounds(Rectangle rect) {
 		scaledPoints = null;
 		super.setBounds(rect);
 	}
 
+	@Override
 	public void setLineWidth(int w) {
 		scaledPoints = null;
 		super.setLineWidth(w);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
@@ -57,10 +57,12 @@ public class ScaledGraphics extends Graphics {
 			this.height = height;
 		}
 
+		@Override
 		public boolean equals(Object obj) {
 			return (((FontKey) obj).font.equals(font) && ((FontKey) obj).height == height);
 		}
 
+		@Override
 		public int hashCode() {
 			return font.hashCode() ^ height;
 		}
@@ -192,6 +194,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#clipRect(Rectangle) */
+	@Override
 	public void clipRect(Rectangle r) {
 		graphics.clipRect(zoomClipRect(r));
 	}
@@ -243,6 +246,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#dispose() */
+	@Override
 	public void dispose() {
 		// Remove all states from the stack
 		while (stackPointer > 0) {
@@ -259,6 +263,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#drawArc(int, int, int, int, int, int) */
+	@Override
 	public void drawArc(int x, int y, int w, int h, int offset, int sweep) {
 		Rectangle z = zoomRect(x, y, w, h);
 		if (z.isEmpty() || sweep == 0)
@@ -267,11 +272,13 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#drawFocus(int, int, int, int) */
+	@Override
 	public void drawFocus(int x, int y, int w, int h) {
 		graphics.drawFocus(zoomRect(x, y, w, h));
 	}
 
 	/** @see Graphics#drawImage(Image, int, int) */
+	@Override
 	public void drawImage(Image srcImage, int x, int y) {
 		org.eclipse.swt.graphics.Rectangle size = srcImage.getBounds();
 		graphics.drawImage(srcImage, 0, 0, size.width, size.height, (int) (Math.floor((x * zoom + fractionalX))),
@@ -280,6 +287,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#drawImage(Image, int, int, int, int, int, int, int, int) */
+	@Override
 	public void drawImage(Image srcImage, int sx, int sy, int sw, int sh, int tx, int ty, int tw, int th) {
 		// "t" == target rectangle, "s" = source
 
@@ -289,17 +297,20 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#drawLine(int, int, int, int) */
+	@Override
 	public void drawLine(int x1, int y1, int x2, int y2) {
 		graphics.drawLine((int) (Math.floor((x1 * zoom + fractionalX))), (int) (Math.floor((y1 * zoom + fractionalY))),
 				(int) (Math.floor((x2 * zoom + fractionalX))), (int) (Math.floor((y2 * zoom + fractionalY))));
 	}
 
 	/** @see Graphics#drawOval(int, int, int, int) */
+	@Override
 	public void drawOval(int x, int y, int w, int h) {
 		graphics.drawOval(zoomRect(x, y, w, h));
 	}
 
 	/** @see Graphics#drawPath(Path) */
+	@Override
 	public void drawPath(Path path) {
 		Path scaledPath = createScaledPath(path);
 		try {
@@ -310,6 +321,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#drawPoint(int, int) */
+	@Override
 	public void drawPoint(int x, int y) {
 		graphics.drawPoint((int) Math.floor(x * zoom + fractionalX), (int) Math.floor(y * zoom + fractionalY));
 	}
@@ -317,11 +329,13 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawPolygon(int[])
 	 */
+	@Override
 	public void drawPolygon(int[] points) {
 		graphics.drawPolygon(zoomPointList(points));
 	}
 
 	/** @see Graphics#drawPolygon(PointList) */
+	@Override
 	public void drawPolygon(PointList points) {
 		graphics.drawPolygon(zoomPointList(points.toIntArray()));
 	}
@@ -329,33 +343,39 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawPolyline(int[])
 	 */
+	@Override
 	public void drawPolyline(int[] points) {
 		graphics.drawPolyline(zoomPointList(points));
 	}
 
 	/** @see Graphics#drawPolyline(PointList) */
+	@Override
 	public void drawPolyline(PointList points) {
 		graphics.drawPolyline(zoomPointList(points.toIntArray()));
 	}
 
 	/** @see Graphics#drawRectangle(int, int, int, int) */
+	@Override
 	public void drawRectangle(int x, int y, int w, int h) {
 		graphics.drawRectangle(zoomRect(x, y, w, h));
 	}
 
 	/** @see Graphics#drawRoundRectangle(Rectangle, int, int) */
+	@Override
 	public void drawRoundRectangle(Rectangle r, int arcWidth, int arcHeight) {
 		graphics.drawRoundRectangle(zoomRect(r.x, r.y, r.width, r.height), (int) (arcWidth * zoom),
 				(int) (arcHeight * zoom));
 	}
 
 	/** @see Graphics#drawString(String, int, int) */
+	@Override
 	public void drawString(String s, int x, int y) {
 		if (allowText)
 			graphics.drawString(s, zoomTextPoint(x, y));
 	}
 
 	/** @see Graphics#drawText(String, int, int) */
+	@Override
 	public void drawText(String s, int x, int y) {
 		if (allowText)
 			graphics.drawText(s, zoomTextPoint(x, y));
@@ -364,6 +384,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawText(String, int, int, int)
 	 */
+	@Override
 	public void drawText(String s, int x, int y, int style) {
 		if (allowText)
 			graphics.drawText(s, zoomTextPoint(x, y), style);
@@ -372,6 +393,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#drawTextLayout(TextLayout, int, int, int, int, Color, Color)
 	 */
+	@Override
 	public void drawTextLayout(TextLayout layout, int x, int y, int selectionStart, int selectionEnd,
 			Color selectionForeground, Color selectionBackground) {
 		TextLayout scaled = zoomTextLayout(layout);
@@ -388,6 +410,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#fillArc(int, int, int, int, int, int) */
+	@Override
 	public void fillArc(int x, int y, int w, int h, int offset, int sweep) {
 		Rectangle z = zoomFillRect(x, y, w, h);
 		if (z.isEmpty() || sweep == 0)
@@ -396,16 +419,19 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#fillGradient(int, int, int, int, boolean) */
+	@Override
 	public void fillGradient(int x, int y, int w, int h, boolean vertical) {
 		graphics.fillGradient(zoomFillRect(x, y, w, h), vertical);
 	}
 
 	/** @see Graphics#fillOval(int, int, int, int) */
+	@Override
 	public void fillOval(int x, int y, int w, int h) {
 		graphics.fillOval(zoomFillRect(x, y, w, h));
 	}
 
 	/** @see Graphics#fillPath(Path) */
+	@Override
 	public void fillPath(Path path) {
 		Path scaledPath = createScaledPath(path);
 		try {
@@ -418,33 +444,39 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#fillPolygon(int[])
 	 */
+	@Override
 	public void fillPolygon(int[] points) {
 		graphics.fillPolygon(zoomPointList(points));
 	}
 
 	/** @see Graphics#fillPolygon(PointList) */
+	@Override
 	public void fillPolygon(PointList points) {
 		graphics.fillPolygon(zoomPointList(points.toIntArray()));
 	}
 
 	/** @see Graphics#fillRectangle(int, int, int, int) */
+	@Override
 	public void fillRectangle(int x, int y, int w, int h) {
 		graphics.fillRectangle(zoomFillRect(x, y, w, h));
 	}
 
 	/** @see Graphics#fillRoundRectangle(Rectangle, int, int) */
+	@Override
 	public void fillRoundRectangle(Rectangle r, int arcWidth, int arcHeight) {
 		graphics.fillRoundRectangle(zoomFillRect(r.x, r.y, r.width, r.height), (int) (arcWidth * zoom),
 				(int) (arcHeight * zoom));
 	}
 
 	/** @see Graphics#fillString(String, int, int) */
+	@Override
 	public void fillString(String s, int x, int y) {
 		if (allowText)
 			graphics.fillString(s, zoomTextPoint(x, y));
 	}
 
 	/** @see Graphics#fillText(String, int, int) */
+	@Override
 	public void fillText(String s, int x, int y) {
 		if (allowText)
 			graphics.fillText(s, zoomTextPoint(x, y));
@@ -453,6 +485,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getAbsoluteScale()
 	 */
+	@Override
 	public double getAbsoluteScale() {
 		return zoom * graphics.getAbsoluteScale();
 	}
@@ -460,6 +493,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getAlpha()
 	 */
+	@Override
 	public int getAlpha() {
 		return graphics.getAlpha();
 	}
@@ -467,11 +501,13 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getAntialias()
 	 */
+	@Override
 	public int getAntialias() {
 		return graphics.getAntialias();
 	}
 
 	/** @see Graphics#getBackgroundColor() */
+	@Override
 	public Color getBackgroundColor() {
 		return graphics.getBackgroundColor();
 	}
@@ -499,6 +535,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#getClip(Rectangle) */
+	@Override
 	public Rectangle getClip(Rectangle rect) {
 		graphics.getClip(rect);
 		int x = (int) (rect.x / zoom);
@@ -519,6 +556,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getAdvanced()
 	 */
+	@Override
 	public boolean getAdvanced() {
 		return graphics.getAdvanced();
 	}
@@ -526,21 +564,25 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getFillRule()
 	 */
+	@Override
 	public int getFillRule() {
 		return graphics.getFillRule();
 	}
 
 	/** @see Graphics#getFont() */
+	@Override
 	public Font getFont() {
 		return getLocalFont();
 	}
 
 	/** @see Graphics#getFontMetrics() */
+	@Override
 	public FontMetrics getFontMetrics() {
 		return FigureUtilities.getFontMetrics(localFont);
 	}
 
 	/** @see Graphics#getForegroundColor() */
+	@Override
 	public Color getForegroundColor() {
 		return graphics.getForegroundColor();
 	}
@@ -548,6 +590,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getInterpolation()
 	 */
+	@Override
 	public int getInterpolation() {
 		return graphics.getInterpolation();
 	}
@@ -555,6 +598,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getLineCap()
 	 */
+	@Override
 	public int getLineCap() {
 		return graphics.getLineCap();
 	}
@@ -562,31 +606,37 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getLineJoin()
 	 */
+	@Override
 	public int getLineJoin() {
 		return graphics.getLineJoin();
 	}
 
 	/** @see Graphics#getLineStyle() */
+	@Override
 	public int getLineStyle() {
 		return graphics.getLineStyle();
 	}
 
 	/** @see Graphics#getLineMiterLimit() */
+	@Override
 	public float getLineMiterLimit() {
 		return graphics.getLineMiterLimit();
 	}
 
 	/** @see Graphics#getLineWidth() */
+	@Override
 	public int getLineWidth() {
 		return (int) getLineWidthFloat();
 	}
 
 	/** @see Graphics#getLineWidthFloat() */
+	@Override
 	public float getLineWidthFloat() {
 		return getLocalLineWidth();
 	}
 
 	/** @see Graphics#getLineAttributes() */
+	@Override
 	public LineAttributes getLineAttributes() {
 		LineAttributes a = graphics.getLineAttributes();
 		a.width = getLocalLineWidth();
@@ -604,16 +654,19 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#getTextAntialias()
 	 */
+	@Override
 	public int getTextAntialias() {
 		return graphics.getTextAntialias();
 	}
 
 	/** @see Graphics#getXORMode() */
+	@Override
 	public boolean getXORMode() {
 		return graphics.getXORMode();
 	}
 
 	/** @see Graphics#popState() */
+	@Override
 	public void popState() {
 		graphics.popState();
 		stackPointer--;
@@ -621,6 +674,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#pushState() */
+	@Override
 	public void pushState() {
 		State s;
 		if (stack.size() > stackPointer) {
@@ -643,22 +697,26 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#restoreState() */
+	@Override
 	public void restoreState() {
 		graphics.restoreState();
 		restoreLocalState((State) stack.get(stackPointer - 1));
 	}
 
 	/** @see Graphics#rotate(float) */
+	@Override
 	public void rotate(float degrees) {
 		graphics.rotate(degrees);
 	}
 
 	/** @see Graphics#scale(double) */
+	@Override
 	public void scale(double amount) {
 		setScale(zoom * amount);
 	}
 
 	/** @see Graphics#setAdvanced(boolean) */
+	@Override
 	public void setAdvanced(boolean advanced) {
 		graphics.setAdvanced(advanced);
 	}
@@ -666,6 +724,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#setAlpha(int)
 	 */
+	@Override
 	public void setAlpha(int alpha) {
 		graphics.setAlpha(alpha);
 	}
@@ -673,16 +732,19 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#setAntialias(int)
 	 */
+	@Override
 	public void setAntialias(int value) {
 		graphics.setAntialias(value);
 	}
 
 	/** @see Graphics#setBackgroundColor(Color) */
+	@Override
 	public void setBackgroundColor(Color rgb) {
 		graphics.setBackgroundColor(rgb);
 	}
 
 	/** @see Graphics#setClip(Path) */
+	@Override
 	public void setClip(Path path) {
 		Path scaledPath = createScaledPath(path);
 		try {
@@ -693,11 +755,13 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#setBackgroundPattern(Pattern) */
+	@Override
 	public void setBackgroundPattern(Pattern pattern) {
 		graphics.setBackgroundPattern(pattern);
 	}
 
 	/** @see Graphics#setClip(Rectangle) */
+	@Override
 	public void setClip(Rectangle r) {
 		graphics.setClip(zoomClipRect(r));
 	}
@@ -705,6 +769,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see org.eclipse.draw2d.Graphics#clipPath(org.eclipse.swt.graphics.Path)
 	 */
+	@Override
 	public void clipPath(Path path) {
 		Path scaledPath = createScaledPath(path);
 		try {
@@ -717,26 +782,31 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#setFillRule(int)
 	 */
+	@Override
 	public void setFillRule(int rule) {
 		graphics.setFillRule(rule);
 	}
 
 	/** @see Graphics#setFont(Font) */
+	@Override
 	public void setFont(Font f) {
 		setLocalFont(f);
 	}
 
 	/** @see Graphics#setForegroundColor(Color) */
+	@Override
 	public void setForegroundColor(Color rgb) {
 		graphics.setForegroundColor(rgb);
 	}
 
 	/** @see Graphics#setForegroundPattern(Pattern) */
+	@Override
 	public void setForegroundPattern(Pattern pattern) {
 		graphics.setForegroundPattern(pattern);
 	}
 
 	/** @see org.eclipse.draw2d.Graphics#setInterpolation(int) */
+	@Override
 	public void setInterpolation(int interpolation) {
 		graphics.setInterpolation(interpolation);
 	}
@@ -744,6 +814,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineCap(int)
 	 */
+	@Override
 	public void setLineCap(int cap) {
 		graphics.setLineCap(cap);
 	}
@@ -751,6 +822,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineDash(int[])
 	 */
+	@Override
 	public void setLineDash(int[] dash) {
 		graphics.setLineDash(dash);
 	}
@@ -758,6 +830,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see org.eclipse.draw2d.Graphics#setLineDash(float[])
 	 */
+	@Override
 	public void setLineDash(float[] dash) {
 		graphics.setLineDash(dash);
 	}
@@ -765,6 +838,7 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see org.eclipse.draw2d.Graphics#setLineDashOffset(float)
 	 */
+	@Override
 	public void setLineDashOffset(float value) {
 		graphics.setLineDashOffset(value);
 	}
@@ -772,31 +846,37 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#setLineJoin(int)
 	 */
+	@Override
 	public void setLineJoin(int join) {
 		graphics.setLineJoin(join);
 	}
 
 	/** @see Graphics#setLineStyle(int) */
+	@Override
 	public void setLineStyle(int style) {
 		graphics.setLineStyle(style);
 	}
 
 	/** @see Graphics#setLineMiterLimit(float) */
+	@Override
 	public void setLineMiterLimit(float value) {
 		graphics.setLineMiterLimit(value);
 	}
 
 	/** @see Graphics#setLineWidth(int) */
+	@Override
 	public void setLineWidth(int width) {
 		setLineWidthFloat(width);
 	}
 
 	/** @see Graphics#setLineWidthFloat(float) */
+	@Override
 	public void setLineWidthFloat(float width) {
 		setLocalLineWidth(width);
 	}
 
 	/** @see Graphics#setLineAttributes(LineAttributes) */
+	@Override
 	public void setLineAttributes(LineAttributes attributes) {
 		graphics.setLineAttributes(attributes);
 		setLocalLineWidth(attributes.width);
@@ -823,16 +903,19 @@ public class ScaledGraphics extends Graphics {
 	/**
 	 * @see Graphics#setTextAntialias(int)
 	 */
+	@Override
 	public void setTextAntialias(int value) {
 		graphics.setTextAntialias(value);
 	}
 
 	/** @see Graphics#setXORMode(boolean) */
+	@Override
 	public void setXORMode(boolean b) {
 		graphics.setXORMode(b);
 	}
 
 	/** @see Graphics#translate(int, int) */
+	@Override
 	public void translate(int dx, int dy) {
 		// fractionalX/Y is the fractional part left over from previous
 		// translates that gets lost in the integer approximation.
@@ -844,6 +927,7 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	/** @see Graphics#translate(float, float) */
+	@Override
 	public void translate(float dx, float dy) {
 		double dxFloat = dx * zoom + fractionalX;
 		double dyFloat = dy * zoom + fractionalY;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SchemeBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SchemeBorder.java
@@ -206,6 +206,7 @@ public class SchemeBorder extends AbstractBorder implements ColorConstants {
 	/**
 	 * @see Border#getInsets(IFigure)
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return getScheme().getInsets();
 	}
@@ -226,6 +227,7 @@ public class SchemeBorder extends AbstractBorder implements ColorConstants {
 	 * 
 	 * @see Border#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -243,6 +245,7 @@ public class SchemeBorder extends AbstractBorder implements ColorConstants {
 	/**
 	 * @see Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics g, Insets insets) {
 		Color[] tl = scheme.getHighlight();
 		Color[] br = scheme.getShadow();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollBar.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollBar.java
@@ -114,6 +114,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 		clickable.setRequestFocusEnabled(false);
 		clickable.setFocusTraversable(false);
 		clickable.addChangeListener(new ChangeListener() {
+			@Override
 			public void handleStateChanged(ChangeEvent evt) {
 				if (clickable.getModel().isArmed())
 					clickable.setBackgroundColor(ColorConstants.black);
@@ -316,6 +317,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 	/**
 	 * @see PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent)
 	 */
+	@Override
 	public void propertyChange(PropertyChangeEvent event) {
 		if (event.getSource() instanceof RangeModel) {
 			setEnabled(getRangeModel().isEnabled());
@@ -345,6 +347,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 	/**
 	 * @see IFigure#revalidate()
 	 */
+	@Override
 	public void revalidate() {
 		// Override default revalidate to prevent going up the parent chain.
 		// Reason for this
@@ -358,6 +361,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 	 * 
 	 * @see Orientable#setDirection(int)
 	 */
+	@Override
 	public void setDirection(int direction) {
 		// Doesn't make sense for Scrollbar.
 	}
@@ -379,6 +383,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 				((Orientable) buttonDown).setDirection(isHorizontal() ? Orientable.EAST : Orientable.SOUTH);
 			buttonDown.setFiringMethod(Clickable.REPEAT_FIRING);
 			buttonDown.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					stepDown();
 				}
@@ -404,6 +409,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 				((Orientable) up).setDirection(isHorizontal() ? Orientable.WEST : Orientable.NORTH);
 			buttonUp.setFiringMethod(Clickable.REPEAT_FIRING);
 			buttonUp.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					stepUp();
 				}
@@ -415,6 +421,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 	/**
 	 * @see IFigure#setEnabled(boolean)
 	 */
+	@Override
 	public void setEnabled(boolean value) {
 		if (isEnabled() == value)
 			return;
@@ -477,6 +484,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 	/**
 	 * @see Orientable#setOrientation(int)
 	 */
+	@Override
 	public void setOrientation(int value) {
 		if ((value == HORIZONTAL) == isHorizontal())
 			return;
@@ -514,6 +522,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 		if (pageDown != null) {
 			pageDown.setFiringMethod(Clickable.REPEAT_FIRING);
 			pageDown.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent event) {
 					pageDown();
 				}
@@ -537,6 +546,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 		if (pageUp != null) {
 			pageUp.setFiringMethod(Clickable.REPEAT_FIRING);
 			pageUp.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent event) {
 					pageUp();
 				}
@@ -633,6 +643,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 		public ThumbDragger() {
 		}
 
+		@Override
 		public void mousePressed(MouseEvent me) {
 			armed = true;
 			start = me.getLocation();
@@ -648,6 +659,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 			me.consume();
 		}
 
+		@Override
 		public void mouseDragged(MouseEvent me) {
 			if (!armed)
 				return;
@@ -657,6 +669,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 			me.consume();
 		}
 
+		@Override
 		public void mouseReleased(MouseEvent me) {
 			if (!armed)
 				return;
@@ -664,6 +677,7 @@ public class ScrollBar extends Figure implements Orientable, PropertyChangeListe
 			me.consume();
 		}
 
+		@Override
 		public void mouseDoubleClicked(MouseEvent me) {
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollBarLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollBarLayout.java
@@ -55,6 +55,7 @@ public class ScrollBarLayout extends AbstractLayout {
 	/**
 	 * @see AbstractLayout#setConstraint(IFigure, Object)
 	 */
+	@Override
 	public void setConstraint(IFigure figure, Object constraint) {
 		if (constraint.equals(UP_ARROW))
 			up = figure;
@@ -71,6 +72,7 @@ public class ScrollBarLayout extends AbstractLayout {
 	/**
 	 * @see AbstractLayout#calculatePreferredSize(IFigure, int, int)
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure parent, int w, int h) {
 		Insets insets = transposer.t(parent.getInsets());
 		Dimension d = new Dimension(16, 16 * 4);
@@ -81,6 +83,7 @@ public class ScrollBarLayout extends AbstractLayout {
 	/**
 	 * @see LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public void layout(IFigure parent) {
 		ScrollBar scrollBar = (ScrollBar) parent;
 
@@ -159,6 +162,7 @@ public class ScrollBarLayout extends AbstractLayout {
 	/**
 	 * @see LayoutManager#remove(IFigure)
 	 */
+	@Override
 	public void remove(IFigure child) {
 		if (child == up) {
 			up = null;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPane.java
@@ -171,6 +171,7 @@ public class ScrollPane extends Figure {
 	 * 
 	 * @see IFigure#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -325,6 +326,7 @@ public class ScrollPane extends Figure {
 	/**
 	 * @see IFigure#validate()
 	 */
+	@Override
 	public void validate() {
 		super.validate();
 		getHorizontalScrollBar().validate();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPaneLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPaneLayout.java
@@ -30,6 +30,7 @@ public class ScrollPaneLayout extends AbstractHintLayout {
 	/**
 	 * @see AbstractHintLayout#calculateMinimumSize(IFigure, int, int)
 	 */
+	@Override
 	public Dimension calculateMinimumSize(IFigure figure, int w, int h) {
 		ScrollPane scrollpane = (ScrollPane) figure;
 		Insets insets = scrollpane.getInsets();
@@ -50,6 +51,7 @@ public class ScrollPaneLayout extends AbstractHintLayout {
 	 * @return the preferred size of the given container
 	 * @since 2.0
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure container, int wHint, int hHint) {
 		ScrollPane scrollpane = (ScrollPane) container;
 		ScrollBar hBar = scrollpane.getHorizontalScrollBar();
@@ -75,6 +77,7 @@ public class ScrollPaneLayout extends AbstractHintLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public void layout(IFigure parent) {
 		ScrollPane scrollpane = (ScrollPane) parent;
 		Viewport viewport = scrollpane.getViewport();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Shape.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Shape.java
@@ -101,6 +101,7 @@ public abstract class Shape extends Figure {
 	 * 
 	 * @see Figure#paintFigure(Graphics)
 	 */
+	@Override
 	public void paintFigure(Graphics graphics) {
 		if (antialias != null) {
 			graphics.setAntialias(antialias.intValue());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SimpleEtchedBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SimpleEtchedBorder.java
@@ -38,6 +38,7 @@ public final class SimpleEtchedBorder extends SchemeBorder {
 	 * 
 	 * @see Border#getInsets(IFigure)
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return new Insets(INSETS);
 	}
@@ -48,6 +49,7 @@ public final class SimpleEtchedBorder extends SchemeBorder {
 	 * 
 	 * @see Border#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -55,6 +57,7 @@ public final class SimpleEtchedBorder extends SchemeBorder {
 	/**
 	 * @see Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics g, Insets insets) {
 		Rectangle rect = getPaintRectangle(figure, insets);
 		FigureUtilities.paintEtchedBorder(g, rect);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/StackLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/StackLayout.java
@@ -26,6 +26,7 @@ public class StackLayout extends AbstractHintLayout {
 	 * 
 	 * @see AbstractHintLayout#calculateMinimumSize(IFigure, int, int)
 	 */
+	@Override
 	protected Dimension calculateMinimumSize(IFigure figure, int wHint, int hHint) {
 		if (wHint > -1)
 			wHint = Math.max(0, wHint - figure.getInsets().getWidth());
@@ -50,6 +51,7 @@ public class StackLayout extends AbstractHintLayout {
 	 * 
 	 * @see AbstractLayout#calculatePreferredSize(IFigure, int, int)
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure figure, int wHint, int hHint) {
 		if (wHint > -1)
 			wHint = Math.max(0, wHint - figure.getInsets().getWidth());
@@ -69,6 +71,7 @@ public class StackLayout extends AbstractHintLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public void layout(IFigure figure) {
 		Rectangle r = figure.getClientArea();
 		figure.getChildren().forEach(child -> child.setBounds(r));

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SubordinateUpdateManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SubordinateUpdateManager.java
@@ -30,6 +30,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	/**
 	 * @see UpdateManager#addDirtyRegion(IFigure, int, int, int, int)
 	 */
+	@Override
 	public void addDirtyRegion(IFigure f, int x, int y, int w, int h) {
 		if (getSuperior() == null)
 			return;
@@ -39,6 +40,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	/**
 	 * @see UpdateManager#addInvalidFigure(IFigure)
 	 */
+	@Override
 	public void addInvalidFigure(IFigure f) {
 		UpdateManager um = getSuperior();
 		if (um == null)
@@ -67,6 +69,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	/**
 	 * @see UpdateManager#performUpdate()
 	 */
+	@Override
 	public void performUpdate() {
 		UpdateManager um = getSuperior();
 		if (um == null)
@@ -77,6 +80,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	/**
 	 * @see UpdateManager#performUpdate(Rectangle)
 	 */
+	@Override
 	public void performUpdate(Rectangle rect) {
 		UpdateManager um = getSuperior();
 		if (um == null)
@@ -87,6 +91,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	/**
 	 * @see UpdateManager#setRoot(IFigure)
 	 */
+	@Override
 	public void setRoot(IFigure f) {
 		root = f;
 	}
@@ -94,6 +99,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	/**
 	 * @see UpdateManager#setGraphicsSource(GraphicsSource)
 	 */
+	@Override
 	public void setGraphicsSource(GraphicsSource gs) {
 		graphicsSource = gs;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/TitleBarBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/TitleBarBorder.java
@@ -60,6 +60,7 @@ public class TitleBarBorder extends AbstractLabeledBorder {
 	 * @return the calculated Insets
 	 * @since 2.0
 	 */
+	@Override
 	protected Insets calculateInsets(IFigure figure) {
 		return new Insets(getTextExtents(figure).height + padding.getHeight(), 0, 0, 0);
 	}
@@ -91,6 +92,7 @@ public class TitleBarBorder extends AbstractLabeledBorder {
 	 * 
 	 * @see org.eclipse.draw2d.AbstractLabeledBorder#getPreferredSize(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure fig) {
 		return super.getPreferredSize(fig).getExpanded(padding.getWidth(), 0);
 	}
@@ -114,6 +116,7 @@ public class TitleBarBorder extends AbstractLabeledBorder {
 	 * 
 	 * @see Border#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -121,6 +124,7 @@ public class TitleBarBorder extends AbstractLabeledBorder {
 	/**
 	 * @see Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics g, Insets insets) {
 		tempRect.setBounds(getPaintRectangle(figure, insets));
 		Rectangle rec = tempRect;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToggleButton.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToggleButton.java
@@ -64,6 +64,7 @@ public class ToggleButton extends Toggle {
 	/**
 	 * @see org.eclipse.draw2d.Figure#paintFigure(Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		if (isSelected() && isOpaque()) {
 			fillCheckeredRectangle(graphics);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToggleModel.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToggleModel.java
@@ -22,6 +22,7 @@ public class ToggleModel extends ButtonModel {
 	 * 
 	 * @since 2.0
 	 */
+	@Override
 	public void fireActionPerformed() {
 		setSelected(!isSelected());
 		super.fireActionPerformed();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
@@ -104,8 +104,10 @@ public class ToolTipHelper extends PopUpHelper {
 			currentTipSource = hoverSource;
 			timer = new Timer(true);
 			timer.schedule(new TimerTask() {
+				@Override
 				public void run() {
 					Display.getDefault().asyncExec(new Runnable() {
+						@Override
 						public void run() {
 							hide();
 						}
@@ -120,6 +122,7 @@ public class ToolTipHelper extends PopUpHelper {
 	 * 
 	 * @see PopUpHelper#dispose()
 	 */
+	@Override
 	public void dispose() {
 		if (isShowing()) {
 			hide();
@@ -127,6 +130,7 @@ public class ToolTipHelper extends PopUpHelper {
 		getShell().dispose();
 	}
 
+	@Override
 	protected void hide() {
 		if (timer != null) {
 			timer.cancel();
@@ -137,9 +141,11 @@ public class ToolTipHelper extends PopUpHelper {
 	/**
 	 * @see PopUpHelper#hookShellListeners()
 	 */
+	@Override
 	protected void hookShellListeners() {
 		// Close the tooltip window if the mouse enters the tooltip
 		getShell().addMouseTrackListener(new MouseTrackAdapter() {
+			@Override
 			public void mouseEnter(org.eclipse.swt.events.MouseEvent e) {
 				hide();
 				currentTipSource = null;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolbarLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolbarLayout.java
@@ -110,6 +110,7 @@ public class ToolbarLayout extends OrderedLayout {
 	 * @see #getMinimumSize(IFigure, int, int)
 	 * @since 2.1
 	 */
+	@Override
 	protected Dimension calculateMinimumSize(IFigure container, int wHint, int hHint) {
 		Insets insets = container.getInsets();
 		if (isHorizontal()) {
@@ -152,6 +153,7 @@ public class ToolbarLayout extends OrderedLayout {
 	 * @see #getPreferredSize(IFigure, int, int)
 	 * @since 2.0
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure container, int wHint, int hHint) {
 		Insets insets = container.getInsets();
 		if (isHorizontal()) {
@@ -205,6 +207,7 @@ public class ToolbarLayout extends OrderedLayout {
 	 * 
 	 * @see org.eclipse.draw2d.OrderedLayout#getDefaultOrientation()
 	 */
+	@Override
 	protected int getDefaultOrientation() {
 		return PositionConstants.VERTICAL;
 	}
@@ -219,6 +222,7 @@ public class ToolbarLayout extends OrderedLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractHintLayout#isSensitiveHorizontally(IFigure)
 	 */
+	@Override
 	protected boolean isSensitiveHorizontally(IFigure parent) {
 		return !isHorizontal();
 	}
@@ -226,6 +230,7 @@ public class ToolbarLayout extends OrderedLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractHintLayout#isSensitiveVertically(IFigure)
 	 */
+	@Override
 	protected boolean isSensitiveVertically(IFigure parent) {
 		return isHorizontal();
 	}
@@ -247,6 +252,7 @@ public class ToolbarLayout extends OrderedLayout {
 	 * 
 	 * @see org.eclipse.draw2d.OrderedLayout#isStretchMinorAxis()
 	 */
+	@Override
 	public boolean isStretchMinorAxis() {
 		return matchWidth;
 	}
@@ -254,6 +260,7 @@ public class ToolbarLayout extends OrderedLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public void layout(IFigure parent) {
 		List<? extends IFigure> children = parent.getChildren();
 		int numChildren = children.size();
@@ -387,6 +394,7 @@ public class ToolbarLayout extends OrderedLayout {
 	 * 
 	 * @see org.eclipse.draw2d.OrderedLayout#setStretchMinorAxis(boolean)
 	 */
+	@Override
 	public void setStretchMinorAxis(boolean value) {
 		matchWidth = value;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Triangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Triangle.java
@@ -37,6 +37,7 @@ public final class Triangle extends Shape implements Orientable {
 	/**
 	 * @see Shape#fillShape(Graphics)
 	 */
+	@Override
 	protected void fillShape(Graphics g) {
 		g.fillPolygon(triangle);
 	}
@@ -44,6 +45,7 @@ public final class Triangle extends Shape implements Orientable {
 	/**
 	 * @see Shape#outlineShape(Graphics)
 	 */
+	@Override
 	protected void outlineShape(Graphics g) {
 		g.drawPolygon(triangle);
 	}
@@ -51,6 +53,7 @@ public final class Triangle extends Shape implements Orientable {
 	/**
 	 * @see Figure#primTranslate(int, int)
 	 */
+	@Override
 	public void primTranslate(int dx, int dy) {
 		super.primTranslate(dx, dy);
 		triangle.translate(dx, dy);
@@ -59,6 +62,7 @@ public final class Triangle extends Shape implements Orientable {
 	/**
 	 * @see Orientable#setDirection(int)
 	 */
+	@Override
 	public void setDirection(int value) {
 		if ((value & (NORTH | SOUTH)) != 0)
 			orientation = VERTICAL;
@@ -72,6 +76,7 @@ public final class Triangle extends Shape implements Orientable {
 	/**
 	 * @see Orientable#setOrientation(int)
 	 */
+	@Override
 	public void setOrientation(int value) {
 		if (orientation == VERTICAL && value == HORIZONTAL) {
 			if (direction == NORTH)
@@ -90,6 +95,7 @@ public final class Triangle extends Shape implements Orientable {
 	/**
 	 * @see IFigure#validate()
 	 */
+	@Override
 	public void validate() {
 		super.validate();
 		Rectangle r = new Rectangle();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Viewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Viewport.java
@@ -58,6 +58,7 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	/**
 	 * @see IFigure#getClientArea(Rectangle)
 	 */
+	@Override
 	public Rectangle getClientArea(Rectangle rect) {
 		super.getClientArea(rect);
 		if (useGraphicsTranslate())
@@ -146,6 +147,7 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	/**
 	 * @see Figure#paintClientArea(Graphics)
 	 */
+	@Override
 	protected void paintClientArea(Graphics g) {
 		if (useGraphicsTranslate()) {
 			Point p = getViewLocation();
@@ -164,6 +166,7 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	/**
 	 * @see org.eclipse.draw2d.Figure#isCoordinateSystem()
 	 */
+	@Override
 	public boolean isCoordinateSystem() {
 		return useGraphicsTranslate() || super.isCoordinateSystem();
 	}
@@ -174,6 +177,7 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	 * 
 	 * @param event the event
 	 */
+	@Override
 	public void propertyChange(PropertyChangeEvent event) {
 		if (event.getSource() instanceof RangeModel) {
 			if (RangeModel.PROPERTY_VALUE.equals(event.getPropertyName())) {
@@ -325,6 +329,7 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	/**
 	 * @see IFigure#translateFromParent(Translatable)
 	 */
+	@Override
 	public void translateFromParent(Translatable t) {
 		if (useTranslate)
 			t.performTranslate(getHorizontalRangeModel().getValue(), getVerticalRangeModel().getValue());
@@ -334,6 +339,7 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	/**
 	 * @see IFigure#translateToParent(Translatable)
 	 */
+	@Override
 	public void translateToParent(Translatable t) {
 		if (useTranslate)
 			t.performTranslate(-getHorizontalRangeModel().getValue(), -getVerticalRangeModel().getValue());
@@ -352,6 +358,7 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	/**
 	 * @see IFigure#validate()
 	 */
+	@Override
 	public void validate() {
 		super.validate();
 		readjustScrollBars();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ViewportAwareConnectionLayerClippingStrategy.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ViewportAwareConnectionLayerClippingStrategy.java
@@ -40,6 +40,7 @@ public class ViewportAwareConnectionLayerClippingStrategy implements IClippingSt
 	/**
 	 * @see org.eclipse.draw2d.IClippingStrategy#getClip(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public Rectangle[] getClip(IFigure figure) {
 		Rectangle[] clipRect = null;
 		if (figure instanceof Connection) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ViewportLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ViewportLayout.java
@@ -27,6 +27,7 @@ public class ViewportLayout extends AbstractHintLayout {
 	 * 
 	 * @see AbstractHintLayout#calculateMinimumSize(IFigure, int, int)
 	 */
+	@Override
 	protected Dimension calculateMinimumSize(IFigure figure, int wHint, int hHint) {
 		Viewport viewport = (Viewport) figure;
 		Dimension min = new Dimension();
@@ -45,6 +46,7 @@ public class ViewportLayout extends AbstractHintLayout {
 	 * @return the Preferred size of the given viewport
 	 * @since 2.0
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure parent, int wHint, int hHint) {
 		Viewport viewport = (Viewport) parent;
 		Insets insets = viewport.getInsets();
@@ -76,6 +78,7 @@ public class ViewportLayout extends AbstractHintLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractHintLayout#isSensitiveHorizontally(IFigure)
 	 */
+	@Override
 	protected boolean isSensitiveHorizontally(IFigure parent) {
 		return ((Viewport) parent).getContentsTracksWidth();
 	}
@@ -83,6 +86,7 @@ public class ViewportLayout extends AbstractHintLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractHintLayout#isSensitiveHorizontally(IFigure)
 	 */
+	@Override
 	protected boolean isSensitiveVertically(IFigure parent) {
 		return ((Viewport) parent).getContentsTracksHeight();
 	}
@@ -90,6 +94,7 @@ public class ViewportLayout extends AbstractHintLayout {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public void layout(IFigure figure) {
 		Viewport viewport = (Viewport) figure;
 		IFigure contents = viewport.getContents();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/XYAnchor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/XYAnchor.java
@@ -37,6 +37,7 @@ public class XYAnchor extends ConnectionAnchorBase {
 	 * 
 	 * @see ConnectionAnchor#getLocation(Point)
 	 */
+	@Override
 	public Point getLocation(Point reference) {
 		return location;
 	}
@@ -48,6 +49,7 @@ public class XYAnchor extends ConnectionAnchorBase {
 	 * @see ConnectionAnchor#getOwner()
 	 * @since 2.0
 	 */
+	@Override
 	public IFigure getOwner() {
 		return null;
 	}
@@ -58,6 +60,7 @@ public class XYAnchor extends ConnectionAnchorBase {
 	 * 
 	 * @see ConnectionAnchor#getReferencePoint()
 	 */
+	@Override
 	public Point getReferencePoint() {
 		return location;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/XYLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/XYLayout.java
@@ -38,6 +38,7 @@ public class XYLayout extends AbstractLayout {
 	 * @see AbstractLayout#calculatePreferredSize(IFigure, int, int)
 	 * @since 2.0
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure f, int wHint, int hHint) {
 		Rectangle rect = new Rectangle();
 		for (IFigure child : f.getChildren()) {
@@ -64,6 +65,7 @@ public class XYLayout extends AbstractLayout {
 	/**
 	 * @see LayoutManager#getConstraint(IFigure)
 	 */
+	@Override
 	public Object getConstraint(IFigure figure) {
 		return constraints.get(figure);
 	}
@@ -109,6 +111,7 @@ public class XYLayout extends AbstractLayout {
 	/**
 	 * @see LayoutManager#remove(IFigure)
 	 */
+	@Override
 	public void remove(IFigure figure) {
 		super.remove(figure);
 		constraints.remove(figure);
@@ -121,6 +124,7 @@ public class XYLayout extends AbstractLayout {
 	 * @see LayoutManager#setConstraint(IFigure, Object)
 	 * @since 2.0
 	 */
+	@Override
 	public void setConstraint(IFigure figure, Object newConstraint) {
 		super.setConstraint(figure, newConstraint);
 		if (newConstraint != null)

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
@@ -162,6 +162,7 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	 * @return <code>true</code> if the given object is equal to this dimension
 	 * @since 2.0
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (o instanceof Dimension) {
 			Dimension d = (Dimension) o;
@@ -402,6 +403,7 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return (width * height) ^ (width + height);
 	}
@@ -453,6 +455,7 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	/**
 	 * @see org.eclipse.draw2d.geometry.Translatable#performScale(double)
 	 */
+	@Override
 	public void performScale(double factor) {
 		scale(factor);
 	}
@@ -460,6 +463,7 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	/**
 	 * @see org.eclipse.draw2d.geometry.Translatable#performTranslate(int, int)
 	 */
+	@Override
 	public void performTranslate(int dx, int dy) {
 		// FIXME: actually Dimension are not translatable. Remove this
 		// method as soon as bug #307276 is resolved.
@@ -610,6 +614,7 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	 * @see Object#toString()
 	 */
 
+	@Override
 	public String toString() {
 		return "Dimension(" + //$NON-NLS-1$
 				preciseWidth() + ", " + //$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Insets.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Insets.java
@@ -93,6 +93,7 @@ public class Insets implements Cloneable, java.io.Serializable {
 	 * @return true if all values are the same.
 	 * @since 2.0
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (o instanceof Insets) {
 			Insets i = (Insets) o;
@@ -162,6 +163,7 @@ public class Insets implements Cloneable, java.io.Serializable {
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return top * 7 + left * 2 + bottom * 31 + right * 37;
 	}
@@ -180,6 +182,7 @@ public class Insets implements Cloneable, java.io.Serializable {
 	 * @return String representation.
 	 * @since 2.0
 	 */
+	@Override
 	public String toString() {
 		return "Insets(t=" + top + ", l=" + left + //$NON-NLS-2$//$NON-NLS-1$
 				", b=" + bottom + ", r=" + right + ")";//$NON-NLS-3$//$NON-NLS-2$//$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
@@ -145,6 +145,7 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 * @return true if both x and y values are equal
 	 * @since 2.0
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (o instanceof Point) {
 			Point p = (Point) o;
@@ -341,6 +342,7 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return (x * y) ^ (x + y);
 	}
@@ -358,11 +360,13 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	}
 
 	/** @see Translatable#performScale(double) */
+	@Override
 	public void performScale(double factor) {
 		scale(factor);
 	}
 
 	/** @see Translatable#performTranslate(int, int) */
+	@Override
 	public void performTranslate(int dx, int dy) {
 		translate(dx, dy);
 	}
@@ -467,6 +471,7 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 * @return String representation.
 	 * @since 2.0
 	 */
+	@Override
 	public String toString() {
 		return "Point(" + preciseX() + ", " + preciseY() + ")";//$NON-NLS-3$//$NON-NLS-2$//$NON-NLS-1$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PointList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PointList.java
@@ -265,6 +265,7 @@ public class PointList implements java.io.Serializable, Translatable {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Translatable#performScale(double)
 	 */
+	@Override
 	public void performScale(double factor) {
 		for (int i = 0; i < points.length; i++)
 			points[i] = (int) Math.floor(points[i] * factor);
@@ -274,6 +275,7 @@ public class PointList implements java.io.Serializable, Translatable {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Translatable#performTranslate(int, int)
 	 */
+	@Override
 	public void performTranslate(int dx, int dy) {
 		for (int i = 0; i < size * 2; i += 2) {
 			points[i] += dx;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
@@ -63,6 +63,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#contains(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public boolean contains(Dimension d) {
 		return preciseWidth() >= d.preciseWidth() && preciseHeight() >= d.preciseHeight();
 	}
@@ -70,6 +71,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#containsProper(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public boolean containsProper(Dimension d) {
 		return preciseWidth() > d.preciseWidth() && preciseHeight() > d.preciseHeight();
 	}
@@ -77,6 +79,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#equals(java.lang.Object)
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (o instanceof PrecisionDimension) {
 			PrecisionDimension d = (PrecisionDimension) o;
@@ -88,6 +91,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#expand(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Dimension expand(Dimension d) {
 		return expandPrecise(d.preciseWidth(), d.preciseHeight());
 	}
@@ -95,6 +99,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#expand(double, double)
 	 */
+	@Override
 	public Dimension expand(double w, double h) {
 		return expandPrecise(w, h);
 	}
@@ -102,6 +107,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#expand(int, int)
 	 */
+	@Override
 	public Dimension expand(int w, int h) {
 		return expandPrecise(w, h);
 	}
@@ -124,6 +130,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#getCopy()
 	 */
+	@Override
 	public Dimension getCopy() {
 		return getPreciseCopy();
 	}
@@ -144,6 +151,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#intersect(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Dimension intersect(Dimension d) {
 		setPreciseWidth(Math.min(d.preciseWidth(), preciseWidth()));
 		setPreciseHeight(Math.min(d.preciseHeight(), preciseHeight()));
@@ -153,6 +161,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#performScale(double)
 	 */
+	@Override
 	public void performScale(double factor) {
 		setPreciseWidth(preciseWidth() * factor);
 		setPreciseHeight(preciseHeight() * factor);
@@ -161,6 +170,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#preciseHeight()
 	 */
+	@Override
 	public double preciseHeight() {
 		updatePreciseHeightDouble();
 		return preciseHeight;
@@ -169,6 +179,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#preciseWidth()
 	 */
+	@Override
 	public double preciseWidth() {
 		updatePreciseWidthDouble();
 		return preciseWidth;
@@ -177,6 +188,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#scale(double, double)
 	 */
+	@Override
 	public Dimension scale(double widthFactor, double heightFactor) {
 		setPreciseWidth(preciseWidth() * widthFactor);
 		setPreciseHeight(preciseHeight() * heightFactor);
@@ -186,6 +198,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#setHeight(int)
 	 */
+	@Override
 	public Dimension setHeight(int h) {
 		return setPreciseHeight(h);
 	}
@@ -244,6 +257,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#setSize(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public void setSize(Dimension d) {
 		setPreciseSize(d.preciseWidth(), d.preciseHeight());
 	}
@@ -251,6 +265,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#setSize(int, int)
 	 */
+	@Override
 	public Dimension setSize(int w, int h) {
 		return setPreciseSize(w, h);
 	}
@@ -258,6 +273,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#setWidth(int)
 	 */
+	@Override
 	public Dimension setWidth(int width) {
 		return setPreciseWidth(width);
 	}
@@ -265,6 +281,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#shrink(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Dimension shrink(Dimension d) {
 		return shrinkPrecise(d.preciseWidth(), d.preciseHeight());
 	}
@@ -272,6 +289,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#shrink(int, int)
 	 */
+	@Override
 	public Dimension shrink(int w, int h) {
 		return shrinkPrecise(w, h);
 	}
@@ -279,6 +297,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#shrink(double, double)
 	 */
+	@Override
 	public Dimension shrink(double w, double h) {
 		return shrinkPrecise(w, h);
 	}
@@ -301,6 +320,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#transpose()
 	 */
+	@Override
 	public Dimension transpose() {
 		double temp = preciseWidth();
 		setPreciseWidth(preciseHeight());
@@ -311,6 +331,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Dimension#union(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Dimension union(Dimension d) {
 		setPreciseWidth(Math.max(preciseWidth(), d.preciseWidth()));
 		setPreciseHeight(Math.max(preciseHeight(), d.preciseHeight()));

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
@@ -74,6 +74,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#equals(java.lang.Object)
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (o instanceof PrecisionPoint) {
 			PrecisionPoint p = (PrecisionPoint) o;
@@ -85,6 +86,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#getCopy()
 	 */
+	@Override
 	public Point getCopy() {
 		return getPreciseCopy();
 	}
@@ -92,6 +94,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#getDifference(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public Dimension getDifference(Point p) {
 		return new PrecisionDimension(this.preciseX() - p.preciseX(), this.preciseY() - p.preciseY());
 	}
@@ -109,6 +112,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#performScale(double)
 	 */
+	@Override
 	public void performScale(double factor) {
 		setPreciseX(preciseX() * factor);
 		setPreciseY(preciseY() * factor);
@@ -117,6 +121,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#performTranslate(int, int)
 	 */
+	@Override
 	public void performTranslate(int dx, int dy) {
 		setPreciseX(preciseX() + dx);
 		setPreciseY(preciseY() + dy);
@@ -125,6 +130,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#preciseX()
 	 */
+	@Override
 	public double preciseX() {
 		updatePreciseXDouble();
 		return preciseX;
@@ -133,6 +139,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#preciseY()
 	 */
+	@Override
 	public double preciseY() {
 		updatePreciseYDouble();
 		return preciseY;
@@ -141,6 +148,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#scale(double, double)
 	 */
+	@Override
 	public Point scale(double xFactor, double yFactor) {
 		setPreciseX(preciseX() * xFactor);
 		setPreciseY(preciseY() * yFactor);
@@ -150,6 +158,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#setLocation(int, int)
 	 */
+	@Override
 	public Point setLocation(int x, int y) {
 		return setPreciseLocation(x, y);
 	}
@@ -157,6 +166,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#setLocation(Point)
 	 */
+	@Override
 	public Point setLocation(Point pt) {
 		return setPreciseLocation(pt.preciseX(), pt.preciseY());
 	}
@@ -216,6 +226,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#setX(int)
 	 */
+	@Override
 	public Point setX(int x) {
 		return setPreciseX(x);
 	}
@@ -223,6 +234,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#setY(int)
 	 */
+	@Override
 	public Point setY(int y) {
 		return setPreciseY(y);
 	}
@@ -230,6 +242,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#translate(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Point translate(Dimension d) {
 		return translatePrecise(d.preciseWidth(), d.preciseHeight());
 	}
@@ -237,6 +250,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#translate(int, int)
 	 */
+	@Override
 	public Point translate(int dx, int dy) {
 		return translatePrecise(dx, dy);
 	}
@@ -244,6 +258,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#translate(double, double)
 	 */
+	@Override
 	public Point translate(double dx, double dy) {
 		return translatePrecise(dx, dy);
 	}
@@ -251,6 +266,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#translate(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public Point translate(Point p) {
 		return translatePrecise(p.preciseX(), p.preciseY());
 	}
@@ -273,6 +289,7 @@ public class PrecisionPoint extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#transpose()
 	 */
+	@Override
 	public Point transpose() {
 		double temp = preciseX();
 		setPreciseX(preciseY());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -102,6 +102,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#contains(double, double)
 	 */
+	@Override
 	public boolean contains(double x, double y) {
 		return containsPrecise(x, y);
 	}
@@ -109,6 +110,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#contains(int, int)
 	 */
+	@Override
 	public boolean contains(int x, int y) {
 		return containsPrecise(x, y);
 	}
@@ -116,6 +118,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#contains(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public boolean contains(Point p) {
 		return containsPrecise(p.preciseX(), p.preciseY());
 	}
@@ -123,6 +126,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#contains(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public boolean contains(Rectangle rect) {
 		return preciseX() <= rect.preciseX() && preciseY() <= rect.preciseY() && right() >= rect.right()
 				&& bottom() >= rect.bottom();
@@ -146,6 +150,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see Rectangle#equals(Object)
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (o instanceof PrecisionRectangle) {
 			PrecisionRectangle rect = (PrecisionRectangle) o;
@@ -168,6 +173,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 * @return <code>this</code> for convenience
 	 * @since 3.4
 	 */
+	@Override
 	public Rectangle expand(double h, double v) {
 		return expandPrecise(h, v);
 	}
@@ -175,6 +181,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#expand(org.eclipse.draw2d.geometry.Insets)
 	 */
+	@Override
 	public Rectangle expand(Insets insets) {
 		if (insets == null)
 			return this;
@@ -188,6 +195,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#expand(int, int)
 	 */
+	@Override
 	public Rectangle expand(int h, int v) {
 		return expandPrecise(h, v);
 	}
@@ -209,6 +217,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getBottom()
 	 */
+	@Override
 	public Point getBottom() {
 		return new PrecisionPoint(preciseX() + preciseWidth() / 2, bottom());
 	}
@@ -216,6 +225,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getBottomLeft()
 	 */
+	@Override
 	public Point getBottomLeft() {
 		return new PrecisionPoint(preciseX(), preciseY() + preciseHeight());
 	}
@@ -223,6 +233,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getBottomRight()
 	 */
+	@Override
 	public Point getBottomRight() {
 		return new PrecisionPoint(preciseX() + preciseWidth(), preciseY() + preciseHeight());
 	}
@@ -230,6 +241,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getCenter()
 	 */
+	@Override
 	public Point getCenter() {
 		return new PrecisionPoint(preciseX() + preciseWidth() / 2.0, preciseY() + preciseHeight() / 2.0);
 	}
@@ -237,6 +249,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getCopy()
 	 */
+	@Override
 	public Rectangle getCopy() {
 		return getPreciseCopy();
 	}
@@ -253,6 +266,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getTop()
 	 */
+	@Override
 	public Point getTop() {
 		return new PrecisionPoint(preciseX() + preciseWidth() / 2, preciseY());
 	}
@@ -260,6 +274,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getTopLeft()
 	 */
+	@Override
 	public Point getTopLeft() {
 		return new PrecisionPoint(preciseX(), preciseY());
 	}
@@ -267,6 +282,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getTopRight()
 	 */
+	@Override
 	public Point getTopRight() {
 		return new PrecisionPoint(preciseX() + preciseWidth(), preciseY());
 	}
@@ -274,6 +290,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#intersect(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public Rectangle intersect(Rectangle rect) {
 		return intersectPrecise(rect);
 	}
@@ -303,6 +320,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#performScale(double)
 	 */
+	@Override
 	public void performScale(double factor) {
 		setPreciseX(preciseX() * factor);
 		setPreciseY(preciseY() * factor);
@@ -313,6 +331,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#performTranslate(int, int)
 	 */
+	@Override
 	public void performTranslate(int dx, int dy) {
 		setPreciseX(preciseX() + dx);
 		setPreciseY(preciseY() + dy);
@@ -330,6 +349,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#preciseHeight()
 	 */
+	@Override
 	public double preciseHeight() {
 		updatePreciseHeightDouble();
 		return preciseHeight;
@@ -347,6 +367,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#preciseWidth()
 	 */
+	@Override
 	public double preciseWidth() {
 		updatePreciseWidthDouble();
 		return preciseWidth;
@@ -355,6 +376,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#preciseX()
 	 */
+	@Override
 	public double preciseX() {
 		updatePreciseXDouble();
 		return preciseX;
@@ -363,6 +385,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#preciseY()
 	 */
+	@Override
 	public double preciseY() {
 		updatePreciseYDouble();
 		return preciseY;
@@ -371,6 +394,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#resize(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Rectangle resize(Dimension d) {
 		return resizePrecise(d.preciseWidth(), d.preciseHeight());
 	}
@@ -378,6 +402,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#resize(double, double)
 	 */
+	@Override
 	public Rectangle resize(double w, double h) {
 		return resizePrecise(w, h);
 	}
@@ -385,6 +410,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#resize(int, int)
 	 */
+	@Override
 	public Rectangle resize(int w, int h) {
 		return resizePrecise(w, h);
 	}
@@ -407,6 +433,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setBounds(int, int, int, int)
 	 */
+	@Override
 	public Rectangle setBounds(int x, int y, int width, int height) {
 		return setPreciseBounds(x, y, width, height);
 	}
@@ -415,6 +442,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setBounds(org.eclipse.draw2d.geometry.Point,
 	 *      org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Rectangle setBounds(Point location, Dimension size) {
 		return setPreciseBounds(location.preciseX(), location.preciseY(), size.preciseWidth(), size.preciseHeight());
 	}
@@ -422,6 +450,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setBounds(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public Rectangle setBounds(Rectangle rect) {
 		return setPreciseBounds(rect.preciseX(), rect.preciseY(), rect.preciseWidth(), rect.preciseHeight());
 	}
@@ -439,6 +468,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setHeight(int)
 	 */
+	@Override
 	public Rectangle setHeight(int height) {
 		return setPreciseHeight(height);
 	}
@@ -446,6 +476,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setLocation(int, int)
 	 */
+	@Override
 	public Rectangle setLocation(int x, int y) {
 		return setPreciseLocation(x, y);
 	}
@@ -453,6 +484,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setLocation(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public Rectangle setLocation(Point loc) {
 		return setPreciseLocation(loc.preciseX(), loc.preciseY());
 	}
@@ -584,6 +616,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setSize(org.eclipse.draw2d.geometry.Dimension)
 	 */
+	@Override
 	public Rectangle setSize(Dimension d) {
 		return setPreciseSize(d.preciseWidth(), d.preciseHeight());
 	}
@@ -591,6 +624,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setSize(int, int)
 	 */
+	@Override
 	public Rectangle setSize(int w, int h) {
 		return setPreciseSize(w, h);
 	}
@@ -608,6 +642,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setWidth(int)
 	 */
+	@Override
 	public Rectangle setWidth(int width) {
 		return setPreciseWidth(width);
 	}
@@ -625,6 +660,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setX(int)
 	 */
+	@Override
 	public Rectangle setX(int value) {
 		return setPreciseX(value);
 	}
@@ -642,6 +678,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#setY(int)
 	 */
+	@Override
 	public Rectangle setY(int value) {
 		return setPreciseY(value);
 	}
@@ -656,6 +693,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 * @return <code>this</code> for convenience
 	 * @since 3.4
 	 */
+	@Override
 	public Rectangle shrink(double h, double v) {
 		return shrinkPrecise(h, v);
 	}
@@ -663,6 +701,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#shrink(org.eclipse.draw2d.geometry.Insets)
 	 */
+	@Override
 	public Rectangle shrink(Insets insets) {
 		if (insets == null)
 			return this;
@@ -676,6 +715,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#shrink(int, int)
 	 */
+	@Override
 	public Rectangle shrink(int h, int v) {
 		return shrinkPrecise(h, v);
 	}
@@ -701,6 +741,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#touches(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public boolean touches(Rectangle rect) {
 		return rect.preciseX() <= preciseX() + preciseWidth() && rect.preciseY() <= preciseY() + preciseHeight()
 				&& rect.preciseX() + rect.preciseWidth() >= preciseX()
@@ -710,6 +751,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#translate(double, double)
 	 */
+	@Override
 	public Rectangle translate(double dx, double dy) {
 		return translatePrecise(dx, dy);
 	}
@@ -717,6 +759,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#translate(int, int)
 	 */
+	@Override
 	public Rectangle translate(int dx, int dy) {
 		return translatePrecise(dx, dy);
 	}
@@ -724,6 +767,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#translate(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public Rectangle translate(Point p) {
 		return translatePrecise(p.preciseX(), p.preciseY());
 	}
@@ -746,6 +790,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#transpose()
 	 */
+	@Override
 	public Rectangle transpose() {
 		double temp = preciseX();
 		setPreciseX(preciseY());
@@ -759,6 +804,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#union(double, double)
 	 */
+	@Override
 	public Rectangle union(double x, double y) {
 		return unionPrecise(x, y);
 	}
@@ -767,6 +813,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 * @see org.eclipse.draw2d.geometry.Rectangle#union(double, double, double,
 	 *      double)
 	 */
+	@Override
 	public Rectangle union(double x, double y, double w, double h) {
 		return unionPrecise(x, y, w, h);
 	}
@@ -774,6 +821,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#union(int, int)
 	 */
+	@Override
 	public Rectangle union(int x, int y) {
 		return unionPrecise(x, y);
 	}
@@ -781,6 +829,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#union(int, int, int, int)
 	 */
+	@Override
 	public Rectangle union(int x, int y, int w, int h) {
 		return unionPrecise(x, y, w, h);
 	}
@@ -788,6 +837,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#union(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public void union(Point p) {
 		unionPrecise(p.preciseX(), p.preciseY());
 	}
@@ -811,6 +861,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#union(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public Rectangle union(Rectangle rect) {
 		if (rect == null || rect.isEmpty())
 			return this;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
@@ -118,6 +118,7 @@ public final class Ray {
 	/**
 	 * @see java.lang.Object#equals(Object)
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (obj == this)
 			return true;
@@ -164,6 +165,7 @@ public final class Ray {
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return (x * y) ^ (x + y);
 	}
@@ -204,6 +206,7 @@ public final class Ray {
 	/**
 	 * @return a String representation
 	 */
+	@Override
 	public String toString() {
 		return "(" + x + "," + y + ")";//$NON-NLS-3$//$NON-NLS-2$//$NON-NLS-1$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -217,6 +217,7 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @return Returns the result of the equality test
 	 * @since 2.0
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (this == o)
 			return true;
@@ -680,6 +681,7 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return (x + height + 1) * (y + width + 1) ^ x ^ y;
 	}
@@ -751,6 +753,7 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	/**
 	 * @see Translatable#performScale(double)
 	 */
+	@Override
 	public void performScale(double factor) {
 		scale(factor);
 	}
@@ -758,6 +761,7 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	/**
 	 * @see Translatable#performTranslate(int, int)
 	 */
+	@Override
 	public void performTranslate(int dx, int dy) {
 		translate(dx, dy);
 	}
@@ -1159,6 +1163,7 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @return String containing the description
 	 * @since 2.0
 	 */
+	@Override
 	public String toString() {
 		return "Rectangle(" + preciseX() + ", " + preciseY() + ", " + //$NON-NLS-3$//$NON-NLS-2$//$NON-NLS-1$
 				preciseWidth() + ", " + preciseHeight() + ")";//$NON-NLS-2$//$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Straight.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Straight.java
@@ -219,6 +219,7 @@ public class Straight {
 	 * 
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Override
 	public boolean equals(Object other) {
 		if (!(other instanceof Straight)) {
 			return false;
@@ -231,6 +232,7 @@ public class Straight {
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return position.hashCode() + direction.hashCode();
 	}
@@ -238,6 +240,7 @@ public class Straight {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return position.toString() + " + s * " + direction.toString(); //$NON-NLS-1$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Vector.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Vector.java
@@ -273,6 +273,7 @@ public class Vector {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "(" + x + "," + y + ")";//$NON-NLS-3$//$NON-NLS-2$//$NON-NLS-1$
 	}
@@ -280,6 +281,7 @@ public class Vector {
 	/**
 	 * @see java.lang.Object#equals(Object)
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (obj == this)
 			return true;
@@ -293,6 +295,7 @@ public class Vector {
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return (int) x + (int) y;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundDirectedGraphLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundDirectedGraphLayout.java
@@ -39,6 +39,7 @@ package org.eclipse.draw2d.graph;
  */
 public final class CompoundDirectedGraphLayout extends DirectedGraphLayout {
 
+	@Override
 	void init() {
 		steps.add(new CompoundTransposeMetrics());
 		steps.add(new CompoundBreakCycles());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundVerticalPlacement.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundVerticalPlacement.java
@@ -22,6 +22,7 @@ class CompoundVerticalPlacement extends VerticalPlacement {
 	/**
 	 * @see GraphVisitor#visit(DirectedGraph) Extended to set subgraph values.
 	 */
+	@Override
 	void visit(DirectedGraph dg) {
 		CompoundDirectedGraph g = (CompoundDirectedGraph) dg;
 		super.visit(g);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/MinCross.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/MinCross.java
@@ -56,6 +56,7 @@ class MinCross extends GraphVisitor {
 	/**
 	 * @see GraphVisitor#visit(org.eclipse.draw2d.graph.DirectedGraph)
 	 */
+	@Override
 	public void visit(DirectedGraph g) {
 		sorter.init(g);
 		this.g = g;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodeCluster.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodeCluster.java
@@ -123,6 +123,7 @@ class NodeCluster extends NodeList {
 		affected.add(this);
 	}
 
+	@Override
 	public boolean equals(Object o) {
 		return o == this;
 	}
@@ -147,6 +148,7 @@ class NodeCluster extends NodeList {
 		return null;
 	}
 
+	@Override
 	public int hashCode() {
 		return hashCode;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodePair.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodePair.java
@@ -27,6 +27,7 @@ class NodePair {
 		this.n2 = n2;
 	}
 
+	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof NodePair) {
 			NodePair np = (NodePair) obj;
@@ -35,6 +36,7 @@ class NodePair {
 		return false;
 	}
 
+	@Override
 	public int hashCode() {
 		return n1.hashCode() ^ n2.hashCode();
 	}
@@ -42,6 +44,7 @@ class NodePair {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "[" + n1 + ", " + n2 + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Obstacle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Obstacle.java
@@ -121,6 +121,7 @@ class Obstacle extends Rectangle {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#toString()
 	 */
+	@Override
 	public String toString() {
 		return "Obstacle(" + x + ", " + y + ", " + //$NON-NLS-3$//$NON-NLS-2$//$NON-NLS-1$
 				width + ", " + height + ")";//$NON-NLS-2$//$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Segment.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Segment.java
@@ -110,6 +110,7 @@ class Segment {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return start + "---" + end; //$NON-NLS-1$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Subgraph.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Subgraph.java
@@ -100,6 +100,7 @@ public class Subgraph extends Node {
 	 * @param n the node in question
 	 * @return <code>true</code> if nested
 	 */
+	@Override
 	boolean isNested(Node n) {
 		return n.nestingIndex >= nestingTreeMin && n.nestingIndex <= nestingIndex;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Vertex.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Vertex.java
@@ -213,6 +213,7 @@ class Vertex extends Point {
 	/**
 	 * @see org.eclipse.draw2d.geometry.Point#toString()
 	 */
+	@Override
 	public String toString() {
 		return "V(" + origX + ", " + origY + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNode.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNode.java
@@ -90,6 +90,7 @@ public class VirtualNode extends Node {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		if (data instanceof Edge)
 			return "VN[" + (((Edge) data).vNodes.indexOf(this) + 1) //$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
@@ -80,6 +80,7 @@ class VirtualNodeCreation extends RevertableChange {
 		graph.removeEdge(edge);
 	}
 
+	@Override
 	void revert() {
 		edge.start = edges[0].start;
 		edge.end = edges[edges.length - 1].end;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/ScrollableThumbnail.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/ScrollableThumbnail.java
@@ -154,6 +154,7 @@ public class ScrollableThumbnail extends Thumbnail {
 	}
 
 	private final FigureListener figureListener = source -> reconfigureSelectorBounds();
+
 	private final KeyListener keyListener = new KeyListener.Stub() {
 		@Override
 		public void keyPressed(KeyEvent ke) {
@@ -194,7 +195,9 @@ public class ScrollableThumbnail extends Thumbnail {
 		initialize();
 	}
 
-	/** @see Thumbnail#deactivate() */
+	/**
+	 * @see Thumbnail#deactivate()
+	 */
 	@Override
 	public void deactivate() {
 		unhookViewport();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/Thumbnail.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/parts/Thumbnail.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.draw2d.parts;
 
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.swt.SWT;
@@ -514,7 +513,9 @@ public class Thumbnail extends Figure implements UpdateListener {
 		return isDirty;
 	}
 
-	/** @see org.eclipse.draw2d.UpdateListener#notifyPainting(Rectangle, Map) */
+	/**
+	 * @see org.eclipse.draw2d.UpdateListener#notifyPainting(Rectangle, Map)
+	 */
 	@Override
 	public void notifyPainting(Rectangle damage, Map<IFigure, Rectangle> dirtyRegions) {
 		for (IFigure current : dirtyRegions.keySet()) {
@@ -529,14 +530,18 @@ public class Thumbnail extends Figure implements UpdateListener {
 		}
 	}
 
-	/** @see org.eclipse.draw2d.UpdateListener#notifyValidating() */
+	/**
+	 * @see org.eclipse.draw2d.UpdateListener#notifyValidating()
+	 */
 	@Override
 	public void notifyValidating() {
 		// setDirty(true);
 		// revalidate();
 	}
 
-	/** @see org.eclipse.draw2d.Figure#paintFigure(Graphics) */
+	/**
+	 * @see org.eclipse.draw2d.Figure#paintFigure(Graphics)
+	 */
 	@Override
 	protected void paintFigure(Graphics graphics) {
 		Image thumbnail = getThumbnailImage();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/AbstractFlowBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/AbstractFlowBorder.java
@@ -29,6 +29,7 @@ public abstract class AbstractFlowBorder extends AbstractBorder implements FlowB
 	/**
 	 * @see FlowBorder#getBottomMargin()
 	 */
+	@Override
 	public int getBottomMargin() {
 		return 0;
 	}
@@ -36,6 +37,7 @@ public abstract class AbstractFlowBorder extends AbstractBorder implements FlowB
 	/**
 	 * @see Border#getInsets(IFigure)
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return IFigure.NO_INSETS;
 	}
@@ -43,6 +45,7 @@ public abstract class AbstractFlowBorder extends AbstractBorder implements FlowB
 	/**
 	 * @see FlowBorder#getLeftMargin()
 	 */
+	@Override
 	public int getLeftMargin() {
 		return 0;
 	}
@@ -50,6 +53,7 @@ public abstract class AbstractFlowBorder extends AbstractBorder implements FlowB
 	/**
 	 * @see FlowBorder#getRightMargin()
 	 */
+	@Override
 	public int getRightMargin() {
 		return 0;
 	}
@@ -57,6 +61,7 @@ public abstract class AbstractFlowBorder extends AbstractBorder implements FlowB
 	/**
 	 * @see FlowBorder#getTopMargin()
 	 */
+	@Override
 	public int getTopMargin() {
 		return 0;
 	}
@@ -70,6 +75,7 @@ public abstract class AbstractFlowBorder extends AbstractBorder implements FlowB
 	 * @param insets   the insets
 	 * @see FlowBorder#paint(FlowFigure, Graphics, Rectangle, int)
 	 */
+	@Override
 	public final void paint(IFigure figure, Graphics graphics, Insets insets) {
 	}
 
@@ -78,6 +84,7 @@ public abstract class AbstractFlowBorder extends AbstractBorder implements FlowB
 	 * 
 	 * @see FlowBorder#paint(FlowFigure, Graphics, Rectangle, int)
 	 */
+	@Override
 	public void paint(FlowFigure figure, Graphics g, Rectangle where, int sides) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockBox.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockBox.java
@@ -31,6 +31,7 @@ public class BlockBox extends CompositeBox {
 	/**
 	 * @see CompositeBox#add(FlowBox)
 	 */
+	@Override
 	public void add(FlowBox box) {
 		width = Math.max(width, box.getWidth());
 		height = Math.max(height, box.getBaseline() + box.getDescent());
@@ -39,6 +40,7 @@ public class BlockBox extends CompositeBox {
 	/**
 	 * @see FlowBox#containsPoint(int, int)
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		return true;
 	}
@@ -46,6 +48,7 @@ public class BlockBox extends CompositeBox {
 	/**
 	 * @see FlowBox#getAscent()
 	 */
+	@Override
 	public int getAscent() {
 		return 0;
 	}
@@ -53,10 +56,12 @@ public class BlockBox extends CompositeBox {
 	/**
 	 * @see FlowBox#getBaseline()
 	 */
+	@Override
 	public int getBaseline() {
 		return y;
 	}
 
+	@Override
 	int getBottomMargin() {
 		return owner.getBottomMargin();
 	}
@@ -64,6 +69,7 @@ public class BlockBox extends CompositeBox {
 	/**
 	 * @see FlowBox#getDescent()
 	 */
+	@Override
 	public int getDescent() {
 		return height;
 	}
@@ -75,10 +81,12 @@ public class BlockBox extends CompositeBox {
 		return height;
 	}
 
+	@Override
 	LineRoot getLineRoot() {
 		return null;
 	}
 
+	@Override
 	int getTopMargin() {
 		return owner.getTopMargin();
 	}
@@ -95,6 +103,7 @@ public class BlockBox extends CompositeBox {
 	/**
 	 * @see CompositeBox#setLineTop(int)
 	 */
+	@Override
 	public void setLineTop(int y) {
 		this.y = y;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlow.java
@@ -59,6 +59,7 @@ public class BlockFlow extends FlowFigure {
 	 * 
 	 * @see org.eclipse.draw2d.text.FlowFigure#contributeBidi(org.eclipse.draw2d.text.BidiProcessor)
 	 */
+	@Override
 	protected void contributeBidi(BidiProcessor proc) {
 		proc.addControlChar(BidiChars.P_SEP);
 	}
@@ -70,6 +71,7 @@ public class BlockFlow extends FlowFigure {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowFigure#createDefaultFlowLayout()
 	 */
+	@Override
 	protected FlowFigureLayout createDefaultFlowLayout() {
 		return new BlockFlowLayout(this);
 	}
@@ -187,6 +189,7 @@ public class BlockFlow extends FlowFigure {
 	/**
 	 * @see org.eclipse.draw2d.Figure#paintBorder(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	public void paintBorder(Graphics graphics) {
 		if (getBorder() instanceof FlowBorder) {
 			Rectangle where = getBlockBox().toRectangle();
@@ -205,6 +208,7 @@ public class BlockFlow extends FlowFigure {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowFigure#postValidate()
 	 */
+	@Override
 	public void postValidate() {
 		Rectangle newBounds = getBlockBox().toRectangle();
 		newBounds.crop(new Insets(getTopMargin(), getLeftMargin(), getBottomMargin(), getRightMargin()));
@@ -214,6 +218,7 @@ public class BlockFlow extends FlowFigure {
 	/**
 	 * @see FlowFigure#revalidate()
 	 */
+	@Override
 	public void revalidate() {
 		BlockFlowLayout layout = (BlockFlowLayout) getLayoutManager();
 		layout.blockContentsChanged();
@@ -226,6 +231,7 @@ public class BlockFlow extends FlowFigure {
 	 * 
 	 * @see org.eclipse.draw2d.text.FlowFigure#revalidateBidi(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	protected void revalidateBidi(IFigure origin) {
 		if (bidiValid) {
 			bidiValid = false;
@@ -284,6 +290,7 @@ public class BlockFlow extends FlowFigure {
 	/**
 	 * @see org.eclipse.draw2d.Figure#useLocalCoordinates()
 	 */
+	@Override
 	protected boolean useLocalCoordinates() {
 		return true;
 	}
@@ -293,6 +300,7 @@ public class BlockFlow extends FlowFigure {
 	 * 
 	 * @see org.eclipse.draw2d.IFigure#validate()
 	 */
+	@Override
 	public void validate() {
 		if (!bidiValid) {
 			BidiProcessor.INSTANCE.setOrientation(getOrientation());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlowLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlowLayout.java
@@ -92,6 +92,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContext#addLine(CompositeBox)
 	 */
+	@Override
 	public void addLine(CompositeBox box) {
 		endLine();
 		addBelowPreviousLine(box);
@@ -110,6 +111,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContainerLayout#cleanup()
 	 */
+	@Override
 	protected void cleanup() {
 		super.cleanup();
 		previousLine = null;
@@ -118,6 +120,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContainerLayout#createNewLine()
 	 */
+	@Override
 	protected void createNewLine() {
 		currentLine = new LineRoot(getBlockFlow().isMirrored());
 		currentLine.setRecommendedWidth(blockBox.getRecommendedWidth());
@@ -146,6 +149,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContext#endLine()
 	 */
+	@Override
 	public void endLine() {
 		if (currentLine == null || !currentLine.isOccupied())
 			return;
@@ -156,6 +160,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContainerLayout#flush()
 	 */
+	@Override
 	protected void flush() {
 		endLine();
 		endBlock();
@@ -181,6 +186,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContext#getContinueOnSameLine()
 	 */
+	@Override
 	public boolean getContinueOnSameLine() {
 		return continueOnSameLine;
 	}
@@ -188,6 +194,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContext#getWidthLookahead(FlowFigure, int[])
 	 */
+	@Override
 	public void getWidthLookahead(FlowFigure child, int result[]) {
 		List<? extends IFigure> children = getFlowFigure().getChildren();
 		int index = -1;
@@ -202,6 +209,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContainerLayout#preLayout()
 	 */
+	@Override
 	protected void preLayout() {
 		setContinueOnSameLine(false);
 		blockBox = getBlockFlow().getBlockBox();
@@ -212,6 +220,7 @@ public class BlockFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowContext#setContinueOnSameLine(boolean)
 	 */
+	@Override
 	public void setContinueOnSameLine(boolean value) {
 		continueOnSameLine = value;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/CaretInfo.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/CaretInfo.java
@@ -116,6 +116,7 @@ public class CaretInfo implements Translatable {
 	/**
 	 * @see Translatable#performScale(double)
 	 */
+	@Override
 	public void performScale(double factor) {
 		x *= factor;
 		baseline *= factor;
@@ -128,6 +129,7 @@ public class CaretInfo implements Translatable {
 	/**
 	 * @see Translatable#performTranslate(int, int)
 	 */
+	@Override
 	public void performTranslate(int dx, int dy) {
 		x += dx;
 		baseline += dy;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/ContentBox.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/ContentBox.java
@@ -24,6 +24,7 @@ public abstract class ContentBox extends FlowBox {
 	/**
 	 * @see FlowBox#getBaseline()
 	 */
+	@Override
 	public int getBaseline() {
 		return lineRoot.getBaseline();
 	}
@@ -39,6 +40,7 @@ public abstract class ContentBox extends FlowBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#getLineRoot()
 	 */
+	@Override
 	LineRoot getLineRoot() {
 		return lineRoot;
 	}
@@ -49,6 +51,7 @@ public abstract class ContentBox extends FlowBox {
 	 * 
 	 * @see org.eclipse.draw2d.text.FlowBox#requiresBidi()
 	 */
+	@Override
 	public boolean requiresBidi() {
 		return bidiLevel > 0;
 	}
@@ -65,6 +68,7 @@ public abstract class ContentBox extends FlowBox {
 		bidiLevel = newLevel;
 	}
 
+	@Override
 	void setLineRoot(LineRoot root) {
 		this.lineRoot = root;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowAdapter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowAdapter.java
@@ -36,6 +36,7 @@ public class FlowAdapter extends FlowFigure {
 	 * 
 	 * @see FlowFigure#contributeBidi(BidiProcessor)
 	 */
+	@Override
 	protected void contributeBidi(BidiProcessor proc) {
 		box.setBidiLevel(-1);
 		// contributes a single object replacement char
@@ -46,6 +47,7 @@ public class FlowAdapter extends FlowFigure {
 	 * @return <code>null</code>
 	 * @see org.eclipse.draw2d.text.FlowFigure#createDefaultFlowLayout()
 	 */
+	@Override
 	protected FlowFigureLayout createDefaultFlowLayout() {
 		return null;
 	}
@@ -56,6 +58,7 @@ public class FlowAdapter extends FlowFigure {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#layout()
 	 */
+	@Override
 	protected void layout() {
 		int wHint = context.getRemainingLineWidth();
 		if (wHint == Integer.MAX_VALUE)
@@ -75,6 +78,7 @@ public class FlowAdapter extends FlowFigure {
 	 * 
 	 * @see FlowFigure#postValidate()
 	 */
+	@Override
 	public void postValidate() {
 		setBounds(new Rectangle(box.getX(), box.getBaseline() - box.ascent, box.width, box.ascent));
 		super.layout();
@@ -86,6 +90,7 @@ public class FlowAdapter extends FlowFigure {
 	 * 
 	 * @see FlowFigure#setBidiInfo(BidiInfo)
 	 */
+	@Override
 	public void setBidiInfo(BidiInfo info) {
 		box.setBidiLevel(info.levelInfo[0]);
 	}
@@ -93,6 +98,7 @@ public class FlowAdapter extends FlowFigure {
 	/**
 	 * @see org.eclipse.draw2d.IFigure#setBounds(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public void setBounds(Rectangle rect) {
 		int x = bounds.x, y = bounds.y;
 
@@ -119,6 +125,7 @@ public class FlowAdapter extends FlowFigure {
 	/**
 	 * @see FlowFigure#setFlowContext(FlowContext)
 	 */
+	@Override
 	public void setFlowContext(FlowContext flowContext) {
 		context = flowContext;
 	}
@@ -128,6 +135,7 @@ public class FlowAdapter extends FlowFigure {
 	 * 
 	 * @see org.eclipse.draw2d.IFigure#validate()
 	 */
+	@Override
 	public void validate() {
 		if (isValid())
 			return;
@@ -138,14 +146,17 @@ public class FlowAdapter extends FlowFigure {
 	private class FigureBox extends ContentBox {
 		private int ascent;
 
+		@Override
 		public boolean containsPoint(int x, int y) {
 			return FlowAdapter.this.containsPoint(x, y);
 		}
 
+		@Override
 		public int getAscent() {
 			return ascent;
 		}
 
+		@Override
 		public int getDescent() {
 			return 0;
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowContainerLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowContainerLayout.java
@@ -40,6 +40,7 @@ public abstract class FlowContainerLayout extends FlowFigureLayout implements Fl
 	 * 
 	 * @see org.eclipse.draw2d.text.FlowContext#addToCurrentLine(FlowBox)
 	 */
+	@Override
 	public void addToCurrentLine(FlowBox child) {
 		getCurrentLine().add(child);
 		setContinueOnSameLine(false);
@@ -78,6 +79,7 @@ public abstract class FlowContainerLayout extends FlowFigureLayout implements Fl
 	/**
 	 * @see FlowContext#getRemainingLineWidth()
 	 */
+	@Override
 	public int getRemainingLineWidth() {
 		return getCurrentLine().getAvailableWidth();
 	}
@@ -85,6 +87,7 @@ public abstract class FlowContainerLayout extends FlowFigureLayout implements Fl
 	/**
 	 * @see FlowContext#isCurrentLineOccupied()
 	 */
+	@Override
 	public boolean isCurrentLineOccupied() {
 		return currentLine != null && currentLine.isOccupied();
 	}
@@ -92,6 +95,7 @@ public abstract class FlowContainerLayout extends FlowFigureLayout implements Fl
 	/**
 	 * @see FlowFigureLayout#layout()
 	 */
+	@Override
 	protected void layout() {
 		preLayout();
 		layoutChildren();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigure.java
@@ -45,6 +45,7 @@ public abstract class FlowFigure extends Figure {
 	 * 
 	 * @see org.eclipse.draw2d.IFigure#add(IFigure, Object, int)
 	 */
+	@Override
 	public void add(IFigure child, Object constraint, int index) {
 		super.add(child, constraint, index);
 		// If this layout manager is a FlowContext, then the child *must* be a
@@ -107,6 +108,7 @@ public abstract class FlowFigure extends Figure {
 	 * 
 	 * @see org.eclipse.draw2d.IFigure#remove(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void remove(IFigure figure) {
 		super.remove(figure);
 		revalidateBidi(this);
@@ -151,6 +153,7 @@ public abstract class FlowFigure extends Figure {
 	 * 
 	 * @see Figure#setBounds(Rectangle)
 	 */
+	@Override
 	public void setBounds(Rectangle r) {
 		if (bounds.equals(r))
 			return;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigureLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigureLayout.java
@@ -49,6 +49,7 @@ public abstract class FlowFigureLayout implements LayoutManager {
 	 * 
 	 * @see org.eclipse.draw2d.LayoutManager#getConstraint(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public Object getConstraint(IFigure child) {
 		return null;
 	}
@@ -76,6 +77,7 @@ public abstract class FlowFigureLayout implements LayoutManager {
 	 * @see org.eclipse.draw2d.LayoutManager#getMinimumSize(org.eclipse.draw2d.IFigure,
 	 *      int, int)
 	 */
+	@Override
 	public Dimension getMinimumSize(IFigure container, int wHint, int hHint) {
 		return null;
 	}
@@ -86,6 +88,7 @@ public abstract class FlowFigureLayout implements LayoutManager {
 	 * @see org.eclipse.draw2d.LayoutManager#getPreferredSize(org.eclipse.draw2d.IFigure,
 	 *      int, int)
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure container, int wHint, int hHint) {
 		return null;
 	}
@@ -95,6 +98,7 @@ public abstract class FlowFigureLayout implements LayoutManager {
 	 * 
 	 * @see org.eclipse.draw2d.LayoutManager#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 	}
 
@@ -106,6 +110,7 @@ public abstract class FlowFigureLayout implements LayoutManager {
 	/**
 	 * @see org.eclipse.draw2d.LayoutManager#layout(IFigure)
 	 */
+	@Override
 	public final void layout(IFigure figure) {
 		layout();
 	}
@@ -115,6 +120,7 @@ public abstract class FlowFigureLayout implements LayoutManager {
 	 * 
 	 * @see org.eclipse.draw2d.LayoutManager#remove(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void remove(IFigure child) {
 	}
 
@@ -124,6 +130,7 @@ public abstract class FlowFigureLayout implements LayoutManager {
 	 * @see org.eclipse.draw2d.LayoutManager#setConstraint(org.eclipse.draw2d.IFigure,
 	 *      java.lang.Object)
 	 */
+	@Override
 	public void setConstraint(IFigure child, Object constraint) {
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowPage.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowPage.java
@@ -34,6 +34,7 @@ public class FlowPage extends BlockFlow {
 	/**
 	 * @see org.eclipse.draw2d.Figure#addNotify()
 	 */
+	@Override
 	public void addNotify() {
 		super.addNotify();
 		setValid(false);
@@ -42,6 +43,7 @@ public class FlowPage extends BlockFlow {
 	/**
 	 * @see org.eclipse.draw2d.text.BlockFlow#createDefaultFlowLayout()
 	 */
+	@Override
 	protected FlowFigureLayout createDefaultFlowLayout() {
 		return new PageFlowLayout(this);
 	}
@@ -49,6 +51,7 @@ public class FlowPage extends BlockFlow {
 	/**
 	 * @see org.eclipse.draw2d.Figure#getMinimumSize(int, int)
 	 */
+	@Override
 	public Dimension getMinimumSize(int w, int h) {
 		return getPreferredSize(w, h);
 	}
@@ -56,6 +59,7 @@ public class FlowPage extends BlockFlow {
 	/**
 	 * @see org.eclipse.draw2d.Figure#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		pageSizeCacheValues = new Dimension[3];
 		super.invalidate();
@@ -64,6 +68,7 @@ public class FlowPage extends BlockFlow {
 	/**
 	 * @see org.eclipse.draw2d.Figure#getPreferredSize(int, int)
 	 */
+	@Override
 	public Dimension getPreferredSize(int width, int h) {
 		for (int i = 0; i < 3; i++) {
 			if (pageSizeCacheKeys[i] == width && pageSizeCacheValues[i] != null)
@@ -142,6 +147,7 @@ public class FlowPage extends BlockFlow {
 	/**
 	 * @see org.eclipse.draw2d.Figure#validate()
 	 */
+	@Override
 	public void validate() {
 		if (isValid())
 			return;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlow.java
@@ -62,6 +62,7 @@ public class InlineFlow extends FlowFigure {
 	 * @param x the relative x coordinate
 	 * @param y the relative y coordinate
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		if (super.containsPoint(x, y)) {
 			List frags = getFragments();
@@ -76,6 +77,7 @@ public class InlineFlow extends FlowFigure {
 	/**
 	 * @see FlowFigure#createDefaultFlowLayout()
 	 */
+	@Override
 	protected FlowFigureLayout createDefaultFlowLayout() {
 		return new InlineFlowLayout(this);
 	}
@@ -97,6 +99,7 @@ public class InlineFlow extends FlowFigure {
 	 * 
 	 * @param graphics the graphics
 	 */
+	@Override
 	protected void paintBorder(Graphics graphics) {
 		if (getBorder() != null) {
 			FlowBorder fb = (FlowBorder) getBorder();
@@ -147,6 +150,7 @@ public class InlineFlow extends FlowFigure {
 	/**
 	 * @see FlowFigure#postValidate()
 	 */
+	@Override
 	public void postValidate() {
 		List list = getFragments();
 		FlowBox box;
@@ -172,6 +176,7 @@ public class InlineFlow extends FlowFigure {
 	 * 
 	 * @param border <code>null</code> or a FlowBorder
 	 */
+	@Override
 	public void setBorder(Border border) {
 		if (border == null || border instanceof FlowBorder)
 			super.setBorder(border);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlowLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlowLayout.java
@@ -39,6 +39,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	 * 
 	 * @param box the box to add
 	 */
+	@Override
 	public void addLine(CompositeBox box) {
 		endLine();
 		getContext().addLine(box);
@@ -47,6 +48,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContainerLayout#createNewLine()
 	 */
+	@Override
 	protected void createNewLine() {
 		currentLine = new NestedLine((InlineFlow) getFlowFigure());
 		setupLine(currentLine);
@@ -55,6 +57,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContext#endLine()
 	 */
+	@Override
 	public void endLine() {
 		flush();
 		getContext().endLine();
@@ -63,6 +66,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContainerLayout#flush()
 	 */
+	@Override
 	protected void flush() {
 		if (currentLine != null && currentLine.isOccupied()) {
 			// We want to preserve the state when a linebox is being added
@@ -79,6 +83,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	 * 
 	 * @see FlowContext#getContinueOnSameLine()
 	 */
+	@Override
 	public boolean getContinueOnSameLine() {
 		return getContext().getContinueOnSameLine();
 	}
@@ -86,6 +91,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContext#getWidthLookahead(FlowFigure, int[])
 	 */
+	@Override
 	public void getWidthLookahead(FlowFigure child, int result[]) {
 		List<? extends IFigure> children = getFlowFigure().getChildren();
 		int index = -1;
@@ -102,6 +108,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	/**
 	 * @see FlowContainerLayout#isCurrentLineOccupied()
 	 */
+	@Override
 	public boolean isCurrentLineOccupied() {
 		return (currentLine != null && !currentLine.getFragments().isEmpty()) || getContext().isCurrentLineOccupied();
 	}
@@ -109,6 +116,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	/**
 	 * Clears out all fragments prior to the call to layoutChildren().
 	 */
+	@Override
 	public void preLayout() {
 		((InlineFlow) getFlowFigure()).getFragments().clear();
 	}
@@ -118,6 +126,7 @@ public class InlineFlowLayout extends FlowContainerLayout {
 	 * 
 	 * @see FlowContext#setContinueOnSameLine(boolean)
 	 */
+	@Override
 	public void setContinueOnSameLine(boolean value) {
 		getContext().setContinueOnSameLine(value);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/LineBox.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/LineBox.java
@@ -35,6 +35,7 @@ public abstract class LineBox extends CompositeBox {
 	/**
 	 * @see org.eclipse.draw2d.text.CompositeBox#add(org.eclipse.draw2d.text.FlowBox)
 	 */
+	@Override
 	public void add(FlowBox child) {
 		fragments.add(child);
 		width += child.getWidth();
@@ -45,6 +46,7 @@ public abstract class LineBox extends CompositeBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#getAscent()
 	 */
+	@Override
 	public int getAscent() {
 		int ascent = 0;
 		for (int i = 0; i < fragments.size(); i++)
@@ -63,6 +65,7 @@ public abstract class LineBox extends CompositeBox {
 		return recommendedWidth - getWidth();
 	}
 
+	@Override
 	int getBottomMargin() {
 		return 0;
 	}
@@ -70,6 +73,7 @@ public abstract class LineBox extends CompositeBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#getDescent()
 	 */
+	@Override
 	public int getDescent() {
 		int descent = 0;
 		for (int i = 0; i < fragments.size(); i++)
@@ -84,6 +88,7 @@ public abstract class LineBox extends CompositeBox {
 		return fragments;
 	}
 
+	@Override
 	int getTopMargin() {
 		return 0;
 	}
@@ -98,6 +103,7 @@ public abstract class LineBox extends CompositeBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#requiresBidi()
 	 */
+	@Override
 	public boolean requiresBidi() {
 		for (Iterator iter = getFragments().iterator(); iter.hasNext();) {
 			FlowBox box = (FlowBox) iter.next();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/LineRoot.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/LineRoot.java
@@ -45,6 +45,7 @@ public class LineRoot extends LineBox {
 	/**
 	 * @see org.eclipse.draw2d.text.CompositeBox#add(org.eclipse.draw2d.text.FlowBox)
 	 */
+	@Override
 	public void add(FlowBox child) {
 		super.add(child);
 		child.setLineRoot(this);
@@ -106,6 +107,7 @@ public class LineRoot extends LineBox {
 	 * 
 	 * @see org.eclipse.draw2d.text.FlowBox#containsPoint(int, int)
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		return false;
 	}
@@ -141,10 +143,12 @@ public class LineRoot extends LineBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#getBaseline()
 	 */
+	@Override
 	public int getBaseline() {
 		return baseline;
 	}
 
+	@Override
 	LineRoot getLineRoot() {
 		return this;
 	}
@@ -211,6 +215,7 @@ public class LineRoot extends LineBox {
 	/**
 	 * @see org.eclipse.draw2d.text.CompositeBox#setLineTop(int)
 	 */
+	@Override
 	public void setLineTop(int top) {
 		this.baseline = top + getAscent();
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/NestedLine.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/NestedLine.java
@@ -26,16 +26,19 @@ public class NestedLine extends LineBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#containsPoint(int, int)
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		// $TODO should contains use LineRoot?
 		return x >= getX() && x < getX() + getWidth() && y >= getBaseline() - getAscentWithBorder()
 				&& y < getBaseline() + getDescentWithBorder();
 	}
 
+	@Override
 	int getAscentWithBorder() {
 		return contentAscent + FlowUtilities.getBorderAscent(owner);
 	}
 
+	@Override
 	int getDescentWithBorder() {
 		return contentDescent + FlowUtilities.getBorderDescent(owner);
 	}
@@ -43,10 +46,12 @@ public class NestedLine extends LineBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#getBaseline()
 	 */
+	@Override
 	public int getBaseline() {
 		return root.getBaseline();
 	}
 
+	@Override
 	LineRoot getLineRoot() {
 		return root;
 	}
@@ -67,6 +72,7 @@ public class NestedLine extends LineBox {
 	 * 
 	 * @return the outer ascent of this box
 	 */
+	@Override
 	public int getOuterAscent() {
 		return contentAscent + FlowUtilities.getBorderAscentWithMargin(owner);
 	}
@@ -79,10 +85,12 @@ public class NestedLine extends LineBox {
 	 * 
 	 * @return the outer descent of this box
 	 */
+	@Override
 	public int getOuterDescent() {
 		return contentDescent + FlowUtilities.getBorderDescentWithMargin(owner);
 	}
 
+	@Override
 	void setLineRoot(LineRoot root) {
 		this.root = root;
 		for (int i = 0; i < fragments.size(); i++)
@@ -92,6 +100,7 @@ public class NestedLine extends LineBox {
 	/**
 	 * @see org.eclipse.draw2d.text.CompositeBox#setLineTop(int)
 	 */
+	@Override
 	public void setLineTop(int top) {
 		throw new RuntimeException("not supported"); //$NON-NLS-1$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/PageFlowLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/PageFlowLayout.java
@@ -30,6 +30,7 @@ public class PageFlowLayout extends BlockFlowLayout {
 	/**
 	 * @see org.eclipse.draw2d.text.BlockFlowLayout#getContextWidth()
 	 */
+	@Override
 	int getContextWidth() {
 		return ((FlowPage) getFlowFigure()).getPageWidth();
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/ParagraphTextLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/ParagraphTextLayout.java
@@ -107,6 +107,7 @@ public class ParagraphTextLayout extends TextLayout {
 			this.trailingBorderSize = trailingBorderSize;
 		}
 
+		@Override
 		public int getWidth() {
 			if (width == null) {
 				width = new int[1];
@@ -138,6 +139,7 @@ public class ParagraphTextLayout extends TextLayout {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowFigureLayout#layout()
 	 */
+	@Override
 	protected void layout() {
 		TextFlow textFlow = (TextFlow) getFlowFigure();
 		int offset = 0;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/SimpleTextLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/SimpleTextLayout.java
@@ -39,6 +39,7 @@ public class SimpleTextLayout extends TextLayout {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowFigureLayout#layout()
 	 */
+	@Override
 	protected void layout() {
 		TextFlow textFlow = (TextFlow) getFlowFigure();
 		String text = textFlow.getText();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
@@ -64,6 +64,7 @@ public class TextFlow extends InlineFlow {
 	 * 
 	 * @see org.eclipse.draw2d.text.FlowFigure#addLeadingWordRequirements(int[])
 	 */
+	@Override
 	public boolean addLeadingWordRequirements(int[] width) {
 		return addLeadingWordWidth(getText(), width);
 	}
@@ -116,6 +117,7 @@ public class TextFlow extends InlineFlow {
 	 * 
 	 * @see org.eclipse.draw2d.text.FlowFigure#contributeBidi(org.eclipse.draw2d.text.BidiProcessor)
 	 */
+	@Override
 	protected void contributeBidi(BidiProcessor proc) {
 		bidiInfo = null;
 		proc.add(this, getText());
@@ -124,6 +126,7 @@ public class TextFlow extends InlineFlow {
 	/**
 	 * @see org.eclipse.draw2d.text.InlineFlow#createDefaultFlowLayout()
 	 */
+	@Override
 	protected FlowFigureLayout createDefaultFlowLayout() {
 		return new ParagraphTextLayout(this);
 	}
@@ -516,6 +519,7 @@ public class TextFlow extends InlineFlow {
 	/**
 	 * @see org.eclipse.draw2d.Figure#paintFigure(Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics g) {
 		TextFragmentBox frag;
 		g.getClip(Rectangle.SINGLETON);
@@ -562,6 +566,7 @@ public class TextFlow extends InlineFlow {
 	/**
 	 * @see InlineFlow#paintSelection(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	protected void paintSelection(Graphics graphics) {
 		if (selectionStart == -1)
 			return;
@@ -608,6 +613,7 @@ public class TextFlow extends InlineFlow {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowFigure#setBidiInfo(org.eclipse.draw2d.text.BidiInfo)
 	 */
+	@Override
 	public void setBidiInfo(BidiInfo info) {
 		this.bidiInfo = info;
 	}
@@ -620,6 +626,7 @@ public class TextFlow extends InlineFlow {
 	 * @param end   the end offset
 	 * @since 3.1
 	 */
+	@Override
 	public void setSelection(int start, int end) {
 		boolean repaint = false;
 
@@ -652,6 +659,7 @@ public class TextFlow extends InlineFlow {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return text;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFragmentBox.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFragmentBox.java
@@ -40,6 +40,7 @@ public class TextFragmentBox extends ContentBox {
 	/**
 	 * @see org.eclipse.draw2d.text.FlowBox#containsPoint(int, int)
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		return x >= getX() && x < getX() + getWidth() && y >= getBaseline() - getAscentWithBorder()
 				&& y <= getBaseline() + getDescentWithBorder();
@@ -51,10 +52,12 @@ public class TextFragmentBox extends ContentBox {
 	 * 
 	 * @return the ascent
 	 */
+	@Override
 	public int getAscent() {
 		return textflow.getAscent();
 	}
 
+	@Override
 	int getAscentWithBorder() {
 		return textflow.getAscent() + FlowUtilities.getBorderAscent(textflow);
 	}
@@ -65,18 +68,22 @@ public class TextFragmentBox extends ContentBox {
 	 * 
 	 * @return the descent
 	 */
+	@Override
 	public int getDescent() {
 		return textflow.getDescent();
 	}
 
+	@Override
 	int getDescentWithBorder() {
 		return textflow.getDescent() + FlowUtilities.getBorderDescent(textflow);
 	}
 
+	@Override
 	int getOuterAscent() {
 		return textflow.getAscent() + FlowUtilities.getBorderAscentWithMargin(textflow);
 	}
 
+	@Override
 	int getOuterDescent() {
 		return textflow.getDescent() + FlowUtilities.getBorderDescentWithMargin(textflow);
 	}
@@ -121,6 +128,7 @@ public class TextFragmentBox extends ContentBox {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "[" + offset + ", " + (offset + length) //$NON-NLS-1$ //$NON-NLS-2$
 				+ ") = \"" + textflow.getText().substring(offset, offset + length) + '\"'; //$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/widgets/ImageBorder.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/widgets/ImageBorder.java
@@ -38,6 +38,7 @@ class ImageBorder extends AbstractBorder {
 		setImage(image);
 	}
 
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return imgInsets;
 	}
@@ -49,10 +50,12 @@ class ImageBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.AbstractBorder#getPreferredSize(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public Dimension getPreferredSize(IFigure f) {
 		return imageSize;
 	}
 
+	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 		if (image == null)
 			return;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/widgets/MultiLineLabel.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/widgets/MultiLineLabel.java
@@ -53,16 +53,19 @@ public final class MultiLineLabel extends FigureCanvas {
 			setBorder(MARGIN);
 		}
 
+		@Override
 		public void handleFocusGained(FocusEvent event) {
 			super.handleFocusGained(event);
 			repaint();
 		}
 
+		@Override
 		public void handleFocusLost(FocusEvent event) {
 			super.handleFocusLost(event);
 			repaint();
 		}
 
+		@Override
 		protected void paintBorder(Graphics graphics) {
 			super.paintBorder(graphics);
 			if (hasFocus()) {
@@ -93,20 +96,24 @@ public final class MultiLineLabel extends FigureCanvas {
 
 	private void addAccessibility() {
 		getAccessible().addAccessibleControlListener(new AccessibleControlAdapter() {
+			@Override
 			public void getRole(AccessibleControlEvent e) {
 				e.detail = ACC.ROLE_LABEL;
 			}
 
+			@Override
 			public void getState(AccessibleControlEvent e) {
 				e.detail = ACC.STATE_READONLY;
 			}
 		});
 		getAccessible().addAccessibleListener(new AccessibleAdapter() {
+			@Override
 			public void getName(AccessibleEvent e) {
 				e.result = getText();
 			}
 		});
 		addKeyListener(new KeyAdapter() {
+			@Override
 			public void keyPressed(KeyEvent e) {
 				Point p = getViewport().getViewLocation();
 				int dy = getFont().getFontData()[0].getHeight();
@@ -138,6 +145,7 @@ public final class MultiLineLabel extends FigureCanvas {
 	/**
 	 * @see org.eclipse.swt.widgets.Control#setEnabled(boolean)
 	 */
+	@Override
 	public void setEnabled(boolean enabled) {
 		super.setEnabled(enabled);
 		textFlow.setEnabled(getEnabled());
@@ -163,6 +171,7 @@ public final class MultiLineLabel extends FigureCanvas {
 	/**
 	 * @see org.eclipse.swt.widgets.Canvas#setFont(org.eclipse.swt.graphics.Font)
 	 */
+	@Override
 	public void setFont(Font font) {
 		super.setFont(font);
 		textFlow.revalidate();

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditor.java
@@ -221,6 +221,7 @@ public class ShapesEditor extends GraphicalEditorWithFlyoutPalette {
 				new ProgressMonitorDialog(shell).run(false, // don't fork
 						false, // not cancelable
 						new WorkspaceModifyOperation() { // run this operation
+							@Override
 							public void execute(final IProgressMonitor monitor) {
 								try {
 									ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditorActionBarContributor.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditorActionBarContributor.java
@@ -3,11 +3,11 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial API and implementation
- *******************************************************************************/
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes;
 
 import org.eclipse.jface.action.IToolBarManager;
@@ -31,6 +31,7 @@ public class ShapesEditorActionBarContributor extends ActionBarContributor {
 	 * 
 	 * @see org.eclipse.gef.ui.actions.ActionBarContributor#buildActions()
 	 */
+	@Override
 	protected void buildActions() {
 		addRetargetAction(new DeleteRetargetAction());
 		addRetargetAction(new UndoRetargetAction());
@@ -42,6 +43,7 @@ public class ShapesEditorActionBarContributor extends ActionBarContributor {
 	 * 
 	 * @see org.eclipse.ui.part.EditorActionBarContributor#contributeToToolBar(org.eclipse.jface.action.IToolBarManager)
 	 */
+	@Override
 	public void contributeToToolBar(IToolBarManager toolBarManager) {
 		toolBarManager.add(getAction(ActionFactory.UNDO.getId()));
 		toolBarManager.add(getAction(ActionFactory.REDO.getId()));
@@ -53,6 +55,7 @@ public class ShapesEditorActionBarContributor extends ActionBarContributor {
 	 * @see
 	 * org.eclipse.gef.ui.actions.ActionBarContributor#declareGlobalActionKeys()
 	 */
+	@Override
 	protected void declareGlobalActionKeys() {
 		// currently none
 	}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditorContextMenuProvider.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditorContextMenuProvider.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
-�* All rights reserved. This program and the accompanying materials
-�* are made available under the terms of the Eclipse Public License v1.0
-�* which accompanies this distribution, and is available at
-�* http://www.eclipse.org/legal/epl-v10.html
-�*
-�* Contributors:
-�*����Elias Volanakis - initial API and implementation
-�*******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes;
 
 import org.eclipse.jface.action.IAction;
@@ -51,6 +51,7 @@ class ShapesEditorContextMenuProvider extends ContextMenuProvider {
 	 * 
 	 * @see org.eclipse.gef.ContextMenuProvider#buildContextMenu(org.eclipse.jface.action.IMenuManager)
 	 */
+	@Override
 	public void buildContextMenu(IMenuManager menu) {
 		// Add standard action groups to the menu
 		GEFActionConstants.addStandardActionGroups(menu);

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditorPaletteFactory.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesEditorPaletteFactory.java
@@ -83,12 +83,14 @@ final class ShapesEditorPaletteFactory {
 		// Add (solid-line) connection tool
 		tool = new ConnectionCreationToolEntry("Solid connection", "Create a solid-line connection",
 				new CreationFactory() {
+					@Override
 					public Object getNewObject() {
 						return null;
 					}
 
 					// see ShapeEditPart#createEditPolicies()
 					// this is abused to transmit the desired line style
+					@Override
 					public Object getObjectType() {
 						return Connection.SOLID_CONNECTION;
 					}
@@ -99,12 +101,14 @@ final class ShapesEditorPaletteFactory {
 		// Add (dashed-line) connection tool
 		tool = new ConnectionCreationToolEntry("Dashed connection", "Create a dashed-line connection",
 				new CreationFactory() {
+					@Override
 					public Object getNewObject() {
 						return null;
 					}
 
 					// see ShapeEditPart#createEditPolicies()
 					// this is abused to transmit the desired line style
+					@Override
 					public Object getObjectType() {
 						return Connection.DASHED_CONNECTION;
 					}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesPlugin.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/ShapesPlugin.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial API and implementation
- *******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/Connection.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/Connection.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
-�* All rights reserved. This program and the accompanying materials
-�* are made available under the terms of the Eclipse Public License v1.0
-�* which accompanies this distribution, and is available at
-�* http://www.eclipse.org/legal/epl-v10.html
-�*
-�* Contributors:
-�*����Elias Volanakis - initial API and implementation
-�*******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes.model;
 
 import org.eclipse.ui.views.properties.ComboBoxPropertyDescriptor;
@@ -94,6 +94,7 @@ public class Connection extends ModelElement {
 	 * 
 	 * @see org.eclipse.ui.views.properties.IPropertySource#getPropertyDescriptors()
 	 */
+	@Override
 	public IPropertyDescriptor[] getPropertyDescriptors() {
 		return descriptors;
 	}
@@ -103,6 +104,7 @@ public class Connection extends ModelElement {
 	 * 
 	 * @see org.eclipse.ui.views.properties.IPropertySource#getPropertyValue(java.lang.Object)
 	 */
+	@Override
 	public Object getPropertyValue(Object id) {
 		if (id.equals(LINESTYLE_PROP)) {
 			if (getLineStyle() == Graphics.LINE_DASH)
@@ -188,6 +190,7 @@ public class Connection extends ModelElement {
 	 * @see org.eclipse.ui.views.properties.IPropertySource#setPropertyValue(java.lang.Object,
 	 *      java.lang.Object)
 	 */
+	@Override
 	public void setPropertyValue(Object id, Object value) {
 		if (id.equals(LINESTYLE_PROP))
 			setLineStyle(Integer.valueOf(1).equals(value) ? Graphics.LINE_DASH : Graphics.LINE_SOLID);

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/EllipticalShape.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/EllipticalShape.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial API and implementation
- *******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes.model;
 
 import org.eclipse.swt.graphics.Image;
@@ -24,10 +24,12 @@ public class EllipticalShape extends Shape {
 
 	private static final long serialVersionUID = 1;
 
+	@Override
 	public Image getIcon() {
 		return ELLIPSE_ICON;
 	}
 
+	@Override
 	public String toString() {
 		return "Ellipse " + hashCode();
 	}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/ModelElement.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/ModelElement.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
-�* All rights reserved. This program and the accompanying materials
-�* are made available under the terms of the Eclipse Public License v1.0
-�* which accompanies this distribution, and is available at
-�* http://www.eclipse.org/legal/epl-v10.html
-�*
-�* Contributors:
-�*����Elias Volanakis - initial API and implementation
-�*******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes.model;
 
 import java.beans.PropertyChangeListener;
@@ -87,6 +87,7 @@ public abstract class ModelElement implements IPropertySource, Serializable {
 	 * 
 	 * @return this instance
 	 */
+	@Override
 	public Object getEditableValue() {
 		return this;
 	}
@@ -95,6 +96,7 @@ public abstract class ModelElement implements IPropertySource, Serializable {
 	 * Children should override this. The default implementation returns an empty
 	 * array.
 	 */
+	@Override
 	public IPropertyDescriptor[] getPropertyDescriptors() {
 		return EMPTY_ARRAY;
 	}
@@ -102,6 +104,7 @@ public abstract class ModelElement implements IPropertySource, Serializable {
 	/**
 	 * Children should override this. The default implementation returns null.
 	 */
+	@Override
 	public Object getPropertyValue(Object id) {
 		return null;
 	}
@@ -109,6 +112,7 @@ public abstract class ModelElement implements IPropertySource, Serializable {
 	/**
 	 * Children should override this. The default implementation returns false.
 	 */
+	@Override
 	public boolean isPropertySet(Object id) {
 		return false;
 	}
@@ -137,6 +141,7 @@ public abstract class ModelElement implements IPropertySource, Serializable {
 	/**
 	 * Children should override this. The default implementation does nothing.
 	 */
+	@Override
 	public void resetPropertyValue(Object id) {
 		// do nothing
 	}
@@ -144,6 +149,7 @@ public abstract class ModelElement implements IPropertySource, Serializable {
 	/**
 	 * Children should override this. The default implementation does nothing.
 	 */
+	@Override
 	public void setPropertyValue(Object id, Object value) {
 		// do nothing
 	}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/RectangularShape.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/RectangularShape.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial API and implementation
- *******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes.model;
 
 import org.eclipse.swt.graphics.Image;
@@ -23,10 +23,12 @@ public class RectangularShape extends Shape {
 
 	private static final long serialVersionUID = 1;
 
+	@Override
 	public Image getIcon() {
 		return RECTANGLE_ICON;
 	}
 
+	@Override
 	public String toString() {
 		return "Rectangle " + hashCode();
 	}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/Shape.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/Shape.java
@@ -95,6 +95,7 @@ public abstract class Shape extends ModelElement {
 		// use a custom cell editor validator for all four array entries
 		for (int i = 0; i < descriptors.length; i++) {
 			((PropertyDescriptor) descriptors[i]).setValidator(new ICellEditorValidator() {
+				@Override
 				public String isValid(Object value) {
 					int intValue = -1;
 					try {

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/commands/ConnectionCreateCommand.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/commands/ConnectionCreateCommand.java
@@ -121,6 +121,7 @@ public class ConnectionCreateCommand extends Command {
 	 * 
 	 * @see org.eclipse.gef.commands.Command#undo()
 	 */
+	@Override
 	public void undo() {
 		connection.disconnect();
 	}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/commands/ConnectionDeleteCommand.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/commands/ConnectionDeleteCommand.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
-�* All rights reserved. This program and the accompanying materials
-�* are made available under the terms of the Eclipse Public License v1.0
-�* which accompanies this distribution, and is available at
-�* http://www.eclipse.org/legal/epl-v10.html
-�*
-�* Contributors:
-�*����Elias Volanakis - initial API and implementation
-�*******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes.model.commands;
 
 import org.eclipse.gef.commands.Command;
@@ -44,6 +44,7 @@ public class ConnectionDeleteCommand extends Command {
 	 * 
 	 * @see org.eclipse.gef.commands.Command#execute()
 	 */
+	@Override
 	public void execute() {
 		connection.disconnect();
 	}
@@ -53,6 +54,7 @@ public class ConnectionDeleteCommand extends Command {
 	 * 
 	 * @see org.eclipse.gef.commands.Command#undo()
 	 */
+	@Override
 	public void undo() {
 		connection.reconnect();
 	}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/commands/package.html
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/commands/package.html
@@ -1,15 +1,15 @@
 <!--
 /*******************************************************************************
  * Copyright (c) 2004 Elias Volanakis.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial contents
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial contents
  *    IBM Corporation
- *******************************************************************************/
+ *******************************************************************************/
 -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/package.html
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/model/package.html
@@ -1,15 +1,15 @@
 <!--
 /*******************************************************************************
  * Copyright (c) 2004 Elias Volanakis.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial contents
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial contents
  *    IBM Corporation
- *******************************************************************************/
+ *******************************************************************************/
 -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/package.html
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/package.html
@@ -1,15 +1,15 @@
 <!--
 /*******************************************************************************
  * Copyright (c) 2004 Elias Volanakis.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial contents
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial contents
  *    IBM Corporation
- *******************************************************************************/
+ *******************************************************************************/
 -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ConnectionEditPart.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ConnectionEditPart.java
@@ -62,6 +62,7 @@ class ConnectionEditPart extends AbstractConnectionEditPart implements PropertyC
 		installEditPolicy(EditPolicy.CONNECTION_ENDPOINTS_ROLE, new ConnectionEndpointEditPolicy());
 		// Allows the removal of the connection model element
 		installEditPolicy(EditPolicy.CONNECTION_ROLE, new ConnectionEditPolicy() {
+			@Override
 			protected Command getDeleteCommand(GroupRequest request) {
 				return new ConnectionDeleteCommand(getModel());
 			}

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ShapeEditPart.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ShapeEditPart.java
@@ -72,6 +72,7 @@ class ShapeEditPart extends AbstractGraphicalEditPart implements PropertyChangeL
 	 * 
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
 	 */
+	@Override
 	protected void createEditPolicies() {
 		// allow removal of the associated model element
 		installEditPolicy(EditPolicy.COMPONENT_ROLE, new ShapeComponentEditPolicy());

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ShapeTreeEditPart.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ShapeTreeEditPart.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2004, 2005 Elias Volanakis and others.
-�* All rights reserved. This program and the accompanying materials
-�* are made available under the terms of the Eclipse Public License v1.0
-�* which accompanies this distribution, and is available at
-�* http://www.eclipse.org/legal/epl-v10.html
-�*
-�* Contributors:
-�*����Elias Volanakis - initial API and implementation
-�*******************************************************************************/
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.gef.examples.shapes.parts;
 
 import java.beans.PropertyChangeEvent;
@@ -46,6 +46,7 @@ class ShapeTreeEditPart extends AbstractTreeEditPart implements PropertyChangeLi
 	/**
 	 * Upon activation, attach to the model element as a property change listener.
 	 */
+	@Override
 	public void activate() {
 		if (!isActive()) {
 			super.activate();
@@ -58,6 +59,7 @@ class ShapeTreeEditPart extends AbstractTreeEditPart implements PropertyChangeLi
 	 * 
 	 * @see org.eclipse.gef.editparts.AbstractTreeEditPart#createEditPolicies()
 	 */
+	@Override
 	protected void createEditPolicies() {
 		// allow removal of the associated model element
 		installEditPolicy(EditPolicy.COMPONENT_ROLE, new ShapeComponentEditPolicy());
@@ -67,6 +69,7 @@ class ShapeTreeEditPart extends AbstractTreeEditPart implements PropertyChangeLi
 	 * Upon deactivation, detach from the model element as a property change
 	 * listener.
 	 */
+	@Override
 	public void deactivate() {
 		if (isActive()) {
 			super.deactivate();
@@ -83,6 +86,7 @@ class ShapeTreeEditPart extends AbstractTreeEditPart implements PropertyChangeLi
 	 * 
 	 * @see org.eclipse.gef.editparts.AbstractTreeEditPart#getImage()
 	 */
+	@Override
 	protected Image getImage() {
 		return getCastedModel().getIcon();
 	}
@@ -92,6 +96,7 @@ class ShapeTreeEditPart extends AbstractTreeEditPart implements PropertyChangeLi
 	 * 
 	 * @see org.eclipse.gef.editparts.AbstractTreeEditPart#getText()
 	 */
+	@Override
 	protected String getText() {
 		return getCastedModel().toString();
 	}
@@ -102,6 +107,7 @@ class ShapeTreeEditPart extends AbstractTreeEditPart implements PropertyChangeLi
 	 * @see java.beans.PropertyChangeListener#propertyChange(java.beans.
 	 * PropertyChangeEvent)
 	 */
+	@Override
 	public void propertyChange(PropertyChangeEvent evt) {
 		refreshVisuals(); // this will cause an invocation of getImage() and
 							// getText(), see below

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ShapesTreeEditPartFactory.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/ShapesTreeEditPartFactory.java
@@ -30,6 +30,7 @@ public class ShapesTreeEditPartFactory implements EditPartFactory {
 	 * @see org.eclipse.gef.EditPartFactory#createEditPart(org.eclipse.gef.EditPart,
 	 * java.lang.Object)
 	 */
+	@Override
 	public EditPart createEditPart(EditPart context, Object model) {
 		if (model instanceof Shape shape) {
 			return new ShapeTreeEditPart(shape);

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/package.html
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/package.html
@@ -1,15 +1,15 @@
 <!--
 /*******************************************************************************
  * Copyright (c) 2004 Elias Volanakis.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Elias Volanakis - initial contents
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Elias Volanakis - initial contents
  *    IBM Corporation
- *******************************************************************************/
+ *******************************************************************************/
 -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>

--- a/org.eclipse.gef.examples.ui.pde/src/org/eclipse/gef/examples/ui/pde/internal/wizards/ProjectUnzipperNewWizard.java
+++ b/org.eclipse.gef.examples.ui.pde/src/org/eclipse/gef/examples/ui/pde/internal/wizards/ProjectUnzipperNewWizard.java
@@ -170,11 +170,13 @@ abstract public class ProjectUnzipperNewWizard extends Wizard implements INewWiz
 	 * 
 	 * @see Wizard#performFinish
 	 */
+	@Override
 	public boolean performFinish() {
 
 		try {
 			IRunnableWithProgress operation = new WorkspaceModifyOperation() {
 
+				@Override
 				public void execute(IProgressMonitor monitor) throws InterruptedException {
 					try {
 						monitor.beginTask(Messages.monitor_creatingProject, 120);
@@ -410,6 +412,7 @@ abstract public class ProjectUnzipperNewWizard extends Wizard implements INewWiz
 	 * 
 	 * @see WizardNewProjectCreationPage#WizardNewProjectCreationPage(String)
 	 */
+	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 
 		wizardNewProjectCreationPage = new WizardNewProjectCreationPage(getPageName());
@@ -484,6 +487,7 @@ abstract public class ProjectUnzipperNewWizard extends Wizard implements INewWiz
 	 * .eclipse.core.runtime.IConfigurationElement, java.lang.String,
 	 * java.lang.Object)
 	 */
+	@Override
 	public void setInitializationData(IConfigurationElement configIn, String propertyName, Object data)
 			throws CoreException {
 		config = configIn;

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
@@ -19,6 +19,7 @@ public class CommandStackTest extends Assert {
 		// capture all notifications in an event list
 		CommandStack stack = new CommandStack();
 		stack.addCommandStackEventListener(new CommandStackEventListener() {
+			@Override
 			public void stackChanged(CommandStackEvent event) {
 				commandStackEvents.add(event);
 			}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
@@ -40,6 +40,7 @@ public class DragEditPartsTrackerTest extends Assert {
 		 * 
 		 * @see org.eclipse.gef.editparts.AbstractEditPart#register()
 		 */
+		@Override
 		protected void register() {
 			// do nothing
 		}
@@ -49,6 +50,7 @@ public class DragEditPartsTrackerTest extends Assert {
 		 * 
 		 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 		 */
+		@Override
 		protected IFigure createFigure() {
 			return new Figure();
 		}
@@ -58,6 +60,7 @@ public class DragEditPartsTrackerTest extends Assert {
 		 * 
 		 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
 		 */
+		@Override
 		protected void createEditPolicies() {
 			// do nothing
 		}
@@ -65,70 +68,87 @@ public class DragEditPartsTrackerTest extends Assert {
 
 	private class DummyEditorPart implements org.eclipse.ui.IEditorPart {
 
+		@Override
 		public void addPropertyListener(IPropertyListener listener) {
 
 		}
 
+		@Override
 		public void createPartControl(Composite parent) {
 
 		}
 
+		@Override
 		public void dispose() {
 
 		}
 
+		@Override
 		public IWorkbenchPartSite getSite() {
 			return null;
 		}
 
+		@Override
 		public String getTitle() {
 			return null;
 		}
 
+		@Override
 		public Image getTitleImage() {
 			return null;
 		}
 
+		@Override
 		public String getTitleToolTip() {
 			return null;
 		}
 
+		@Override
 		public void removePropertyListener(IPropertyListener listener) {
 
 		}
 
+		@Override
 		public void setFocus() {
 
 		}
 
+		@Override
 		public IEditorInput getEditorInput() {
 			return null;
 		}
 
+		@Override
 		public IEditorSite getEditorSite() {
 			return null;
 		}
 
+		@Override
 		public void init(IEditorSite site, IEditorInput input) throws PartInitException {
 
 		}
 
+		@Override
 		public void doSave(IProgressMonitor monitor) {
 
 		}
 
+		@Override
 		public void doSaveAs() {
 
 		}
 
+		@Override
 		public boolean isDirty() {
 			return false;
 		}
 
+		@Override
 		public boolean isSaveAsAllowed() {
 			return false;
 		}
 
+		@Override
 		public boolean isSaveOnCloseNeeded() {
 			return false;
 		}
@@ -146,6 +166,7 @@ public class DragEditPartsTrackerTest extends Assert {
 			super(sourceEditPart);
 		}
 
+		@Override
 		public List createOperationSet() {
 			return super.createOperationSet();
 		}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/PaletteCustomizerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/PaletteCustomizerTest.java
@@ -25,9 +25,11 @@ import org.junit.Test;
 public class PaletteCustomizerTest extends Assert {
 
 	class TestCustomizer extends PaletteCustomizer {
+		@Override
 		public void revertToSaved() {
 		}
 
+		@Override
 		public void save() {
 		}
 	}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/ToolUtilitiesTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/ToolUtilitiesTest.java
@@ -37,6 +37,7 @@ public class ToolUtilitiesTest extends Assert {
 		 * 
 		 * @see org.eclipse.gef.editparts.AbstractEditPart#register()
 		 */
+		@Override
 		protected void register() {
 			// do nothing
 		}
@@ -46,6 +47,7 @@ public class ToolUtilitiesTest extends Assert {
 		 * 
 		 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 		 */
+		@Override
 		protected IFigure createFigure() {
 			// TODO Auto-generated method stub
 			return new Figure();
@@ -56,6 +58,7 @@ public class ToolUtilitiesTest extends Assert {
 		 * 
 		 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
 		 */
+		@Override
 		protected void createEditPolicies() {
 			// do nothing
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/AutoexposeHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/AutoexposeHelper.java
@@ -90,6 +90,7 @@ public interface AutoexposeHelper {
 		private Point where;
 		public AutoexposeHelper result;
 
+		@Override
 		public boolean evaluate(EditPart editpart) {
 			result = editpart.getAdapter(AutoexposeHelper.class);
 			if (result != null && result.detect(where))

--- a/org.eclipse.gef/src/org/eclipse/gef/CompoundSnapToHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/CompoundSnapToHelper.java
@@ -51,6 +51,7 @@ public class CompoundSnapToHelper extends SnapToHelper {
 	 * @see SnapToHelper#snapRectangle(Request, int, PrecisionRectangle,
 	 *      PrecisionRectangle)
 	 */
+	@Override
 	public int snapRectangle(Request request, int snapOrientation, PrecisionRectangle baseRect,
 			PrecisionRectangle result) {
 		for (int i = 0; i < getDelegates().length && snapOrientation != NONE; i++)

--- a/org.eclipse.gef/src/org/eclipse/gef/ContextMenuProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ContextMenuProvider.java
@@ -56,6 +56,7 @@ public abstract class ContextMenuProvider extends MenuManager implements IMenuLi
 	/**
 	 * @see IMenuListener#menuAboutToShow(IMenuManager)
 	 */
+	@Override
 	public void menuAboutToShow(IMenuManager menu) {
 		buildContextMenu(menu);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/EditDomain.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditDomain.java
@@ -48,6 +48,7 @@ public class EditDomain {
 	 * Tool accordingly.
 	 */
 	private PaletteListener paletteListener = new PaletteListener() {
+		@Override
 		public void activeToolChanged(PaletteViewer viewer, ToolEntry tool) {
 			handlePaletteToolChanged();
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartListener.java
@@ -28,30 +28,35 @@ public interface EditPartListener {
 		/**
 		 * @see org.eclipse.gef.EditPartListener#childAdded(EditPart, int)
 		 */
+		@Override
 		public void childAdded(EditPart child, int index) {
 		}
 
 		/**
 		 * @see org.eclipse.gef.EditPartListener#partActivated(EditPart)
 		 */
+		@Override
 		public void partActivated(EditPart editpart) {
 		}
 
 		/**
 		 * @see org.eclipse.gef.EditPartListener#partDeactivated(EditPart)
 		 */
+		@Override
 		public void partDeactivated(EditPart editpart) {
 		}
 
 		/**
 		 * @see org.eclipse.gef.EditPartListener#removingChild(EditPart, int)
 		 */
+		@Override
 		public void removingChild(EditPart child, int index) {
 		}
 
 		/**
 		 * @see org.eclipse.gef.EditPartListener#selectedStateChanged(EditPart)
 		 */
+		@Override
 		public void selectedStateChanged(EditPart part) {
 		}
 	};

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
@@ -374,6 +374,7 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * 
 	 * @see org.eclipse.jface.viewers.ISelectionProvider#getSelection()
 	 */
+	@Override
 	ISelection getSelection();
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/KeyStroke.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/KeyStroke.java
@@ -137,6 +137,7 @@ public class KeyStroke {
 	 * @return true iff the Object is an equivalent KeyStroke
 	 * @param obj the Object being compared
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof KeyStroke) {
 			KeyStroke stroke = (KeyStroke) obj;
@@ -149,6 +150,7 @@ public class KeyStroke {
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return (stateMask + 1) * ((character ^ keyCode) + 1) // One of these is
 																// always Zero.

--- a/org.eclipse.gef/src/org/eclipse/gef/MouseWheelZoomHandler.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/MouseWheelZoomHandler.java
@@ -40,6 +40,7 @@ public final class MouseWheelZoomHandler implements MouseWheelHandler {
 	 * 
 	 * @see MouseWheelHandler#handleMouseWheel(Event, EditPartViewer)
 	 */
+	@Override
 	public void handleMouseWheel(Event event, EditPartViewer viewer) {
 		ZoomManager zoomMgr = (ZoomManager) viewer.getProperty(ZoomManager.class.toString());
 		if (zoomMgr != null) {

--- a/org.eclipse.gef/src/org/eclipse/gef/RootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/RootEditPart.java
@@ -32,6 +32,7 @@ public interface RootEditPart extends EditPart {
 	 * 
 	 * @return The <code>EditPartViewer</code>
 	 */
+	@Override
 	EditPartViewer getViewer();
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/SnapToGrid.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SnapToGrid.java
@@ -117,6 +117,7 @@ public class SnapToGrid extends SnapToHelper {
 	 * @see SnapToHelper#snapRectangle(Request, int, PrecisionRectangle,
 	 *      PrecisionRectangle)
 	 */
+	@Override
 	public int snapRectangle(Request request, int snapLocations, PrecisionRectangle rect, PrecisionRectangle result) {
 
 		rect = rect.getPreciseCopy();

--- a/org.eclipse.gef/src/org/eclipse/gef/SnapToGuides.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SnapToGuides.java
@@ -243,6 +243,7 @@ public class SnapToGuides extends SnapToHelper {
 	 * @see SnapToHelper#snapRectangle(Request, int, PrecisionRectangle,
 	 *      PrecisionRectangle)
 	 */
+	@Override
 	public int snapRectangle(Request request, int snapOrientation, PrecisionRectangle baseRect,
 			PrecisionRectangle result) {
 		if (request instanceof GroupRequest && ((GroupRequest) request).getEditParts().size() > 1)

--- a/org.eclipse.gef/src/org/eclipse/gef/commands/Command.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/commands/Command.java
@@ -75,6 +75,7 @@ public abstract class Command {
 		if (command == null)
 			return this;
 		class ChainedCompoundCommand extends CompoundCommand {
+			@Override
 			public Command chain(Command c) {
 				add(c);
 				return this;

--- a/org.eclipse.gef/src/org/eclipse/gef/commands/UnexecutableCommand.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/commands/UnexecutableCommand.java
@@ -26,6 +26,7 @@ public final class UnexecutableCommand extends Command {
 	/**
 	 * @return <code>false</code>
 	 */
+	@Override
 	public boolean canExecute() {
 		return false;
 	}
@@ -33,6 +34,7 @@ public final class UnexecutableCommand extends Command {
 	/**
 	 * @return <code>false</code>
 	 */
+	@Override
 	public boolean canUndo() {
 		return false;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDragSourceListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDragSourceListener.java
@@ -49,18 +49,21 @@ public abstract class AbstractTransferDragSourceListener implements TransferDrag
 	/**
 	 * @see org.eclipse.swt.dnd.DragSourceListener#dragFinished(DragSourceEvent)
 	 */
+	@Override
 	public void dragFinished(DragSourceEvent event) {
 	}
 
 	/**
 	 * @see org.eclipse.swt.dnd.DragSourceListener#dragStart(DragSourceEvent)
 	 */
+	@Override
 	public void dragStart(DragSourceEvent event) {
 	}
 
 	/**
 	 * @see TransferDragSourceListener#getTransfer()
 	 */
+	@Override
 	public Transfer getTransfer() {
 		return transfer;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDropTargetListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDropTargetListener.java
@@ -107,6 +107,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	 * 
 	 * @see DropTargetListener#dragEnter(DropTargetEvent)
 	 */
+	@Override
 	public void dragEnter(DropTargetEvent event) {
 		resetHover();
 		setCurrentEvent(event);
@@ -121,6 +122,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	 * 
 	 * @see DropTargetListener#dragLeave(DropTargetEvent)
 	 */
+	@Override
 	public void dragLeave(DropTargetEvent event) {
 		setCurrentEvent(event);
 		unload();
@@ -133,6 +135,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	 * 
 	 * @see DropTargetListener#dragOperationChanged(DropTargetEvent)
 	 */
+	@Override
 	public void dragOperationChanged(DropTargetEvent event) {
 		resetHover();
 		setCurrentEvent(event);
@@ -146,6 +149,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	 * 
 	 * @see DropTargetListener#dragOver(org.eclipse.swt.dnd.DropTargetEvent)
 	 */
+	@Override
 	public void dragOver(DropTargetEvent event) {
 		setCurrentEvent(event);
 		handleDragOver();
@@ -171,6 +175,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	 * 
 	 * @see DropTargetListener#drop(DropTargetEvent)
 	 */
+	@Override
 	public void drop(DropTargetEvent event) {
 		setCurrentEvent(event);
 		eraseTargetFeedback();
@@ -184,6 +189,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	 * 
 	 * @see DropTargetListener#dropAccept(DropTargetEvent)
 	 */
+	@Override
 	public void dropAccept(DropTargetEvent event) {
 		setCurrentEvent(event);
 	}
@@ -268,6 +274,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	/**
 	 * @see TransferDropTargetListener#getTransfer()
 	 */
+	@Override
 	public Transfer getTransfer() {
 		return transfer;
 	}
@@ -379,6 +386,7 @@ public abstract class AbstractTransferDropTargetListener implements TransferDrop
 	 * @return <code>true</code> if this TransferDropTargetListener is enabled for
 	 *         the given DropTargetEvent
 	 */
+	@Override
 	public boolean isEnabled(DropTargetEvent event) {
 		for (int i = 0; i < event.dataTypes.length; i++) {
 			if (getTransfer().isSupportedType(event.dataTypes[i])) {

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/SimpleObjectTransfer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/SimpleObjectTransfer.java
@@ -42,6 +42,7 @@ public abstract class SimpleObjectTransfer extends ByteArrayTransfer {
 	 * 
 	 * @see org.eclipse.swt.dnd.Transfer#javaToNative(Object, TransferData)
 	 */
+	@Override
 	public void javaToNative(Object object, TransferData transferData) {
 		setObject(object);
 		startTime = System.currentTimeMillis();
@@ -56,6 +57,7 @@ public abstract class SimpleObjectTransfer extends ByteArrayTransfer {
 	 * 
 	 * @see org.eclipse.swt.dnd.Transfer#nativeToJava(TransferData)
 	 */
+	@Override
 	public Object nativeToJava(TransferData transferData) {
 		byte bytes[] = (byte[]) super.nativeToJava(transferData);
 		if (bytes == null) {

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransfer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransfer.java
@@ -48,6 +48,7 @@ public final class TemplateTransfer extends SimpleObjectTransfer {
 	/**
 	 * @see org.eclipse.swt.dnd.Transfer#getTypeIds()
 	 */
+	@Override
 	protected int[] getTypeIds() {
 		return new int[] { TYPEID };
 	}
@@ -55,6 +56,7 @@ public final class TemplateTransfer extends SimpleObjectTransfer {
 	/**
 	 * @see org.eclipse.swt.dnd.Transfer#getTypeNames()
 	 */
+	@Override
 	protected String[] getTypeNames() {
 		return new String[] { TYPE_NAME };
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDragSourceListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDragSourceListener.java
@@ -55,6 +55,7 @@ public class TemplateTransferDragSourceListener extends AbstractTransferDragSour
 	/**
 	 * @see AbstractTransferDragSourceListener#dragFinished(DragSourceEvent)
 	 */
+	@Override
 	public void dragFinished(DragSourceEvent event) {
 		TemplateTransfer.getInstance().setTemplate(null);
 	}
@@ -65,6 +66,7 @@ public class TemplateTransferDragSourceListener extends AbstractTransferDragSour
 	 * 
 	 * @param event the DragSourceEvent
 	 */
+	@Override
 	public void dragSetData(DragSourceEvent event) {
 		event.data = getTemplate();
 	}
@@ -75,6 +77,7 @@ public class TemplateTransferDragSourceListener extends AbstractTransferDragSour
 	 * 
 	 * @see org.eclipse.swt.dnd.DragSourceListener#dragStart(DragSourceEvent)
 	 */
+	@Override
 	public void dragStart(DragSourceEvent event) {
 		Object template = getTemplate();
 		if (template == null)

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDropTargetListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDropTargetListener.java
@@ -45,6 +45,7 @@ public class TemplateTransferDropTargetListener extends AbstractTransferDropTarg
 	/**
 	 * @see org.eclipse.gef.dnd.AbstractTransferDropTargetListener#createTargetRequest()
 	 */
+	@Override
 	protected Request createTargetRequest() {
 		// Look at the data on templatetransfer.
 		// Create factory
@@ -85,6 +86,7 @@ public class TemplateTransferDropTargetListener extends AbstractTransferDropTarg
 	 * 
 	 * @see AbstractTransferDropTargetListener#handleDragOperationChanged()
 	 */
+	@Override
 	protected void handleDragOperationChanged() {
 		getCurrentEvent().detail = DND.DROP_COPY;
 		super.handleDragOperationChanged();
@@ -96,6 +98,7 @@ public class TemplateTransferDropTargetListener extends AbstractTransferDropTarg
 	 * 
 	 * @see org.eclipse.gef.dnd.AbstractTransferDropTargetListener#handleDragOver()
 	 */
+	@Override
 	protected void handleDragOver() {
 		getCurrentEvent().detail = DND.DROP_COPY;
 		getCurrentEvent().feedback = DND.FEEDBACK_SCROLL | DND.FEEDBACK_EXPAND;
@@ -107,6 +110,7 @@ public class TemplateTransferDropTargetListener extends AbstractTransferDropTarg
 	 * 
 	 * @see org.eclipse.gef.dnd.AbstractTransferDropTargetListener#handleDrop()
 	 */
+	@Override
 	protected void handleDrop() {
 		super.handleDrop();
 		selectAddedObject();
@@ -129,6 +133,7 @@ public class TemplateTransferDropTargetListener extends AbstractTransferDropTarg
 	/**
 	 * Assumes that the target request is a {@link CreateRequest}.
 	 */
+	@Override
 	protected void updateTargetRequest() {
 		CreateRequest request = getCreateRequest();
 		request.setLocation(getDropLocation());

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractConnectionEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractConnectionEditPart.java
@@ -58,6 +58,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 		/**
 		 * @see AccessibleAnchorProvider#getSourceAnchorLocations()
 		 */
+		@Override
 		public List getSourceAnchorLocations() {
 			List list = new ArrayList();
 			if (getFigure() instanceof Connection) {
@@ -71,6 +72,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 		/**
 		 * @see AccessibleAnchorProvider#getTargetAnchorLocations()
 		 */
+		@Override
 		public List getTargetAnchorLocations() {
 			return getSourceAnchorLocations();
 		}
@@ -91,6 +93,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	/**
 	 * @see org.eclipse.gef.EditPart#addNotify()
 	 */
+	@Override
 	public void addNotify() {
 		activateFigure();
 		super.addNotify();
@@ -101,6 +104,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	 * 
 	 * @return The created Figure.
 	 */
+	@Override
 	protected IFigure createFigure() {
 		return new PolylineConnection();
 	}
@@ -146,6 +150,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	/**
 	 * @see org.eclipse.gef.EditPart#getDragTracker(Request)
 	 */
+	@Override
 	public DragTracker getDragTracker(Request req) {
 		return new SelectEditPartTracker(this);
 	}
@@ -153,6 +158,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	/**
 	 * @see org.eclipse.gef.ConnectionEditPart#getSource()
 	 */
+	@Override
 	public EditPart getSource() {
 		return sourceEditPart;
 	}
@@ -160,6 +166,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	/**
 	 * @see org.eclipse.gef.ConnectionEditPart#getTarget()
 	 */
+	@Override
 	public EditPart getTarget() {
 		return targetEditPart;
 	}
@@ -215,6 +222,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	 * 
 	 * @see org.eclipse.gef.EditPart#refresh()
 	 */
+	@Override
 	public void refresh() {
 		refreshSourceAnchor();
 		refreshTargetAnchor();
@@ -243,6 +251,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	 * 
 	 * @see org.eclipse.gef.EditPart#removeNotify()
 	 */
+	@Override
 	public void removeNotify() {
 		deactivateFigure();
 		super.removeNotify();
@@ -253,6 +262,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	 * 
 	 * @see org.eclipse.gef.EditPart#setParent(EditPart)
 	 */
+	@Override
 	public void setParent(EditPart parent) {
 		boolean wasNull = getParent() == null;
 		boolean becomingNull = parent == null;
@@ -268,6 +278,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	 * 
 	 * @param editPart EditPart which is the source.
 	 */
+	@Override
 	public void setSource(EditPart editPart) {
 		if (sourceEditPart == editPart)
 			return;
@@ -285,6 +296,7 @@ public abstract class AbstractConnectionEditPart extends AbstractGraphicalEditPa
 	 * 
 	 * @param editPart EditPart which is the target.
 	 */
+	@Override
 	public void setTarget(EditPart editPart) {
 		if (targetEditPart == editPart)
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
@@ -234,6 +234,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * 
 	 * @param listener the listener
 	 */
+	@Override
 	public void addEditPartListener(EditPartListener listener) {
 		eventListeners.addListener(EditPartListener.class, listener);
 	}
@@ -611,6 +612,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * @see EditPart#getTargetEditPart(Request)
 	 * @see EditPolicy#getTargetEditPart(Request)
 	 */
+	@Override
 	public EditPart getTargetEditPart(Request request) {
 		for (EditPolicy ep : getEditPolicyIterable()) {
 			EditPart editPart = ep.getTargetEditPart(request);
@@ -684,6 +686,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	/**
 	 * @return <code>true</code> if this EditPart is active.
 	 */
+	@Override
 	public boolean isActive() {
 		return getFlag(FLAG_ACTIVE);
 	}
@@ -715,6 +718,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * properties. Subclasses should extend this method to handle additional types
 	 * of structural refreshing.
 	 */
+	@Override
 	public void refresh() {
 		refreshVisuals();
 		refreshChildren();
@@ -1096,6 +1100,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * 
 	 * @return a description
 	 */
+	@Override
 	public String toString() {
 		String c = getClass().getName();
 		c = c.substring(c.lastIndexOf('.') + 1);

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
@@ -73,6 +73,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 		/**
 		 * @see AccessibleEditPart#getChildCount(AccessibleControlEvent)
 		 */
+		@Override
 		public void getChildCount(AccessibleControlEvent e) {
 			e.detail = AbstractGraphicalEditPart.this.getChildren().size();
 		}
@@ -80,6 +81,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 		/**
 		 * @see AccessibleEditPart#getChildren(AccessibleControlEvent)
 		 */
+		@Override
 		public void getChildren(AccessibleControlEvent e) {
 			ArrayList<Integer> children = new ArrayList<>(AbstractGraphicalEditPart.this.getChildren().size());
 			for (EditPart part : AbstractGraphicalEditPart.this.getChildren()) {
@@ -94,6 +96,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 		/**
 		 * @see AccessibleEditPart#getLocation(AccessibleControlEvent)
 		 */
+		@Override
 		public void getLocation(AccessibleControlEvent e) {
 			Rectangle bounds = getFigure().getBounds().getCopy();
 			getFigure().translateToAbsolute(bounds);
@@ -108,6 +111,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 		/**
 		 * @see AccessibleEditPart#getState(AccessibleControlEvent)
 		 */
+		@Override
 		public void getState(AccessibleControlEvent e) {
 			e.detail = ACC.STATE_SELECTABLE | ACC.STATE_FOCUSABLE;
 			if (getSelected() != EditPart.SELECTED_NONE)
@@ -119,6 +123,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 		/**
 		 * @see AccessibleEditPart#getRole(AccessibleControlEvent)
 		 */
+		@Override
 		public void getRole(AccessibleControlEvent e) {
 			e.detail = ACC.ROLE_LABEL;
 		}
@@ -510,6 +515,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 	/**
 	 * @see org.eclipse.gef.GraphicalEditPart#getSourceConnections()
 	 */
+	@Override
 	public List getSourceConnections() {
 		if (sourceConnections == null)
 			return Collections.EMPTY_LIST;
@@ -519,6 +525,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 	/**
 	 * @see org.eclipse.gef.GraphicalEditPart#getTargetConnections()
 	 */
+	@Override
 	public List getTargetConnections() {
 		if (targetConnections == null)
 			return Collections.EMPTY_LIST;

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractTreeEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractTreeEditPart.java
@@ -60,6 +60,7 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements T
 	 * 
 	 * @see AbstractEditPart#addChildVisual(EditPart, int)
 	 */
+	@Override
 	protected void addChildVisual(EditPart childEditPart, int index) {
 		Widget widget = getWidget();
 		TreeItem item;
@@ -86,6 +87,7 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements T
 	 * 
 	 * @see AbstractEditPart#createEditPolicies()
 	 */
+	@Override
 	protected void createEditPolicies() {
 	}
 
@@ -98,6 +100,7 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements T
 	/**
 	 * @see EditPart#getDragTracker(Request)
 	 */
+	@Override
 	public DragTracker getDragTracker(Request req) {
 		return null;
 	}
@@ -125,6 +128,7 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements T
 	/**
 	 * @see TreeEditPart#getWidget()
 	 */
+	@Override
 	public Widget getWidget() {
 		return widget;
 	}
@@ -174,6 +178,7 @@ public abstract class AbstractTreeEditPart extends AbstractEditPart implements T
 	 * 
 	 * @see org.eclipse.gef.TreeEditPart#setWidget(Widget)
 	 */
+	@Override
 	public void setWidget(Widget widget) {
 		if (widget != null) {
 			widget.setData(this);

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
@@ -87,6 +87,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	private LayeredPane innerLayers;
 	private LayeredPane printableLayers;
 	private PropertyChangeListener gridListener = new PropertyChangeListener() {
+		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			String property = evt.getPropertyName();
 			if (property.equals(SnapToGrid.PROPERTY_GRID_ORIGIN) || property.equals(SnapToGrid.PROPERTY_GRID_SPACING)
@@ -98,6 +99,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
+	@Override
 	protected IFigure createFigure() {
 		FreeformViewport viewport = new FreeformViewport();
 		innerLayers = new FreeformLayeredPane();
@@ -160,6 +162,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	 * 
 	 * @see org.eclipse.gef.GraphicalEditPart#getContentPane()
 	 */
+	@Override
 	public IFigure getContentPane() {
 		return getLayer(PRIMARY_LAYER);
 	}
@@ -169,6 +172,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	 * 
 	 * @see org.eclipse.gef.EditPart#getDragTracker(org.eclipse.gef.Request)
 	 */
+	@Override
 	public DragTracker getDragTracker(Request req) {
 		/*
 		 * The root will only be asked for a drag tracker if for some reason the
@@ -182,6 +186,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	 * 
 	 * @see LayerManager#getLayer(Object)
 	 */
+	@Override
 	public IFigure getLayer(Object key) {
 		if (innerLayers == null)
 			return null;
@@ -199,6 +204,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	 * 
 	 * @see org.eclipse.gef.EditPart#getModel()
 	 */
+	@Override
 	public Object getModel() {
 		return LayerManager.ID;
 	}
@@ -239,6 +245,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#register()
 	 */
+	@Override
 	protected void register() {
 		super.register();
 		if (getLayer(GRID_LAYER) != null) {
@@ -250,6 +257,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	/**
 	 * @see AbstractEditPart#unregister()
 	 */
+	@Override
 	protected void unregister() {
 		getViewer().removePropertyChangeListener(gridListener);
 		super.unregister();

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/GraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/GraphicalRootEditPart.java
@@ -57,12 +57,14 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
 	 */
+	@Override
 	protected void createEditPolicies() {
 	}
 
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
+	@Override
 	protected IFigure createFigure() {
 		innerLayers = new LayeredPane();
 		printableLayers = new LayeredPane();
@@ -97,6 +99,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * 
 	 * @see org.eclipse.gef.EditPart#getCommand(org.eclipse.gef.Request)
 	 */
+	@Override
 	public Command getCommand(Request req) {
 		return UnexecutableCommand.INSTANCE;
 	}
@@ -104,6 +107,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	/**
 	 * @see org.eclipse.gef.RootEditPart#getContents()
 	 */
+	@Override
 	public EditPart getContents() {
 		return contents;
 	}
@@ -113,6 +117,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * 
 	 * @see org.eclipse.gef.EditPart#getDragTracker(org.eclipse.gef.Request)
 	 */
+	@Override
 	public DragTracker getDragTracker(Request req) {
 		// The drawing cannot be dragged.
 		return new MarqueeDragTracker();
@@ -121,6 +126,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	/**
 	 * @see LayerManager#getLayer(java.lang.Object)
 	 */
+	@Override
 	public IFigure getLayer(Object key) {
 		if (innerLayers == null)
 			return null;
@@ -136,6 +142,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * 
 	 * @see org.eclipse.gef.GraphicalEditPart#getContentPane()
 	 */
+	@Override
 	public IFigure getContentPane() {
 		return getLayer(PRIMARY_LAYER);
 	}
@@ -143,6 +150,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	/**
 	 * @see org.eclipse.gef.EditPart#getModel()
 	 */
+	@Override
 	public Object getModel() {
 		return LayerManager.ID;
 	}
@@ -152,6 +160,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * 
 	 * @see org.eclipse.gef.EditPart#getRoot()
 	 */
+	@Override
 	public RootEditPart getRoot() {
 		return this;
 	}
@@ -159,6 +168,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	/**
 	 * @see org.eclipse.gef.EditPart#getViewer()
 	 */
+	@Override
 	public EditPartViewer getViewer() {
 		return viewer;
 	}
@@ -168,12 +178,14 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * 
 	 * @see AbstractEditPart#refreshChildren()
 	 */
+	@Override
 	protected void refreshChildren() {
 	}
 
 	/**
 	 * @see org.eclipse.gef.RootEditPart#setContents(org.eclipse.gef.EditPart)
 	 */
+	@Override
 	public void setContents(EditPart editpart) {
 		if (contents != null)
 			removeChild(contents);
@@ -185,6 +197,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	/**
 	 * @see org.eclipse.gef.RootEditPart#setViewer(org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void setViewer(EditPartViewer newViewer) {
 		if (viewer == newViewer)
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/GridLayer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/GridLayer.java
@@ -54,6 +54,7 @@ public class GridLayer extends FreeformLayer {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#getPreferredSize(int, int)
 	 */
+	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
 		return new Dimension();
 	}
@@ -61,6 +62,7 @@ public class GridLayer extends FreeformLayer {
 	/**
 	 * @see org.eclipse.draw2d.Figure#paintFigure(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		super.paintFigure(graphics);
 		paintGrid(graphics);

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/RootTreeEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/RootTreeEditPart.java
@@ -43,6 +43,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	 * @param childEditPart EditPart of child to be added.
 	 * @param index         Position where it is to be added.
 	 */
+	@Override
 	protected void addChildVisual(EditPart childEditPart, int index) {
 		((TreeEditPart) childEditPart).setWidget(widget);
 	}
@@ -50,12 +51,14 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
 	 */
+	@Override
 	protected void createEditPolicies() {
 	}
 
 	/**
 	 * @see org.eclipse.gef.EditPart#getCommand(org.eclipse.gef.Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		return UnexecutableCommand.INSTANCE;
 	}
@@ -63,6 +66,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	/**
 	 * @see org.eclipse.gef.RootEditPart#getContents()
 	 */
+	@Override
 	public EditPart getContents() {
 		return contents;
 	}
@@ -72,6 +76,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	 * 
 	 * @see org.eclipse.gef.EditPart#getDragTracker(org.eclipse.gef.Request)
 	 */
+	@Override
 	public DragTracker getDragTracker(Request request) {
 		return null;
 	}
@@ -81,6 +86,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	 * 
 	 * @see org.eclipse.gef.EditPart#getRoot()
 	 */
+	@Override
 	public RootEditPart getRoot() {
 		return this;
 	}
@@ -88,6 +94,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	/**
 	 * @see org.eclipse.gef.RootEditPart#getViewer()
 	 */
+	@Override
 	public EditPartViewer getViewer() {
 		return viewer;
 	}
@@ -97,6 +104,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	 * 
 	 * @see org.eclipse.gef.TreeEditPart#getWidget()
 	 */
+	@Override
 	public Widget getWidget() {
 		return widget;
 	}
@@ -106,6 +114,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	 * 
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#refreshChildren()
 	 */
+	@Override
 	protected void refreshChildren() {
 	}
 
@@ -116,6 +125,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	 * 
 	 * @param childEditPart EditPart of child to be removed.
 	 */
+	@Override
 	protected void removeChildVisual(EditPart childEditPart) {
 		((TreeEditPart) childEditPart).setWidget(null);
 	}
@@ -123,6 +133,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	/**
 	 * @see org.eclipse.gef.RootEditPart#setContents(org.eclipse.gef.EditPart)
 	 */
+	@Override
 	public void setContents(EditPart editpart) {
 		if (contents != null) {
 			if (getWidget() != null)
@@ -138,6 +149,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	/**
 	 * @see org.eclipse.gef.RootEditPart#setViewer(org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void setViewer(EditPartViewer epviewer) {
 		viewer = epviewer;
 	}
@@ -149,6 +161,7 @@ public class RootTreeEditPart extends org.eclipse.gef.editparts.AbstractEditPart
 	 * 
 	 * @see org.eclipse.gef.TreeEditPart#setWidget(org.eclipse.swt.widgets.Widget)
 	 */
+	@Override
 	public void setWidget(Widget w) {
 		widget = w;
 		if (contents != null)

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/SimpleRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/SimpleRootEditPart.java
@@ -38,6 +38,7 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	 * 
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
 	 */
+	@Override
 	protected void createEditPolicies() {
 	}
 
@@ -46,6 +47,7 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	 * 
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
+	@Override
 	protected IFigure createFigure() {
 		Figure figure = new Figure();
 		figure.setLayoutManager(new StackLayout());
@@ -58,6 +60,7 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	 * 
 	 * @see EditPart#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request req) {
 		return UnexecutableCommand.INSTANCE;
 	}
@@ -65,6 +68,7 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	/**
 	 * @see RootEditPart#getContents()
 	 */
+	@Override
 	public EditPart getContents() {
 		return contents;
 	}
@@ -72,6 +76,7 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	/**
 	 * @see EditPart#getRoot()
 	 */
+	@Override
 	public RootEditPart getRoot() {
 		return this;
 	}
@@ -79,6 +84,7 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	/**
 	 * @see EditPart#getViewer()
 	 */
+	@Override
 	public EditPartViewer getViewer() {
 		return viewer;
 	}
@@ -88,12 +94,14 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	 * 
 	 * @see AbstractEditPart#refreshChildren()
 	 */
+	@Override
 	protected void refreshChildren() {
 	}
 
 	/**
 	 * @see RootEditPart#setContents(EditPart)
 	 */
+	@Override
 	public void setContents(EditPart editpart) {
 		if (contents == editpart)
 			return;
@@ -107,6 +115,7 @@ public class SimpleRootEditPart extends AbstractGraphicalEditPart implements Roo
 	/**
 	 * @see RootEditPart#setViewer(EditPartViewer)
 	 */
+	@Override
 	public void setViewer(EditPartViewer newViewer) {
 		if (viewer == newViewer)
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportAutoexposeHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportAutoexposeHelper.java
@@ -75,6 +75,7 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 	 * 
 	 * @see org.eclipse.gef.AutoexposeHelper#detect(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public boolean detect(Point where) {
 		lastStepTime = 0;
 		Viewport port = findViewport(owner);
@@ -95,6 +96,7 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 	 * 
 	 * @see org.eclipse.gef.AutoexposeHelper#step(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public boolean step(Point where) {
 		Viewport port = findViewport(owner);
 
@@ -144,6 +146,7 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "ViewportAutoexposeHelper for: " + owner; //$NON-NLS-1$
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportExposeHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportExposeHelper.java
@@ -52,6 +52,7 @@ public class ViewportExposeHelper extends ViewportHelper implements ExposeHelper
 	 * 
 	 * @see org.eclipse.gef.ExposeHelper#exposeDescendant(EditPart)
 	 */
+	@Override
 	public void exposeDescendant(EditPart part) {
 		Viewport port = findViewport(owner);
 		if (port == null)

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportMouseWheelHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportMouseWheelHelper.java
@@ -65,6 +65,7 @@ public class ViewportMouseWheelHelper extends ViewportHelper implements MouseWhe
 	 * 
 	 * @see org.eclipse.gef.MouseWheelHelper#handleMouseWheelScrolled(org.eclipse.swt.widgets.Event)
 	 */
+	@Override
 	public void handleMouseWheelScrolled(Event event) {
 		Viewport viewport = findViewport(owner);
 		if (viewport == null || !viewport.isShowing())

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/AbstractEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/AbstractEditPolicy.java
@@ -33,6 +33,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#activate()
 	 */
+	@Override
 	public void activate() {
 	}
 
@@ -41,6 +42,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 	}
 
@@ -59,6 +61,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#eraseSourceFeedback(Request)
 	 */
+	@Override
 	public void eraseSourceFeedback(Request request) {
 	}
 
@@ -67,6 +70,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#eraseTargetFeedback(Request)
 	 */
+	@Override
 	public void eraseTargetFeedback(Request request) {
 	}
 
@@ -77,6 +81,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		return null;
 	}
@@ -84,6 +89,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getHost()
 	 */
+	@Override
 	public EditPart getHost() {
 		return host;
 	}
@@ -95,6 +101,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getTargetEditPart(Request)
 	 */
+	@Override
 	public EditPart getTargetEditPart(Request request) {
 		return null;
 	}
@@ -102,6 +109,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	/**
 	 * @see org.eclipse.gef.EditPolicy#setHost(EditPart)
 	 */
+	@Override
 	public void setHost(EditPart host) {
 		this.host = host;
 	}
@@ -111,6 +119,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#showSourceFeedback(Request)
 	 */
+	@Override
 	public void showSourceFeedback(Request request) {
 	}
 
@@ -119,12 +128,14 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#showTargetFeedback(Request)
 	 */
+	@Override
 	public void showTargetFeedback(Request request) {
 	}
 
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		String c = getClass().getName();
 		c = c.substring(c.lastIndexOf('.') + 1);
@@ -140,6 +151,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#understandsRequest(Request)
 	 */
+	@Override
 	public boolean understandsRequest(Request req) {
 		return false;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/BendpointEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/BendpointEditPolicy.java
@@ -54,6 +54,7 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#activate()
 	 */
+	@Override
 	public void activate() {
 		super.activate();
 		getConnection().addPropertyChangeListener(Connection.PROPERTY_POINTS, this);
@@ -112,6 +113,7 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 * 
 	 * @see SelectionHandlesEditPolicy#createSelectionHandles()
 	 */
+	@Override
 	protected List createSelectionHandles() {
 		List list = new ArrayList();
 		if (isAutomaticallyBending())
@@ -127,6 +129,7 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		getConnection().removePropertyChangeListener(Connection.PROPERTY_POINTS, this);
 		super.deactivate();
@@ -147,6 +150,7 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseSourceFeedback(Request)
 	 */
+	@Override
 	public void eraseSourceFeedback(Request request) {
 		if (REQ_MOVE_BENDPOINT.equals(request.getType()) || REQ_CREATE_BENDPOINT.equals(request.getType()))
 			eraseConnectionFeedback((BendpointRequest) request);
@@ -157,6 +161,7 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (REQ_MOVE_BENDPOINT.equals(request.getType())) {
 			if (isDeleting)
@@ -244,6 +249,7 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 * 
 	 * @see java.beans.PropertyChangeListener#propertyChange(PropertyChangeEvent)
 	 */
+	@Override
 	public void propertyChange(PropertyChangeEvent evt) {
 		// $TODO optimize so that handles aren't added constantly.
 		if (getHost().getSelected() != EditPart.SELECTED_NONE)
@@ -382,6 +388,7 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 * @see #showMoveBendpointFeedback(BendpointRequest)
 	 * @param request the Request
 	 */
+	@Override
 	public void showSourceFeedback(Request request) {
 		if (REQ_MOVE_BENDPOINT.equals(request.getType()))
 			showMoveBendpointFeedback((BendpointRequest) request);

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ComponentEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ComponentEditPolicy.java
@@ -55,6 +55,7 @@ public abstract class ComponentEditPolicy extends AbstractEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (REQ_ORPHAN.equals(request.getType()))
 			return getOrphanCommand();

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConnectionEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConnectionEditPolicy.java
@@ -31,6 +31,7 @@ public abstract class ConnectionEditPolicy extends AbstractEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (REQ_DELETE.equals(request.getType()))
 			return getDeleteCommand((GroupRequest) request);

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConnectionEndpointEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConnectionEndpointEditPolicy.java
@@ -52,6 +52,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 
 	class ConnectionFocus extends Polygon implements PropertyChangeListener {
 		AncestorListener ancestorListener = new AncestorListener.Stub() {
+			@Override
 			public void ancestorMoved(IFigure ancestor) {
 				revalidate();
 			}
@@ -64,27 +65,32 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 			setOutline(true);
 		}
 
+		@Override
 		public void addNotify() {
 			super.addNotify();
 			getConnection().addPropertyChangeListener(Connection.PROPERTY_POINTS, this);
 			getConnection().addAncestorListener(ancestorListener);
 		}
 
+		@Override
 		protected void outlineShape(Graphics g) {
 			g.setLineDash(new int[] { 1, 1 });
 			super.outlineShape(g);
 		}
 
+		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			revalidate();
 		}
 
+		@Override
 		public void removeNotify() {
 			getConnection().removePropertyChangeListener(Connection.PROPERTY_POINTS, this);
 			getConnection().removeAncestorListener(ancestorListener);
 			super.removeNotify();
 		}
 
+		@Override
 		public void validate() {
 			if (isValid())
 				return;
@@ -99,6 +105,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.editpolicies.SelectionHandlesEditPolicy#createSelectionHandles()
 	 */
+	@Override
 	protected List createSelectionHandles() {
 		List list = new ArrayList();
 		list.add(new ConnectionEndpointHandle((ConnectionEditPart) getHost(), ConnectionLocator.SOURCE));
@@ -126,6 +133,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseSourceFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void eraseSourceFeedback(Request request) {
 		if (REQ_RECONNECT_TARGET.equals(request.getType()) || REQ_RECONNECT_SOURCE.equals(request.getType()))
 			eraseConnectionMoveFeedback((ReconnectRequest) request);
@@ -134,6 +142,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getCommand(org.eclipse.gef.Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		return null;
 	}
@@ -171,6 +180,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 * @see #showFocus()
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#hideFocus()
 	 */
+	@Override
 	protected void hideFocus() {
 		if (focus != null) {
 			removeFeedback(focus);
@@ -210,6 +220,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#showFocus()
 	 */
+	@Override
 	protected void showFocus() {
 		if (focus == null) {
 			focus = new ConnectionFocus();
@@ -220,6 +231,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#showSourceFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void showSourceFeedback(Request request) {
 		if (REQ_RECONNECT_SOURCE.equals(request.getType()) || REQ_RECONNECT_TARGET.equals(request.getType()))
 			showConnectionMoveFeedback((ReconnectRequest) request);

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConstrainedLayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConstrainedLayoutEditPolicy.java
@@ -143,6 +143,7 @@ public abstract class ConstrainedLayoutEditPolicy extends LayoutEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.LayoutEditPolicy#createChildEditPolicy(EditPart)
 	 */
+	@Override
 	protected EditPolicy createChildEditPolicy(EditPart child) {
 		return new ResizableEditPolicy();
 	}
@@ -155,6 +156,7 @@ public abstract class ConstrainedLayoutEditPolicy extends LayoutEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.LayoutEditPolicy#getAddCommand(Request)
 	 */
+	@Override
 	protected Command getAddCommand(Request generic) {
 		ChangeBoundsRequest request = (ChangeBoundsRequest) generic;
 		List editParts = request.getEditParts();
@@ -186,6 +188,7 @@ public abstract class ConstrainedLayoutEditPolicy extends LayoutEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (REQ_RESIZE_CHILDREN.equals(request.getType()))
 			return getResizeChildrenCommand((ChangeBoundsRequest) request);
@@ -369,6 +372,7 @@ public abstract class ConstrainedLayoutEditPolicy extends LayoutEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.LayoutEditPolicy#getMoveChildrenCommand(Request)
 	 */
+	@Override
 	protected Command getMoveChildrenCommand(Request request) {
 		// By default, move and resize are treated the same for constrained
 		// layouts.

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ContainerEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ContainerEditPolicy.java
@@ -49,6 +49,7 @@ public abstract class ContainerEditPolicy extends AbstractEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getCommand(org.eclipse.gef.Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (REQ_CREATE.equals(request.getType()))
 			return getCreateCommand((CreateRequest) request);

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/DirectEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/DirectEditPolicy.java
@@ -32,6 +32,7 @@ public abstract class DirectEditPolicy extends GraphicalEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseSourceFeedback(Request)
 	 */
+	@Override
 	public void eraseSourceFeedback(Request request) {
 		if (RequestConstants.REQ_DIRECT_EDIT == request.getType())
 			eraseDirectEditFeedback((DirectEditRequest) request);
@@ -53,6 +54,7 @@ public abstract class DirectEditPolicy extends GraphicalEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (RequestConstants.REQ_DIRECT_EDIT == request.getType())
 			return getDirectEditCommand((DirectEditRequest) request);
@@ -86,6 +88,7 @@ public abstract class DirectEditPolicy extends GraphicalEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#showSourceFeedback(Request)
 	 */
+	@Override
 	public void showSourceFeedback(Request request) {
 		if (RequestConstants.REQ_DIRECT_EDIT == request.getType())
 			showDirectEditFeedback((DirectEditRequest) request);
@@ -130,6 +133,7 @@ public abstract class DirectEditPolicy extends GraphicalEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#understandsRequest(Request)
 	 */
+	@Override
 	public boolean understandsRequest(Request request) {
 		if (RequestConstants.REQ_DIRECT_EDIT.equals(request.getType()))
 			return true;

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/FlowLayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/FlowLayoutEditPolicy.java
@@ -114,6 +114,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	/**
 	 * @see OrderedLayoutEditPolicy#getInsertionReference(Request)
 	 */
+	@Override
 	protected EditPart getInsertionReference(Request request) {
 		List<? extends EditPart> children = getHost().getChildren();
 
@@ -171,6 +172,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	 * 
 	 * @see LayoutEditPolicy#showLayoutTargetFeedback(Request)
 	 */
+	@Override
 	protected void showLayoutTargetFeedback(Request request) {
 		if (getHost().getChildren().isEmpty())
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/GraphicalNodeEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/GraphicalNodeEditPolicy.java
@@ -59,6 +59,7 @@ public abstract class GraphicalNodeEditPolicy extends GraphicalEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		if (connectionFeedback != null) {
 			removeFeedback(connectionFeedback);
@@ -87,6 +88,7 @@ public abstract class GraphicalNodeEditPolicy extends GraphicalEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#eraseSourceFeedback(Request)
 	 */
+	@Override
 	public void eraseSourceFeedback(Request request) {
 		if (REQ_CONNECTION_END.equals(request.getType()))
 			eraseCreationFeedback((CreateConnectionRequest) request);
@@ -105,6 +107,7 @@ public abstract class GraphicalNodeEditPolicy extends GraphicalEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#eraseTargetFeedback(Request)
 	 */
+	@Override
 	public void eraseTargetFeedback(Request request) {
 		if (REQ_CONNECTION_START.equals(request.getType()) || REQ_CONNECTION_END.equals(request.getType())
 				|| REQ_RECONNECT_SOURCE.equals(request.getType()) || REQ_RECONNECT_TARGET.equals(request.getType()))
@@ -117,6 +120,7 @@ public abstract class GraphicalNodeEditPolicy extends GraphicalEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (REQ_CONNECTION_START.equals(request.getType()))
 			return getConnectionCreateCommand((CreateConnectionRequest) request);
@@ -238,6 +242,7 @@ public abstract class GraphicalNodeEditPolicy extends GraphicalEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getTargetEditPart(Request)
 	 */
+	@Override
 	public EditPart getTargetEditPart(Request request) {
 		if (REQ_CONNECTION_START.equals(request.getType()) || REQ_CONNECTION_END.equals(request.getType())
 				|| REQ_RECONNECT_SOURCE.equals(request.getType()) || REQ_RECONNECT_TARGET.equals(request.getType()))
@@ -262,6 +267,7 @@ public abstract class GraphicalNodeEditPolicy extends GraphicalEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#showSourceFeedback(Request)
 	 */
+	@Override
 	public void showSourceFeedback(Request request) {
 		if (REQ_CONNECTION_END.equals(request.getType()))
 			showCreationFeedback((CreateConnectionRequest) request);
@@ -280,6 +286,7 @@ public abstract class GraphicalNodeEditPolicy extends GraphicalEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#showTargetFeedback(Request)
 	 */
+	@Override
 	public void showTargetFeedback(Request request) {
 		if (REQ_CONNECTION_START.equals(request.getType()) || REQ_CONNECTION_END.equals(request.getType())
 				|| REQ_RECONNECT_SOURCE.equals(request.getType()) || REQ_RECONNECT_TARGET.equals(request.getType()))

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
@@ -80,6 +80,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.editpolicies.SelectionHandlesEditPolicy#createSelectionHandles()
 	 */
+	@Override
 	protected List createSelectionHandles() {
 		List list = new ArrayList();
 		createMoveHandle(list);
@@ -155,6 +156,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		if (feedback != null) {
 			removeFeedback(feedback);
@@ -180,6 +182,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseSourceFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void eraseSourceFeedback(Request request) {
 		if ((REQ_MOVE.equals(request.getType()) && isDragAllowed()) || REQ_CLONE.equals(request.getType())
 				|| REQ_ADD.equals(request.getType()))
@@ -189,6 +192,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getCommand(org.eclipse.gef.Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		Object type = request.getType();
 
@@ -280,6 +284,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 * @see #showFocus()
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#hideFocus()
 	 */
+	@Override
 	protected void hideFocus() {
 		if (focusRect != null)
 			removeFeedback(focusRect);
@@ -331,8 +336,10 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#showFocus()
 	 */
+	@Override
 	protected void showFocus() {
 		focusRect = new AbstractHandle((GraphicalEditPart) getHost(), new Locator() {
+			@Override
 			public void relocate(IFigure target) {
 				IFigure figure = getHostFigure();
 				Rectangle r;
@@ -349,6 +356,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 				setBorder(new FocusBorder());
 			}
 
+			@Override
 			protected DragTracker createDragTracker() {
 				return null;
 			}
@@ -361,6 +369,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#showSourceFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void showSourceFeedback(Request request) {
 		if ((REQ_MOVE.equals(request.getType()) && isDragAllowed()) || REQ_ADD.equals(request.getType())
 				|| REQ_CLONE.equals(request.getType()))
@@ -374,6 +383,7 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#understandsRequest(org.eclipse.gef.Request)
 	 */
+	@Override
 	public boolean understandsRequest(Request request) {
 		if (REQ_MOVE.equals(request.getType()))
 			return isDragAllowed();

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/OrderedLayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/OrderedLayoutEditPolicy.java
@@ -54,6 +54,7 @@ public abstract class OrderedLayoutEditPolicy extends LayoutEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.LayoutEditPolicy#createChildEditPolicy(EditPart)
 	 */
+	@Override
 	protected EditPolicy createChildEditPolicy(EditPart child) {
 		return new NonResizableEditPolicy();
 	}
@@ -85,6 +86,7 @@ public abstract class OrderedLayoutEditPolicy extends LayoutEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.LayoutEditPolicy#getAddCommand(Request)
 	 */
+	@Override
 	protected Command getAddCommand(Request req) {
 		ChangeBoundsRequest request = (ChangeBoundsRequest) req;
 		List editParts = request.getEditParts();
@@ -116,6 +118,7 @@ public abstract class OrderedLayoutEditPolicy extends LayoutEditPolicy {
 	 * 
 	 * @see LayoutEditPolicy#getMoveChildrenCommand(Request)
 	 */
+	@Override
 	protected Command getMoveChildrenCommand(Request request) {
 		CompoundCommand command = new CompoundCommand();
 		List editParts = ((ChangeBoundsRequest) request).getEditParts();

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ResizableEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ResizableEditPolicy.java
@@ -53,6 +53,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	/**
 	 * @see org.eclipse.gef.editpolicies.SelectionHandlesEditPolicy#createSelectionHandles()
 	 */
+	@Override
 	protected List createSelectionHandles() {
 		if (resizeDirections == PositionConstants.NONE) {
 			// non resizable, so delegate to super implementation
@@ -112,6 +113,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#eraseSourceFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void eraseSourceFeedback(Request request) {
 		if (REQ_RESIZE.equals(request.getType()))
 			eraseChangeBoundsFeedback((ChangeBoundsRequest) request);
@@ -122,6 +124,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getCommand(org.eclipse.gef.Request)
 	 */
+	@Override
 	public Command getCommand(Request request) {
 		if (REQ_RESIZE.equals(request.getType())) {
 			return getResizeCommand((ChangeBoundsRequest) request);
@@ -173,6 +176,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#showSourceFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void showSourceFeedback(Request request) {
 		if (REQ_RESIZE.equals(request.getType())) {
 			showChangeBoundsFeedback((ChangeBoundsRequest) request);
@@ -184,6 +188,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#understandsRequest(org.eclipse.gef.Request)
 	 */
+	@Override
 	public boolean understandsRequest(Request request) {
 		if (REQ_RESIZE.equals(request.getType())) {
 			// check all resize directions of the request are supported

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/RootComponentEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/RootComponentEditPolicy.java
@@ -26,6 +26,7 @@ public class RootComponentEditPolicy extends ComponentEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.editpolicies.ComponentEditPolicy#createDeleteCommand(GroupRequest)
 	 */
+	@Override
 	protected Command createDeleteCommand(GroupRequest request) {
 		return UnexecutableCommand.INSTANCE;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ScrollableSelectionFeedbackEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ScrollableSelectionFeedbackEditPolicy.java
@@ -236,6 +236,7 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	/**
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#hideSelection()
 	 */
+	@Override
 	protected void hideSelection() {
 		// remove figure and layout listeners
 		getHostFigure().removeLayoutListener(layoutListener);
@@ -303,6 +304,7 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	/**
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#showSelection()
 	 */
+	@Override
 	protected void showSelection() {
 		// force ViewportExposeHelper to perform auto scrolling before
 		// showing the feedback.

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SelectionEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SelectionEditPolicy.java
@@ -40,6 +40,7 @@ public abstract class SelectionEditPolicy extends org.eclipse.gef.editpolicies.G
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#activate()
 	 */
+	@Override
 	public void activate() {
 		super.activate();
 		addSelectionListener();
@@ -52,6 +53,7 @@ public abstract class SelectionEditPolicy extends org.eclipse.gef.editpolicies.G
 	 */
 	protected void addSelectionListener() {
 		selectionListener = new EditPartListener.Stub() {
+			@Override
 			public void selectedStateChanged(EditPart part) {
 				setSelectedState(part.getSelected());
 				setFocus(part.hasFocus());
@@ -66,6 +68,7 @@ public abstract class SelectionEditPolicy extends org.eclipse.gef.editpolicies.G
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		removeSelectionListener();
 		setSelectedState(EditPart.SELECTED_NONE);
@@ -76,6 +79,7 @@ public abstract class SelectionEditPolicy extends org.eclipse.gef.editpolicies.G
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getTargetEditPart(Request)
 	 */
+	@Override
 	public EditPart getTargetEditPart(Request request) {
 		if (RequestConstants.REQ_SELECTION.equals(request.getType()))
 			return getHost();

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SelectionHandlesEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SelectionHandlesEditPolicy.java
@@ -67,6 +67,7 @@ public abstract class SelectionHandlesEditPolicy extends SelectionEditPolicy imp
 	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleHandleProvider.class)
 			return key.cast(new AccessibleHandleProvider() {
+				@Override
 				public List<Point> getAccessibleHandleLocations() {
 					List<Point> result = new ArrayList<>();
 					if (handles != null) {
@@ -87,6 +88,7 @@ public abstract class SelectionHandlesEditPolicy extends SelectionEditPolicy imp
 	 * 
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#hideSelection()
 	 */
+	@Override
 	protected void hideSelection() {
 		removeSelectionHandles();
 	}
@@ -108,6 +110,7 @@ public abstract class SelectionHandlesEditPolicy extends SelectionEditPolicy imp
 	 * 
 	 * @see org.eclipse.gef.editpolicies.SelectionEditPolicy#showSelection()
 	 */
+	@Override
 	protected void showSelection() {
 		addSelectionHandles();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SnapFeedbackPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SnapFeedbackPolicy.java
@@ -45,6 +45,7 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseTargetFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void eraseTargetFeedback(Request request) {
 		for (int i = 0; i < guide.length; i++) {
 			if (guide[i] != null)
@@ -73,6 +74,7 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 		/**
 		 * @see org.eclipse.draw2d.Figure#paintFigure(org.eclipse.draw2d.Graphics)
 		 */
+		@Override
 		protected void paintFigure(Graphics graphics) {
 			if (opacity != FRAMES) {
 				if (image != null) {
@@ -93,6 +95,7 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 					count++;
 				}
 				Display.getCurrent().timerExec(100, new Runnable() {
+					@Override
 					public void run() {
 						opacity = Math.min(FRAMES, opacity + 1);
 						repaint();
@@ -109,6 +112,7 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 		/**
 		 * @see org.eclipse.draw2d.Figure#removeNotify()
 		 */
+		@Override
 		public void removeNotify() {
 			if (image != null) {
 				image.dispose();
@@ -179,6 +183,7 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#showTargetFeedback(org.eclipse.gef.Request)
 	 */
+	@Override
 	public void showTargetFeedback(Request req) {
 		if (req.getType().equals(REQ_MOVE) || req.getType().equals(REQ_RESIZE) || req.getType().equals(REQ_CLONE)
 				|| req.getType().equals(REQ_ADD) || req.getType().equals(REQ_CREATE)) {

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/TreeContainerEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/TreeContainerEditPolicy.java
@@ -69,6 +69,7 @@ public abstract class TreeContainerEditPolicy extends AbstractEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseTargetFeedback(Request)
 	 */
+	@Override
 	public void eraseTargetFeedback(Request req) {
 		if (req.getType().equals(REQ_MOVE) || req.getType().equals(REQ_ADD) || req.getType().equals(REQ_CREATE))
 			eraseDropFeedback(req);
@@ -105,6 +106,7 @@ public abstract class TreeContainerEditPolicy extends AbstractEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#getCommand(Request)
 	 */
+	@Override
 	public Command getCommand(Request req) {
 		if (req.getType().equals(REQ_MOVE_CHILDREN))
 			return getMoveChildrenCommand((ChangeBoundsRequest) req);
@@ -122,6 +124,7 @@ public abstract class TreeContainerEditPolicy extends AbstractEditPolicy {
 	 * 
 	 * @see org.eclipse.gef.EditPolicy#getTargetEditPart(Request)
 	 */
+	@Override
 	public EditPart getTargetEditPart(Request req) {
 		if (req.getType().equals(REQ_ADD) || req.getType().equals(REQ_MOVE) || req.getType().equals(REQ_CREATE)) {
 			DropRequest drop = (DropRequest) req;
@@ -182,6 +185,7 @@ public abstract class TreeContainerEditPolicy extends AbstractEditPolicy {
 	/**
 	 * @see org.eclipse.gef.EditPolicy#showTargetFeedback(Request)
 	 */
+	@Override
 	public void showTargetFeedback(Request req) {
 		if (req.getType().equals(REQ_MOVE) || req.getType().equals(REQ_ADD) || req.getType().equals(REQ_CREATE))
 			showDropFeedback((DropRequest) req);

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/XYLayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/XYLayoutEditPolicy.java
@@ -47,6 +47,7 @@ public abstract class XYLayoutEditPolicy extends ConstrainedLayoutEditPolicy {
 	 *      org.eclipse.gef.GraphicalEditPart,
 	 *      org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	protected Object getConstraintFor(Request request, GraphicalEditPart child, Rectangle rect) {
 		if (request instanceof ChangeBoundsRequest) {
 			if (((ChangeBoundsRequest) request).getSizeDelta().width == 0
@@ -71,6 +72,7 @@ public abstract class XYLayoutEditPolicy extends ConstrainedLayoutEditPolicy {
 	 * @param p the input Point
 	 * @return a Rectangle
 	 */
+	@Override
 	public Object getConstraintFor(Point p) {
 		return new Rectangle(p, PREFERRED_SIZE);
 	}
@@ -81,6 +83,7 @@ public abstract class XYLayoutEditPolicy extends ConstrainedLayoutEditPolicy {
 	 * @param r the input Rectangle
 	 * @return a copy of the input Rectangle
 	 */
+	@Override
 	public Object getConstraintFor(Rectangle r) {
 		return new Rectangle(r);
 	}
@@ -101,6 +104,7 @@ public abstract class XYLayoutEditPolicy extends ConstrainedLayoutEditPolicy {
 	 * 
 	 * @see ConstrainedLayoutEditPolicy#getLayoutOrigin()
 	 */
+	@Override
 	protected Point getLayoutOrigin() {
 		return getXYLayout().getOrigin(getLayoutContainer());
 	}
@@ -127,6 +131,7 @@ public abstract class XYLayoutEditPolicy extends ConstrainedLayoutEditPolicy {
 	/**
 	 * @see org.eclipse.gef.editpolicies.LayoutEditPolicy#showSizeOnDropFeedback(org.eclipse.gef.requests.CreateRequest)
 	 */
+	@Override
 	protected void showSizeOnDropFeedback(CreateRequest request) {
 		Point p = new Point(request.getLocation().getCopy());
 		Dimension size = request.getSize().getCopy();

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/AbstractHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/AbstractHandle.java
@@ -69,6 +69,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	/**
 	 * Adds this as an {@link AncestorListener} to the owner's {@link Figure}.
 	 */
+	@Override
 	public void addNotify() {
 		super.addNotify();
 		// Listen to the owner figure so the handle moves when the
@@ -79,6 +80,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	/**
 	 * @see org.eclipse.draw2d.AncestorListener#ancestorMoved(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void ancestorMoved(IFigure ancestor) {
 		revalidate();
 	}
@@ -86,12 +88,14 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	/**
 	 * @see org.eclipse.draw2d.AncestorListener#ancestorAdded(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void ancestorAdded(IFigure ancestor) {
 	}
 
 	/**
 	 * @see org.eclipse.draw2d.AncestorListener#ancestorRemoved(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void ancestorRemoved(IFigure ancestor) {
 	}
 
@@ -107,6 +111,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	 * 
 	 * @see org.eclipse.gef.Handle#getAccessibleLocation()
 	 */
+	@Override
 	public Point getAccessibleLocation() {
 		Point p = getBounds().getCenter();
 		translateToAbsolute(p);
@@ -131,6 +136,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	 * 
 	 * @return the drag tracker
 	 */
+	@Override
 	public DragTracker getDragTracker() {
 		if (dragTracker == null)
 			dragTracker = createDragTracker();
@@ -167,6 +173,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	/**
 	 * @see org.eclipse.draw2d.IFigure#removeNotify()
 	 */
+	@Override
 	public void removeNotify() {
 		getOwnerFigure().removeAncestorListener(this);
 		super.removeNotify();
@@ -215,6 +222,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	 * 
 	 * @see org.eclipse.draw2d.IFigure#validate()
 	 */
+	@Override
 	public void validate() {
 		if (isValid())
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointCreationHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointCreationHandle.java
@@ -85,6 +85,7 @@ public class BendpointCreationHandle extends BendpointHandle {
 	 * 
 	 * @return the new ConnectionBendpointTracker
 	 */
+	@Override
 	protected DragTracker createDragTracker() {
 		ConnectionBendpointTracker tracker;
 		tracker = new ConnectionBendpointTracker((ConnectionEditPart) getOwner(), getIndex());

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointHandle.java
@@ -32,6 +32,7 @@ public class BendpointHandle extends ConnectionHandle implements PropertyChangeL
 	 * 
 	 * @return returns null by default
 	 */
+	@Override
 	protected DragTracker createDragTracker() {
 		return null;
 	}
@@ -56,6 +57,7 @@ public class BendpointHandle extends ConnectionHandle implements PropertyChangeL
 	 * 
 	 * @param event the event that caused the points change
 	 */
+	@Override
 	public void propertyChange(PropertyChangeEvent event) {
 		revalidate();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointMoveHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointMoveHandle.java
@@ -83,6 +83,7 @@ public class BendpointMoveHandle extends BendpointHandle {
 	 * 
 	 * @return the new ConnectionBendpointTracker
 	 */
+	@Override
 	protected DragTracker createDragTracker() {
 		ConnectionBendpointTracker tracker;
 		tracker = new ConnectionBendpointTracker((ConnectionEditPart) getOwner(), getIndex());

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionEndpointHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionEndpointHandle.java
@@ -84,6 +84,7 @@ public class ConnectionEndpointHandle extends ConnectionHandle {
 	 * 
 	 * @return the new ConnectionEndpointTracker
 	 */
+	@Override
 	protected DragTracker createDragTracker() {
 		if (isFixed())
 			return null;

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionHandle.java
@@ -52,6 +52,7 @@ public abstract class ConnectionHandle extends SquareHandle implements PropertyC
 	 * Adds this as a {@link org.eclipse.draw2d.FigureListener} to the owner's
 	 * {@link org.eclipse.draw2d.Figure}.
 	 */
+	@Override
 	public void addNotify() {
 		super.addNotify();
 		getConnection().addPropertyChangeListener(Connection.PROPERTY_POINTS, this);
@@ -79,6 +80,7 @@ public abstract class ConnectionHandle extends SquareHandle implements PropertyC
 	/**
 	 * @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent)
 	 */
+	@Override
 	public void propertyChange(PropertyChangeEvent evt) {
 		if (evt.getPropertyName().equals(Connection.PROPERTY_POINTS))
 			revalidate();
@@ -89,6 +91,7 @@ public abstract class ConnectionHandle extends SquareHandle implements PropertyC
 	 * 
 	 * @see org.eclipse.draw2d.IFigure#removeNotify()
 	 */
+	@Override
 	public void removeNotify() {
 		getConnection().removePropertyChangeListener(Connection.PROPERTY_POINTS, this);
 		super.removeNotify();

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/CornerTriangleBorder.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/CornerTriangleBorder.java
@@ -46,6 +46,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 * 
 	 * @see org.eclipse.draw2d.Border#isOpaque()
 	 */
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -53,6 +54,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#getInsets(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return new Insets(1);
 	}
@@ -65,6 +67,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 * @param graphics The <code>Graphics</code>.
 	 * @param insets   The <code>Insets</code>.
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 		// Don't paint the center of the figure.
 		int width = 1, edgeSize;

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandle.java
@@ -59,6 +59,7 @@ public class MoveHandle extends AbstractHandle {
 	 * 
 	 * @see org.eclipse.gef.handles.AbstractHandle#createDragTracker()
 	 */
+	@Override
 	protected DragTracker createDragTracker() {
 		DragEditPartsTracker tracker = new DragEditPartsTracker(getOwner());
 		tracker.setDefaultCursor(getCursor());
@@ -72,6 +73,7 @@ public class MoveHandle extends AbstractHandle {
 	 * @param y The y coordinate.
 	 * @return <code>true</code> if the point (x,y) is contained within this handle.
 	 */
+	@Override
 	public boolean containsPoint(int x, int y) {
 		if (!super.containsPoint(x, y))
 			return false;
@@ -83,6 +85,7 @@ public class MoveHandle extends AbstractHandle {
 	 * 
 	 * @see org.eclipse.gef.Handle#getAccessibleLocation()
 	 */
+	@Override
 	public Point getAccessibleLocation() {
 		Point p = getBounds().getTopRight().translate(-1, getBounds().height / 4);
 		translateToAbsolute(p);

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandleLocator.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandleLocator.java
@@ -50,6 +50,7 @@ public class MoveHandleLocator implements Locator {
 	 * 
 	 * @param target The IFigure to relocate
 	 */
+	@Override
 	public void relocate(IFigure target) {
 		Insets insets = target.getInsets();
 		Rectangle bounds;

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
@@ -54,6 +54,7 @@ public class NonResizableHandle extends MoveHandle {
 	 * Initializes the handle. Sets the {@link org.eclipse.gef.DragTracker} and
 	 * DragCursor.
 	 */
+	@Override
 	protected void initialize() {
 		setOpaque(false);
 		border = new CornerTriangleBorder(false);
@@ -65,6 +66,7 @@ public class NonResizableHandle extends MoveHandle {
 	/**
 	 * Updates the handle's color by setting the border's primary attribute.
 	 */
+	@Override
 	public void validate() {
 		border.setPrimary(getOwner().getSelected() == EditPart.SELECTED_PRIMARY);
 		super.validate();

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/RelativeHandleLocator.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/RelativeHandleLocator.java
@@ -40,6 +40,7 @@ public class RelativeHandleLocator extends org.eclipse.draw2d.RelativeLocator {
 	 * 
 	 * @see org.eclipse.draw2d.RelativeLocator#getReferenceBox()
 	 */
+	@Override
 	protected Rectangle getReferenceBox() {
 		IFigure f = getReferenceFigure();
 		if (f instanceof HandleBounds)

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ResizeHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ResizeHandle.java
@@ -57,6 +57,7 @@ public class ResizeHandle extends SquareHandle {
 	 * 
 	 * @return returns <code>null</code>
 	 */
+	@Override
 	protected DragTracker createDragTracker() {
 		return new ResizeTracker(getOwner(), cursorDirection);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/SquareHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/SquareHandle.java
@@ -106,6 +106,7 @@ public abstract class SquareHandle extends AbstractHandle {
 	 * 
 	 * @param g The graphics used to paint the figure.
 	 */
+	@Override
 	public void paintFigure(Graphics g) {
 		Rectangle r = getBounds();
 		r.shrink(1, 1);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
@@ -32,6 +32,7 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 		singleton = this;
 	}
 
+	@Override
 	public void start(BundleContext bc) throws Exception {
 		super.start(bc);
 		context = bc;
@@ -58,6 +59,7 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 	/**
 	 * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
 	 */
+	@Override
 	public void stop(BundleContext context) throws Exception {
 		savePluginPreferences();
 		super.stop(context);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/PropertySourceAdapterFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/PropertySourceAdapterFactory.java
@@ -45,6 +45,7 @@ public class PropertySourceAdapterFactory implements IAdapterFactory {
 		return Platform.getAdapterManager().getAdapter(model, adapterType);
 	}
 
+	@Override
 	public Class<?>[] getAdapterList() {
 		return new Class[] { IPropertySource.class };
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/PaletteSelectionTool.java
@@ -32,6 +32,7 @@ public class PaletteSelectionTool extends SelectionTool {
 		return false;
 	}
 
+	@Override
 	protected boolean handleKeyDown(KeyEvent e) {
 		if (handleAbort(e)) {
 			loadDefaultTool();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/ToolbarDropdownContributionItem.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/ToolbarDropdownContributionItem.java
@@ -65,10 +65,12 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * polluting ToolbarDropdownContributionItem with public listener methods.
 	 */
 	private class ActionListener implements Listener, IPropertyChangeListener {
+		@Override
 		public void handleEvent(Event event) {
 			ToolbarDropdownContributionItem.this.handleWidgetEvent(event);
 		}
 
+		@Override
 		public void propertyChange(PropertyChangeEvent event) {
 			ToolbarDropdownContributionItem.this.actionPropertyChange(event);
 		}
@@ -170,6 +172,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 				update(e.getProperty());
 			} else {
 				display.asyncExec(new Runnable() {
+					@Override
 					public void run() {
 						update(e.getProperty());
 					}
@@ -196,6 +199,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * Compares this action contribution item with another object. Two action
 	 * contribution items are equal if they refer to the identical Action.
 	 */
+	@Override
 	public boolean equals(Object o) {
 		if (!(o instanceof ToolbarDropdownContributionItem)) {
 			return false;
@@ -209,6 +213,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * the action's checked property has been set, a toggle button is created and
 	 * primed to the value of the checked property.
 	 */
+	@Override
 	public void fill(Composite parent) {
 		if (widget == null && parent != null) {
 			int flags = SWT.PUSH;
@@ -240,6 +245,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * primed to the value of the checked property. If the action's menu creator
 	 * property has been set, a cascading submenu is created.
 	 */
+	@Override
 	public void fill(Menu parent, int index) {
 		if (widget == null && parent != null) {
 			int flags = SWT.PUSH;
@@ -286,6 +292,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * primed to the value of the checked property. If the action's menu creator
 	 * property has been set, a drop-down tool item is created.
 	 */
+	@Override
 	public void fill(ToolBar parent, int index) {
 		if (widget == null && parent != null) {
 			int flags = SWT.PUSH;
@@ -338,6 +345,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 			Display display = Display.getDefault();
 			if (display != null) {
 				display.disposeExec(new Runnable() {
+					@Override
 					public void run() {
 						if (globalImageCache != null) {
 							globalImageCache.dispose();
@@ -448,6 +456,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	/*
 	 * (non-Javadoc) Method declared on Object.
 	 */
+	@Override
 	public int hashCode() {
 		return action.hashCode();
 	}
@@ -455,6 +464,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	/*
 	 * (non-Javadoc) Method declared on IContributionItem.
 	 */
+	@Override
 	public boolean isEnabled() {
 		return action != null && action.isEnabled();
 	}
@@ -464,6 +474,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * returns <code>true</code> for menu items and <code>false</code> for
 	 * everything else.
 	 */
+	@Override
 	public boolean isDynamic() {
 		if (widget instanceof MenuItem) {
 			// Optimization. Only recreate the item is the check style has
@@ -493,6 +504,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * The action item implementation of this <code>IContributionItem</code> method
 	 * calls <code>update(null)</code>.
 	 */
+	@Override
 	public final void update() {
 		update(null);
 	}
@@ -503,6 +515,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 	 * @param propertyName the name of the property, or <code>null</code> meaning
 	 *                     all applicable properties
 	 */
+	@Override
 	public void update(String propertyName) {
 		if (widget != null) {
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ColumnsLayout.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ColumnsLayout.java
@@ -37,6 +37,7 @@ public class ColumnsLayout extends PaletteContainerFlowLayout {
 	/**
 	 * @see org.eclipse.draw2d.FlowLayout#getChildSize(IFigure, int, int)
 	 */
+	@Override
 	protected Dimension getChildSize(IFigure child, int wHint, int hHint) {
 		if (!(child instanceof SeparatorEditPart.SeparatorFigure)) {
 			Dimension hints = getMinimumHints(child, wHint, hHint);
@@ -77,6 +78,7 @@ public class ColumnsLayout extends PaletteContainerFlowLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractHintLayout#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		super.invalidate();
 		cachedConstraint = null;

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DetailedLabelFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DetailedLabelFigure.java
@@ -83,6 +83,7 @@ public class DetailedLabelFigure extends Figure {
 	/**
 	 * @see org.eclipse.draw2d.Figure#addNotify()
 	 */
+	@Override
 	public void addNotify() {
 		super.addNotify();
 		updateFont(layoutMode);
@@ -105,6 +106,7 @@ public class DetailedLabelFigure extends Figure {
 	/**
 	 * @see org.eclipse.draw2d.IFigure#handleFocusGained(FocusEvent)
 	 */
+	@Override
 	public void handleFocusGained(FocusEvent event) {
 		super.handleFocusGained(event);
 		updateImage();
@@ -113,6 +115,7 @@ public class DetailedLabelFigure extends Figure {
 	/**
 	 * @see org.eclipse.draw2d.Figure#handleFocusLost(FocusEvent)
 	 */
+	@Override
 	public void handleFocusLost(FocusEvent event) {
 		super.handleFocusLost(event);
 		updateImage();
@@ -267,12 +270,14 @@ public class DetailedLabelFigure extends Figure {
 			}
 		}
 
+		@Override
 		public Image getImage() {
 			if (shadedImage != null)
 				return shadedImage;
 			return super.getImage();
 		}
 
+		@Override
 		public void setImage(Image image) {
 			if (image == super.getImage())
 				return;

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
@@ -61,6 +61,7 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
+	@Override
 	public IFigure createFigure() {
 		DrawerFigure fig = new DrawerFigure(getViewer().getControl()) {
 			@Override
@@ -72,6 +73,7 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 		fig.setPinned(getModel().isInitiallyPinned());
 
 		fig.getCollapseToggle().addFocusListener(new FocusListener.Stub() {
+			@Override
 			public void focusGained(FocusEvent fe) {
 				getViewer().select(DrawerEditPart.this);
 			}
@@ -124,10 +126,12 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 		return getDrawerFigure().getContentPane();
 	}
 
+	@Override
 	public boolean isExpanded() {
 		return getDrawerFigure().isExpanded();
 	}
 
+	@Override
 	public boolean isPinnedOpen() {
 		return getDrawerFigure().isPinnedOpen();
 	}
@@ -145,6 +149,7 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 	 *         only true when the drawer is expanded and the auto-collapse strategy
 	 *         is <code>PaletteViewerPreferences.COLLAPSE_AS_NEEDED</code>.
 	 */
+	@Override
 	public boolean canBePinned() {
 		return getDrawerFigure().isPinShowing();
 	}
@@ -260,6 +265,7 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 		getDrawerFigure().setTitleIcon(image);
 	}
 
+	@Override
 	public void setPinnedOpen(boolean pinned) {
 		getDrawerFigure().setPinned(pinned);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
@@ -90,6 +90,7 @@ public class DrawerFigure extends Figure {
 			setRequestFocusEnabled(true);
 			addChangeListener(new ChangeListener() {
 
+				@Override
 				public void handleStateChanged(ChangeEvent e) {
 					if (e.getPropertyName().equals(ButtonModel.SELECTED_PROPERTY)) {
 						Animation.markBegin();
@@ -102,10 +103,12 @@ public class DrawerFigure extends Figure {
 			});
 		}
 
+		@Override
 		public IFigure getToolTip() {
 			return buildTooltip();
 		}
 
+		@Override
 		protected void paintFigure(Graphics g) {
 			super.paintFigure(g);
 			Rectangle r = Rectangle.SINGLETON;
@@ -150,6 +153,7 @@ public class DrawerFigure extends Figure {
 		 * selection and appearance (background color).
 		 */
 		setLayoutManager(new PaletteToolbarLayout() {
+			@Override
 			protected boolean isChildGrowing(IFigure child) {
 				int wHint = child.getBounds().width;
 				return child.getPreferredSize(wHint, -1).height != child.getMinimumSize(wHint, -1).height;
@@ -244,10 +248,12 @@ public class DrawerFigure extends Figure {
 			/**
 			 * @see org.eclipse.draw2d.Figure#getToolTip()
 			 */
+			@Override
 			public IFigure getToolTip() {
 				return buildTooltip();
 			}
 
+			@Override
 			protected void paintFigure(Graphics graphics) {
 				Rectangle r = Rectangle.SINGLETON;
 				r.setBounds(getBounds());
@@ -260,6 +266,7 @@ public class DrawerFigure extends Figure {
 		tipLabel.setOpaque(false);
 		tipLabel.setBorder(TOOLTIP_BORDER);
 		collapseToggle.addMouseMotionListener(new MouseMotionListener.Stub() {
+			@Override
 			public void mouseMoved(MouseEvent e) {
 				if (!drawerLabel.getBounds().contains(e.getLocation()))
 					return;
@@ -282,6 +289,7 @@ public class DrawerFigure extends Figure {
 			}
 		});
 		tipLabel.addMouseListener(new MouseListener.Stub() {
+			@Override
 			public void mousePressed(MouseEvent e) {
 				if (e.button == 1) {
 					Rectangle original = getCollapseToggle().getBounds().getCopy();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DropShadowButtonBorder.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DropShadowButtonBorder.java
@@ -37,14 +37,17 @@ class DropShadowButtonBorder extends AbstractBorder {
 	 * @param figure Figure for which this is the border.
 	 * @return Insets for this border.
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return insets;
 	}
 
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
 
+	@Override
 	public void paint(IFigure figure, Graphics g, Insets insets) {
 		ButtonModel model = ((Clickable) figure).getModel();
 		Rectangle r = getPaintRectangle(figure, insets);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
@@ -82,6 +82,7 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 		}
 	}
 
+	@Override
 	public void dispose() {
 		if (shellListener != null) {
 			control.getShell().removeShellListener(shellListener);
@@ -93,11 +94,13 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 	/**
 	 * @see org.eclipse.draw2d.PopUpHelper#hide()
 	 */
+	@Override
 	protected void hide() {
 		super.hide();
 		currentHelper = null;
 	}
 
+	@Override
 	protected void hookShellListeners() {
 
 		/*
@@ -105,6 +108,7 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 		 * shell
 		 */
 		getShell().addMouseTrackListener(new MouseTrackAdapter() {
+			@Override
 			public void mouseExit(MouseEvent e) {
 				getShell().setCapture(false);
 				dispose();
@@ -116,6 +120,7 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 		 * mouseEnter is not received on the tooltip when it appears.
 		 */
 		getShell().addMouseMoveListener(new MouseMoveListener() {
+			@Override
 			public void mouseMove(MouseEvent e) {
 				Point eventPoint = getShell().toDisplay(new Point(e.x, e.y));
 				if (!getShell().getBounds().contains(eventPoint)) {
@@ -130,8 +135,10 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 		// window.
 		if (shellListener == null) {
 			shellListener = new ShellAdapter() {
+				@Override
 				public void shellDeactivated(ShellEvent event) {
 					Display.getCurrent().asyncExec(new Runnable() {
+						@Override
 						public void run() {
 							Shell active = Display.getCurrent().getActiveShell();
 							if (getShell() == active || control.getShell() == active || getShell().isDisposed())
@@ -154,12 +161,14 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 		 */
 		if (SWT.getPlatform().equals("gtk")) { //$NON-NLS-1$
 			getShell().addPaintListener(new PaintListener() {
+				@Override
 				public void paintControl(PaintEvent event) {
 					Point cursorLoc = Display.getCurrent().getCursorLocation();
 					if (!getShell().getBounds().contains(cursorLoc)) {
 						// This must be run asynchronously. If not, other paint
 						// listeners may attempt to paint on a disposed control.
 						Display.getCurrent().asyncExec(new Runnable() {
+							@Override
 							public void run() {
 								if (isShowing())
 									getShell().setCapture(false);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/GroupEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/GroupEditPart.java
@@ -39,6 +39,7 @@ public class GroupEditPart extends PaletteEditPart {
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
+	@Override
 	public IFigure createFigure() {
 		Figure figure = new Figure();
 		figure.setOpaque(true);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/OverlayScrollPaneLayout.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/OverlayScrollPaneLayout.java
@@ -27,6 +27,7 @@ public class OverlayScrollPaneLayout extends ScrollPaneLayout {
 	 * 
 	 * @since 2.0
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure container, int wHint, int hHint) {
 		ScrollPane scrollpane = (ScrollPane) container;
 		Insets insets = scrollpane.getInsets();
@@ -39,6 +40,7 @@ public class OverlayScrollPaneLayout extends ScrollPaneLayout {
 	}
 
 	/** {@inheritDoc} */
+	@Override
 	public void layout(IFigure parent) {
 		ScrollPane scrollpane = (ScrollPane) parent;
 		Rectangle clientArea = parent.getClientArea();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteContainerFlowLayout.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteContainerFlowLayout.java
@@ -48,6 +48,7 @@ public class PaletteContainerFlowLayout extends FlowLayout {
 	 * @see org.eclipse.draw2d.AbstractLayout#calculatePreferredSize(IFigure, int,
 	 *      int)
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure container, int wHint, int hHint) {
 
 		Dimension prefSize = super.calculatePreferredSize(container, wHint, hHint);
@@ -94,6 +95,7 @@ public class PaletteContainerFlowLayout extends FlowLayout {
 	 * 
 	 * @see FlowLayout#getChildSize(IFigure, int, int)
 	 */
+	@Override
 	protected Dimension getChildSize(IFigure child, int wHint, int hHint) {
 		if (child instanceof PinnablePaletteStackFigure) {
 			return ((PinnablePaletteStackFigure) child).getHeaderPreferredSize(wHint, hHint);
@@ -108,6 +110,7 @@ public class PaletteContainerFlowLayout extends FlowLayout {
 	 * 
 	 * @see FlowLayout#layoutRow(IFigure)
 	 */
+	@Override
 	protected void layoutRow(IFigure parent) {
 		int majorAdjustment = 0;
 		int minorAdjustment = 0;
@@ -174,6 +177,7 @@ public class PaletteContainerFlowLayout extends FlowLayout {
 	 * 
 	 * @see FlowLayout#setBoundsOfChild(IFigure, IFigure, Rectangle)
 	 */
+	@Override
 	protected void setBoundsOfChild(IFigure parent, IFigure child, Rectangle bounds) {
 
 		if (child instanceof PinnablePaletteStackFigure && ((PinnablePaletteStackFigure) child).isExpanded()) {

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
@@ -83,14 +83,17 @@ public final class PaletteScrollBar extends ScrollBar {
 		super();
 	}
 
+	@Override
 	public boolean containsPoint(int x, int y) {
 		return findDescendantAtExcluding(x, y, IdentitySearch.INSTANCE) != null;
 	}
 
+	@Override
 	protected Clickable createDefaultDownButton() {
 		return createTransparentArrowButton(true);
 	}
 
+	@Override
 	protected Clickable createDefaultUpButton() {
 		return createTransparentArrowButton(false);
 	}
@@ -104,6 +107,7 @@ public final class PaletteScrollBar extends ScrollBar {
 	 */
 	private Toggle createTransparentArrowButton(final boolean down) {
 		Toggle button = new Toggle() {
+			@Override
 			protected void paintFigure(Graphics g) {
 				// paint background
 				if (!getModel().isMouseOver())
@@ -144,6 +148,7 @@ public final class PaletteScrollBar extends ScrollBar {
 		return transposedPoints;
 	}
 
+	@Override
 	public IFigure findFigureAt(int x, int y, TreeSearch search) {
 		IFigure result = super.findFigureAt(x, y, search);
 		if (result != this)
@@ -151,13 +156,16 @@ public final class PaletteScrollBar extends ScrollBar {
 		return null;
 	}
 
+	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
 		return new Dimension(wHint, hHint);
 	}
 
+	@Override
 	protected void initialize() {
 		super.initialize();
 		setLayoutManager(new ScrollBarLayout(transposer) {
+			@Override
 			protected Rectangle layoutButtons(ScrollBar scrollBar) {
 				Rectangle bounds = transposer.t(scrollBar.getClientArea());
 				Dimension buttonSize = new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT);
@@ -180,10 +188,12 @@ public final class PaletteScrollBar extends ScrollBar {
 		setOpaque(false);
 	}
 
+	@Override
 	protected void stepDown() {
 		timedStep(false);
 	}
 
+	@Override
 	protected void stepUp() {
 		timedStep(true);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
@@ -59,6 +59,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 
 	// listen to changes of clickable tool figure
 	private ChangeListener clickableListener = new ChangeListener() {
+		@Override
 		public void handleStateChanged(ChangeEvent event) {
 			if (event.getPropertyName().equals(ButtonModel.MOUSEOVER_PROPERTY))
 				arrowFigure.getModel().setMouseOver(activeFigure.getModel().isMouseOver());
@@ -69,6 +70,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 
 	// listen to changes of arrow figure
 	private ChangeListener clickableArrowListener = new ChangeListener() {
+		@Override
 		public void handleStateChanged(ChangeEvent event) {
 			if (event.getPropertyName().equals(ButtonModel.MOUSEOVER_PROPERTY))
 				activeFigure.getModel().setMouseOver(arrowFigure.getModel().isMouseOver());
@@ -82,6 +84,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 
 	// listen to see if active tool is changed in palette
 	private PaletteListener paletteListener = new PaletteListener() {
+		@Override
 		public void activeToolChanged(PaletteViewer palette, ToolEntry tool) {
 			if (getStack().getChildren().contains(tool)) {
 				if (!arrowFigure.getModel().isSelected())
@@ -224,6 +227,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 	/**
 	 * Opens the menu to display the choices for the active entry.
 	 */
+	@Override
 	public void openMenu() {
 		MenuManager menuManager = new MenuManager();
 
@@ -286,6 +290,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 		super.showTargetFeedback(request);
 	}
 
+	@Override
 	public PaletteEditPart getActiveEntry() {
 		return (PaletteEditPart) getViewer().getEditPartRegistry().get(getStack().getActiveEntry());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinFigure.java
@@ -52,6 +52,7 @@ public class PinFigure extends Toggle {
 
 		addChangeListener(new ChangeListener() {
 
+			@Override
 			public void handleStateChanged(ChangeEvent e) {
 				if (e.getPropertyName().equals(ButtonModel.SELECTED_PROPERTY)) {
 					if (isSelected()) {
@@ -67,6 +68,7 @@ public class PinFigure extends Toggle {
 		});
 	}
 
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		super.paintFigure(graphics);
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
@@ -38,6 +38,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 	// listen to see if active tool is changed in the palette
 	private PaletteListener paletteListener = new PaletteListener() {
 
+		@Override
 		public void activeToolChanged(PaletteViewer palette, ToolEntry tool) {
 			if (!getFigure().isPinnedOpen() && getStack().getChildren().contains(tool)) {
 				if (!getStack().getActiveEntry().equals(tool)) {
@@ -200,6 +201,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 		getFigure().setLayoutMode(getLayoutSetting());
 	}
 
+	@Override
 	public void openMenu() {
 		setExpanded(true);
 	}
@@ -208,22 +210,27 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 		getFigure().setExpanded(value);
 	}
 
+	@Override
 	public boolean isExpanded() {
 		return getFigure().isExpanded();
 	}
 
+	@Override
 	public boolean canBePinned() {
 		return isExpanded();
 	}
 
+	@Override
 	public boolean isPinnedOpen() {
 		return getFigure().isPinnedOpen();
 	}
 
+	@Override
 	public void setPinnedOpen(boolean pinned) {
 		getFigure().setPinned(pinned);
 	}
 
+	@Override
 	public PaletteEditPart getActiveEntry() {
 		return (PaletteEditPart) getViewer().getEditPartRegistry().get(getStack().getActiveEntry());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackFigure.java
@@ -63,10 +63,12 @@ public class PinnablePaletteStackFigure extends Figure {
 		/**
 		 * @return false so that the focus rectangle is not drawn.
 		 */
+		@Override
 		public boolean hasFocus() {
 			return false;
 		}
 
+		@Override
 		public void paintFigure(Graphics graphics) {
 			Rectangle rect = getClientArea();
 
@@ -121,10 +123,12 @@ public class PinnablePaletteStackFigure extends Figure {
 	 */
 	private class HeaderIconLayout extends StackLayout {
 
+		@Override
 		protected boolean isSensitiveVertically(IFigure container) {
 			return false;
 		}
 
+		@Override
 		public void layout(IFigure parent) {
 
 			Rectangle r = parent.getClientArea();
@@ -155,10 +159,12 @@ public class PinnablePaletteStackFigure extends Figure {
 	 */
 	private class HeaderListLayout extends StackLayout {
 
+		@Override
 		protected boolean isSensitiveVertically(IFigure container) {
 			return false;
 		}
 
+		@Override
 		protected Dimension calculatePreferredSize(IFigure parent, int wHint, int hHint) {
 			if (isExpanded()) {
 				Dimension pinSize = pinFigure.getSize();
@@ -170,6 +176,7 @@ public class PinnablePaletteStackFigure extends Figure {
 			}
 		}
 
+		@Override
 		public void layout(IFigure parent) {
 
 			Rectangle r = parent.getClientArea();
@@ -206,10 +213,12 @@ public class PinnablePaletteStackFigure extends Figure {
 	 */
 	private class PaletteStackIconLayout extends AbstractLayout {
 
+		@Override
 		protected Dimension calculatePreferredSize(IFigure parent, int wHint, int hHint) {
 			return parent.getSize();
 		}
 
+		@Override
 		public void layout(IFigure parent) {
 			if (isExpanded()) {
 				headerFigure.setBounds(headerBoundsLayoutHint);
@@ -237,6 +246,7 @@ public class PinnablePaletteStackFigure extends Figure {
 	 */
 	private ChangeListener clickableArrowListener = new ChangeListener() {
 
+		@Override
 		public void handleStateChanged(ChangeEvent event) {
 			Clickable clickable = (Clickable) event.getSource();
 			if (event.getPropertyName() == ButtonModel.MOUSEOVER_PROPERTY
@@ -302,6 +312,7 @@ public class PinnablePaletteStackFigure extends Figure {
 		add(headerFigure);
 	}
 
+	@Override
 	protected void paintFigure(Graphics g) {
 		super.paintFigure(g);
 
@@ -566,6 +577,7 @@ public class PinnablePaletteStackFigure extends Figure {
 		return headerFigure.getPreferredSize(wHint, hHint);
 	}
 
+	@Override
 	public boolean containsPoint(int x, int y) {
 		return headerFigure.containsPoint(x, y) || (isExpanded() && expandablePane.containsPoint(x, y));
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/RaisedBorder.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/RaisedBorder.java
@@ -27,6 +27,7 @@ public class RaisedBorder extends MarginBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#getInsets(IFigure)
 	 */
+	@Override
 	public Insets getInsets(IFigure figure) {
 		return insets;
 	}
@@ -43,6 +44,7 @@ public class RaisedBorder extends MarginBorder {
 		super(t, l, b, r);
 	}
 
+	@Override
 	public boolean isOpaque() {
 		return true;
 	}
@@ -50,6 +52,7 @@ public class RaisedBorder extends MarginBorder {
 	/**
 	 * @see org.eclipse.draw2d.Border#paint(IFigure, Graphics, Insets)
 	 */
+	@Override
 	public void paint(IFigure figure, Graphics g, Insets insets) {
 		g.setLineStyle(Graphics.LINE_SOLID);
 		g.setLineWidth(1);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SeparatorBorder.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SeparatorBorder.java
@@ -23,6 +23,7 @@ final class SeparatorBorder extends MarginBorder {
 		super(t, l, b, r);
 	}
 
+	@Override
 	public void paint(IFigure f, Graphics g, Insets i) {
 		Rectangle r = getPaintRectangle(f, i);
 		r.height--;

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SeparatorEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SeparatorEditPart.java
@@ -42,6 +42,7 @@ public class SeparatorEditPart extends PaletteEditPart {
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
+	@Override
 	protected IFigure createFigure() {
 		return new SeparatorFigure();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SliderPaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SliderPaletteEditPart.java
@@ -29,6 +29,7 @@ public class SliderPaletteEditPart extends PaletteEditPart {
 		super(paletteRoot);
 	}
 
+	@Override
 	public IFigure createFigure() {
 		Figure figure = new Figure();
 		figure.setOpaque(true);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
@@ -55,6 +55,7 @@ public class ToolEntryEditPart extends PaletteEditPart {
 			enabled = false;
 		}
 
+		@Override
 		public void run() {
 			if (enabled) {
 				getButtonModel().setArmed(false);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolbarEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolbarEditPart.java
@@ -41,6 +41,7 @@ public class ToolbarEditPart extends GroupEditPart {
 	public IFigure createFigure() {
 		IFigure figure = new Figure() {
 
+			@Override
 			protected void paintFigure(Graphics graphics) {
 				super.paintFigure(graphics);
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/DragGuidePolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/DragGuidePolicy.java
@@ -52,6 +52,7 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 	 * deactivated (and hence eraseSourceFeedback is never called on this policy).
 	 * So we make sure that this policy cleans up when it is deactivated.
 	 */
+	@Override
 	public void deactivate() {
 		removeFeedback();
 		super.deactivate();
@@ -70,6 +71,7 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 		}
 	}
 
+	@Override
 	public void eraseSourceFeedback(Request request) {
 		getGuideEditPart().updateLocationOfFigures(getGuideEditPart().getZoomedPosition());
 		getHostFigure().setVisible(true);
@@ -88,6 +90,7 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 		return attachedEditParts;
 	}
 
+	@Override
 	public Command getCommand(Request request) {
 		Command cmd;
 		final ChangeBoundsRequest req = (ChangeBoundsRequest) request;
@@ -243,6 +246,7 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 		}
 	}
 
+	@Override
 	public boolean understandsRequest(Request req) {
 		return req.getType().equals(REQ_MOVE);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
@@ -157,6 +157,7 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 	public <T> T getAdapter(final Class<T> key) {
 		if (key == AccessibleHandleProvider.class) {
 			return key.cast(new AccessibleHandleProvider() {
+				@Override
 				public List<Point> getAccessibleHandleLocations() {
 					List<Point> result = new ArrayList<>();
 					Point pt = getFigure().getBounds().getCenter();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideFigure.java
@@ -46,6 +46,7 @@ public class GuideFigure extends Figure {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#getPreferredSize(int, int)
 	 */
+	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
 		Dimension prefSize;
 		if (isHorizontal()) {
@@ -59,12 +60,14 @@ public class GuideFigure extends Figure {
 		return prefSize;
 	}
 
+	@Override
 	public void handleFocusGained(FocusEvent event) {
 		super.handleFocusGained(event);
 		repaint();
 		getUpdateManager().performUpdate();
 	}
 
+	@Override
 	public void handleFocusLost(FocusEvent event) {
 		super.handleFocusLost(event);
 		repaint();
@@ -80,6 +83,7 @@ public class GuideFigure extends Figure {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#paintFigure(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		// Since painting can occur a lot, using a transposer is not good for
 		// performance.

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuidePlaceHolder.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuidePlaceHolder.java
@@ -25,6 +25,7 @@ public class GuidePlaceHolder extends GuideFigure {
 		setBackgroundColor(ColorConstants.lightGray);
 	}
 
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		PointList list = new PointList();
 		if (isHorizontal()) {

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerContextMenuProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerContextMenuProvider.java
@@ -25,6 +25,7 @@ public class RulerContextMenuProvider extends ContextMenuProvider {
 		super(viewer);
 	}
 
+	@Override
 	public void buildContextMenu(IMenuManager menu) {
 		GEFActionConstants.addStandardActionGroups(menu);
 		menu.appendToGroup(GEFActionConstants.GROUP_ADD, new CreateGuideAction(getViewer()));

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerDragTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerDragTracker.java
@@ -40,6 +40,7 @@ public class RulerDragTracker extends SimpleDragTracker {
 		guideline.setVisible(false);
 	}
 
+	@Override
 	protected void eraseSourceFeedback() {
 		if (guide.getParent() != null) {
 			guide.getParent().remove(guide);
@@ -49,6 +50,7 @@ public class RulerDragTracker extends SimpleDragTracker {
 		}
 	}
 
+	@Override
 	protected Command getCommand() {
 		if (isCreationValid() && !isDelete())
 			return source.getRulerProvider().getCreateGuideCommand(getCurrentPosition());
@@ -56,6 +58,7 @@ public class RulerDragTracker extends SimpleDragTracker {
 			return UnexecutableCommand.INSTANCE;
 	}
 
+	@Override
 	protected String getCommandName() {
 		return REQ_CREATE;
 	}
@@ -80,10 +83,12 @@ public class RulerDragTracker extends SimpleDragTracker {
 		return position;
 	}
 
+	@Override
 	protected String getDebugName() {
 		return "Guide creation"; //$NON-NLS-1$
 	}
 
+	@Override
 	protected Cursor getDefaultCursor() {
 		if (isDelete())
 			return super.getDefaultCursor();
@@ -93,12 +98,14 @@ public class RulerDragTracker extends SimpleDragTracker {
 			return SharedCursors.NO;
 	}
 
+	@Override
 	protected boolean handleButtonDown(int button) {
 		stateTransition(STATE_INITIAL, STATE_DRAG_IN_PROGRESS);
 		showSourceFeedback();
 		return true;
 	}
 
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (stateTransition(STATE_DRAG_IN_PROGRESS, STATE_TERMINAL)) {
 			setCurrentCommand(getCommand());
@@ -137,10 +144,12 @@ public class RulerDragTracker extends SimpleDragTracker {
 		return pos < min || pos > max;
 	}
 
+	@Override
 	protected boolean movedPastThreshold() {
 		return true;
 	}
 
+	@Override
 	protected void showSourceFeedback() {
 		if (guide.getParent() == null) {
 			getCurrentViewer().deselectAll();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPartFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPartFactory.java
@@ -32,6 +32,7 @@ public class RulerEditPartFactory implements EditPartFactory {
 	 * @see org.eclipse.gef.EditPartFactory#createEditPart(org.eclipse.gef.EditPart,
 	 * java.lang.Object)
 	 */
+	@Override
 	public EditPart createEditPart(EditPart parentEditPart, Object model) {
 		// the model can be null when the contents of the root edit part are set
 		// to null

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
@@ -88,6 +88,7 @@ public class RulerFigure extends Figure {
 		return drawFocus;
 	}
 
+	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
 		Dimension prefSize = new Dimension();
 		if (isHorizontal()) {
@@ -113,6 +114,7 @@ public class RulerFigure extends Figure {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		super.invalidate();
 		dpu = -1.0;
@@ -131,6 +133,7 @@ public class RulerFigure extends Figure {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#paintFigure(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		/*
 		 * @TODO:Pratik maybe you can break this method into a few methods. that might

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerLayout.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerLayout.java
@@ -29,6 +29,7 @@ public class RulerLayout extends XYLayout {
 	 * @see org.eclipse.draw2d.AbstractLayout#calculatePreferredSize(org.eclipse.draw2d.IFigure,
 	 *      int, int)
 	 */
+	@Override
 	protected Dimension calculatePreferredSize(IFigure container, int wHint, int hHint) {
 		return new Dimension(1, 1);
 	}
@@ -36,6 +37,7 @@ public class RulerLayout extends XYLayout {
 	/**
 	 * @see org.eclipse.draw2d.AbstractLayout#getConstraint(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public Object getConstraint(IFigure child) {
 		return constraints.get(child);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerRootEditPart.java
@@ -54,6 +54,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#addChildVisual(org.eclipse.gef.EditPart,
 	 *      int)
 	 */
+	@Override
 	protected void addChildVisual(EditPart childEditPart, int index) {
 		IFigure child = ((GraphicalEditPart) childEditPart).getFigure();
 		getViewport().setContents(child);
@@ -62,6 +63,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
+	@Override
 	protected IFigure createFigure() {
 		return new RulerViewport();
 	}
@@ -91,6 +93,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 	/**
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#removeChildVisual(org.eclipse.gef.EditPart)
 	 */
+	@Override
 	protected void removeChildVisual(EditPart childEditPart) {
 		getViewport().setContents(null);
 	}
@@ -167,6 +170,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 		/**
 		 * @see org.eclipse.draw2d.IFigure#getPreferredSize(int, int)
 		 */
+		@Override
 		public Dimension getPreferredSize(int wHint, int hHint) {
 			if (this.getContents() == null)
 				return new Dimension();
@@ -187,12 +191,14 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 		 * 
 		 * @see org.eclipse.draw2d.Viewport#readjustScrollBars()
 		 */
+		@Override
 		protected void readjustScrollBars() {
 		}
 
 		/**
 		 * @see org.eclipse.draw2d.Figure#paintBorder(org.eclipse.draw2d.Graphics)
 		 */
+		@Override
 		protected void paintBorder(Graphics graphics) {
 			super.paintBorder(graphics);
 			if (this.getContents() != null && ((RulerFigure) this.getContents()).getDrawFocus()) {
@@ -213,6 +219,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 		/**
 		 * @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent)
 		 */
+		@Override
 		public void propertyChange(PropertyChangeEvent event) {
 			if (this.getContents() != null && event.getSource() instanceof RangeModel) {
 				String property = event.getPropertyName();
@@ -224,6 +231,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 		/**
 		 * @see org.eclipse.draw2d.Viewport#setContents(org.eclipse.draw2d.IFigure)
 		 */
+		@Override
 		public void setContents(IFigure figure) {
 			super.setContents(figure);
 			// Need to layout when contents change
@@ -236,6 +244,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 		 * 
 		 * @see org.eclipse.draw2d.Figure#useLocalCoordinates()
 		 */
+		@Override
 		protected boolean useLocalCoordinates() {
 			return true;
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/MarqueeToolEntry.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/MarqueeToolEntry.java
@@ -59,6 +59,7 @@ public class MarqueeToolEntry extends ToolEntry {
 	/**
 	 * @see org.eclipse.gef.palette.PaletteEntry#getDescription()
 	 */
+	@Override
 	public String getDescription() {
 		String description = super.getDescription();
 		if (description != null)
@@ -89,6 +90,7 @@ public class MarqueeToolEntry extends ToolEntry {
 	/**
 	 * @see org.eclipse.gef.palette.PaletteEntry#getLargeIcon()
 	 */
+	@Override
 	public ImageDescriptor getLargeIcon() {
 		ImageDescriptor imageDescriptor = super.getLargeIcon();
 		if (imageDescriptor != null) {
@@ -120,6 +122,7 @@ public class MarqueeToolEntry extends ToolEntry {
 	/**
 	 * @see org.eclipse.gef.palette.PaletteEntry#getSmallIcon()
 	 */
+	@Override
 	public ImageDescriptor getSmallIcon() {
 		ImageDescriptor imageDescriptor = super.getSmallIcon();
 		if (imageDescriptor != null) {

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteContainer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteContainer.java
@@ -226,6 +226,7 @@ public class PaletteContainer extends PaletteEntry {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "Palette Container (" //$NON-NLS-1$
 				+ (getLabel() != null ? getLabel() : "") //$NON-NLS-1$

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteDrawer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteDrawer.java
@@ -81,6 +81,7 @@ public class PaletteDrawer extends PaletteContainer {
 	 * @param type the type being requested
 	 * @return true if this can be a child of this container
 	 */
+	@Override
 	public boolean acceptsType(Object type) {
 		if (type.equals(PALETTE_TYPE_DRAWER) || type.equals(PaletteGroup.PALETTE_TYPE_GROUP))
 			return false;

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteEntry.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteEntry.java
@@ -418,6 +418,7 @@ public class PaletteEntry {
 	/**
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "Palette Entry (" + (label != null ? label : "") //$NON-NLS-2$//$NON-NLS-1$
 				+ ")"; //$NON-NLS-1$

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteRoot.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteRoot.java
@@ -30,6 +30,7 @@ public class PaletteRoot extends PaletteContainer {
 	/**
 	 * @see org.eclipse.gef.palette.PaletteContainer#acceptsType(java.lang.Object)
 	 */
+	@Override
 	public boolean acceptsType(Object type) {
 		if (type.equals(ToolEntry.PALETTE_TYPE_TOOL) || type.equals(PaletteStack.PALETTE_TYPE_STACK))
 			return false;
@@ -56,6 +57,7 @@ public class PaletteRoot extends PaletteContainer {
 	/**
 	 * @see Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return "Palette Root"; //$NON-NLS-1$
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteStack.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteStack.java
@@ -34,6 +34,7 @@ public class PaletteStack extends PaletteContainer {
 	 * active entry can be updated if the current active entry is hidden.
 	 */
 	private PropertyChangeListener childListener = new PropertyChangeListener() {
+		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			if (evt.getPropertyName().equals(PaletteEntry.PROPERTY_VISIBLE) && evt.getNewValue() == Boolean.FALSE
 					&& activeEntry == evt.getSource()) {
@@ -73,6 +74,7 @@ public class PaletteStack extends PaletteContainer {
 	 * @param type the type being requested
 	 * @return true if this can be a child of this container
 	 */
+	@Override
 	public boolean acceptsType(Object type) {
 		if (!type.equals(ToolEntry.PALETTE_TYPE_TOOL))
 			return false;
@@ -83,6 +85,7 @@ public class PaletteStack extends PaletteContainer {
 	 * @see org.eclipse.gef.palette.PaletteContainer#add(int,
 	 *      org.eclipse.gef.palette.PaletteEntry)
 	 */
+	@Override
 	public void add(int index, PaletteEntry entry) {
 		super.add(index, entry);
 		checkActiveEntry();
@@ -91,6 +94,7 @@ public class PaletteStack extends PaletteContainer {
 	/**
 	 * @see org.eclipse.gef.palette.PaletteContainer#addAll(java.util.List)
 	 */
+	@Override
 	public void addAll(List list) {
 		super.addAll(list);
 		checkActiveEntry();
@@ -134,6 +138,7 @@ public class PaletteStack extends PaletteContainer {
 	/**
 	 * @see org.eclipse.gef.palette.PaletteContainer#remove(org.eclipse.gef.palette.PaletteEntry)
 	 */
+	@Override
 	public void remove(PaletteEntry entry) {
 		super.remove(entry);
 		checkActiveEntry();
@@ -154,11 +159,13 @@ public class PaletteStack extends PaletteContainer {
 		listeners.firePropertyChange(PROPERTY_ACTIVE_ENTRY, oldEntry, activeEntry);
 	}
 
+	@Override
 	public void add(PaletteEntry entry) {
 		super.add(entry);
 		updateListeners(Collections.singletonList(entry), true);
 	}
 
+	@Override
 	public void setChildren(List list) {
 		updateListeners(getChildren(), false);
 		super.setChildren(list);

--- a/org.eclipse.gef/src/org/eclipse/gef/print/PrintGraphicalViewerOperation.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/print/PrintGraphicalViewerOperation.java
@@ -61,6 +61,7 @@ public class PrintGraphicalViewerOperation extends PrintFigureOperation {
 	/**
 	 * @see org.eclipse.draw2d.PrintOperation#preparePrintSource()
 	 */
+	@Override
 	protected void preparePrintSource() {
 		super.preparePrintSource();
 		selectedEditParts = new ArrayList(viewer.getSelectedEditParts());
@@ -70,6 +71,7 @@ public class PrintGraphicalViewerOperation extends PrintFigureOperation {
 	/**
 	 * @see org.eclipse.draw2d.PrintOperation#restorePrintSource()
 	 */
+	@Override
 	protected void restorePrintSource() {
 		super.restorePrintSource();
 		viewer.setSelection(new StructuredSelection(selectedEditParts));

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/AlignmentRequest.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/AlignmentRequest.java
@@ -107,6 +107,7 @@ public class AlignmentRequest extends ChangeBoundsRequest {
 	/**
 	 * @see ChangeBoundsRequest#getTransformedRectangle(Rectangle)
 	 */
+	@Override
 	public Rectangle getTransformedRectangle(Rectangle rect) {
 		Rectangle result = rect.getCopy();
 		Rectangle reference = getAlignmentRectangle();

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/ChangeBoundsRequest.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/ChangeBoundsRequest.java
@@ -49,6 +49,7 @@ public class ChangeBoundsRequest extends GroupRequest implements DropRequest {
 	 * 
 	 * @return The location of the mouse pointer.
 	 */
+	@Override
 	public Point getLocation() {
 		return mouseLocation;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/CreateConnectionRequest.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/CreateConnectionRequest.java
@@ -66,6 +66,7 @@ public class CreateConnectionRequest extends CreateRequest implements TargetRequ
 	 * 
 	 * @param part the target EditPart
 	 */
+	@Override
 	public void setTargetEditPart(EditPart part) {
 		targetEditPart = part;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/CreateRequest.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/CreateRequest.java
@@ -59,6 +59,7 @@ public class CreateRequest extends org.eclipse.gef.Request implements DropReques
 	 * 
 	 * @return the location
 	 */
+	@Override
 	public Point getLocation() {
 		return location;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/ReconnectRequest.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/ReconnectRequest.java
@@ -79,6 +79,7 @@ public class ReconnectRequest extends LocationRequest implements DropRequest, Ta
 	 * 
 	 * @param ep the target edit part
 	 */
+	@Override
 	public void setTargetEditPart(EditPart ep) {
 		target = ep;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/SimpleFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/SimpleFactory.java
@@ -35,6 +35,7 @@ public class SimpleFactory implements CreationFactory {
 	 * 
 	 * @return The newly created object.
 	 */
+	@Override
 	public Object getNewObject() {
 		try {
 			return type.newInstance();
@@ -48,6 +49,7 @@ public class SimpleFactory implements CreationFactory {
 	 * 
 	 * @return The type of object this factory creates.
 	 */
+	@Override
 	public Object getObjectType() {
 		return type;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerChangeListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerChangeListener.java
@@ -65,24 +65,28 @@ public interface RulerChangeListener {
 		/**
 		 * @see RulerChangeListener#notifyUnitsChanged(int)
 		 */
+		@Override
 		public void notifyUnitsChanged(int newUnit) {
 		}
 
 		/**
 		 * @see RulerChangeListener#notifyGuideReparented(Object)
 		 */
+		@Override
 		public void notifyGuideReparented(Object guide) {
 		}
 
 		/**
 		 * @see RulerChangeListener#notifyGuideMoved(Object)
 		 */
+		@Override
 		public void notifyGuideMoved(Object guide) {
 		}
 
 		/**
 		 * @see RulerChangeListener#notifyPartAttachmentChanged(Object, Object)
 		 */
+		@Override
 		public void notifyPartAttachmentChanged(Object part, Object guide) {
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractConnectionCreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractConnectionCreationTool.java
@@ -62,6 +62,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	private EditPartViewer viewer;
 
 	private EditPartListener.Stub deactivationListener = new EditPartListener.Stub() {
+		@Override
 		public void partDeactivated(EditPart editpart) {
 			handleSourceDeactivated();
 		}
@@ -88,6 +89,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#calculateCursor()
 	 */
+	@Override
 	protected Cursor calculateCursor() {
 		if (isInState(STATE_INITIAL)) {
 			if (getCurrentCommand() != null)
@@ -99,6 +101,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#createTargetRequest()
 	 */
+	@Override
 	protected Request createTargetRequest() {
 		CreateRequest req = new CreateConnectionRequest();
 		req.setFactory(getFactory());
@@ -110,6 +113,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.Tool#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		eraseSourceFeedback();
 		setConnectionSource(null);
@@ -133,6 +137,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		if (isInState(STATE_CONNECTION_STARTED | STATE_ACCESSIBLE_DRAG_IN_PROGRESS))
 			return REQ_CONNECTION_END;
@@ -143,6 +148,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Connection Creation Tool";//$NON-NLS-1$
 	}
@@ -150,6 +156,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugNameForState(int)
 	 */
+	@Override
 	protected String getDebugNameForState(int s) {
 		if (s == STATE_CONNECTION_STARTED || s == STATE_ACCESSIBLE_DRAG_IN_PROGRESS)
 			return "Connection Started";//$NON-NLS-1$
@@ -187,6 +194,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	 * @param button which button is pressed
 	 * @return <code>true</code> if the button down was processed
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		if (isInState(STATE_INITIAL) && button == 1) {
 			updateTargetRequest();
@@ -213,6 +221,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (isInState(STATE_TERMINAL | STATE_INVALID))
 			handleFinished();
@@ -222,6 +231,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleCommandStackChanged()
 	 */
+	@Override
 	protected boolean handleCommandStackChanged() {
 		if (!isInState(STATE_INITIAL)) {
 			if (getCurrentInput().isMouseButtonDown(1))
@@ -254,6 +264,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDrag()
 	 */
+	@Override
 	protected boolean handleDrag() {
 		if (isInState(STATE_CONNECTION_STARTED))
 			return handleMove();
@@ -263,6 +274,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragInProgress()
 	 */
+	@Override
 	protected boolean handleDragInProgress() {
 		if (isInState(STATE_ACCESSIBLE_DRAG_IN_PROGRESS))
 			return handleMove();
@@ -272,6 +284,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleFocusLost()
 	 */
+	@Override
 	protected boolean handleFocusLost() {
 		if (isInState(STATE_CONNECTION_STARTED)) {
 			eraseSourceFeedback();
@@ -285,6 +298,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#handleHover()
 	 */
+	@Override
 	protected boolean handleHover() {
 		if (isInState(STATE_CONNECTION_STARTED))
 			updateAutoexposeHelper();
@@ -294,6 +308,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#handleInvalidInput()
 	 */
+	@Override
 	protected boolean handleInvalidInput() {
 		eraseSourceFeedback();
 		setConnectionSource(null);
@@ -303,6 +318,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleMove()
 	 */
+	@Override
 	protected boolean handleMove() {
 		if (isInState(STATE_CONNECTION_STARTED) && viewer != getCurrentViewer())
 			return false;
@@ -373,6 +389,7 @@ public class AbstractConnectionCreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#updateTargetRequest()
 	 */
+	@Override
 	protected void updateTargetRequest() {
 		CreateConnectionRequest request = (CreateConnectionRequest) getTargetRequest();
 		request.setType(getCommandName());

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractTool.java
@@ -192,6 +192,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	private Command command;
 
 	private CommandStackEventListener commandStackListener = new CommandStackEventListener() {
+		@Override
 		public void stackChanged(CommandStackEvent event) {
 			if (event.isPreChangeEvent())
 				handleCommandStackChanged();
@@ -254,6 +255,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * 
 	 * @see #deactivate()
 	 */
+	@Override
 	public void activate() {
 		resetFlags();
 		accessibleBegin = -1;
@@ -375,6 +377,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * 
 	 * @see #activate()
 	 */
+	@Override
 	public void deactivate() {
 		setFlag(FLAG_ACTIVE, false);
 		setViewer(null);
@@ -426,6 +429,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param event  The SWT focus event
 	 * @param viewer The viewer that the focus event is over.
 	 */
+	@Override
 	public void focusGained(FocusEvent event, EditPartViewer viewer) {
 		setViewer(viewer);
 		handleFocusGained();
@@ -437,6 +441,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param event  The SWT focus event
 	 * @param viewer The viewer that the focus event is over.
 	 */
+	@Override
 	public void focusLost(FocusEvent event, EditPartViewer viewer) {
 		setViewer(viewer);
 		handleFocusLost();
@@ -967,6 +972,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param evt    the key event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void keyDown(KeyEvent evt, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -982,6 +988,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param event  the traverse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void keyTraversed(TraverseEvent event, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -997,6 +1004,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param evt    the key event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void keyUp(KeyEvent evt, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1012,6 +1020,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param me     the mouse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void mouseDoubleClick(MouseEvent me, EditPartViewer viewer) {
 		if (me.button > 5 || !isViewerImportant(viewer))
 			return;
@@ -1028,6 +1037,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param me     the mouse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void mouseDown(MouseEvent me, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1049,6 +1059,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param me     the mouse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void mouseDrag(MouseEvent me, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1071,6 +1082,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param viewer the originating viewer
 	 * 
 	 */
+	@Override
 	public void mouseHover(MouseEvent me, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1086,6 +1098,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param me     the mouse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void mouseMove(MouseEvent me, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1131,6 +1144,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param me     the mouse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void mouseUp(MouseEvent me, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1150,6 +1164,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param viewer the originating viewer
 	 * @see #performViewerMouseWheel(Event, EditPartViewer)
 	 */
+	@Override
 	public void mouseWheelScrolled(Event event, EditPartViewer viewer) {
 		if (isInState(STATE_INITIAL))
 			performViewerMouseWheel(event, viewer);
@@ -1175,6 +1190,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	/**
 	 * @see org.eclipse.gef.Tool#nativeDragFinished(DragSourceEvent, EditPartViewer)
 	 */
+	@Override
 	public void nativeDragFinished(DragSourceEvent event, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1185,6 +1201,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	/**
 	 * @see org.eclipse.gef.Tool#nativeDragStarted(DragSourceEvent, EditPartViewer)
 	 */
+	@Override
 	public void nativeDragStarted(DragSourceEvent event, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1352,6 +1369,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param domain the edit domain
 	 * @see #getDomain()
 	 */
+	@Override
 	public void setEditDomain(EditDomain domain) {
 		this.domain = domain;
 	}
@@ -1381,6 +1399,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * 
 	 * @see org.eclipse.gef.Tool#setProperties(java.util.Map)
 	 */
+	@Override
 	public void setProperties(Map properties) {
 		if (properties == null)
 			return;
@@ -1436,6 +1455,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * 
 	 * @param viewer the viewer
 	 */
+	@Override
 	public void setViewer(EditPartViewer viewer) {
 		if (viewer == currentViewer)
 			return;
@@ -1490,6 +1510,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param me     the mouse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void viewerEntered(MouseEvent me, EditPartViewer viewer) {
 		if (!isViewerImportant(viewer))
 			return;
@@ -1507,6 +1528,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param me     the mouse event
 	 * @param viewer the originating viewer
 	 */
+	@Override
 	public void viewerExited(MouseEvent me, EditPartViewer viewer) {
 		/*
 		 * FEATURE in SWT. mouseExited comes after mouseEntered. So only call handle

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionBendpointTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionBendpointTracker.java
@@ -58,6 +58,7 @@ public class ConnectionBendpointTracker extends SimpleDragTracker {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#createOperationSet()
 	 */
+	@Override
 	protected List createOperationSet() {
 		List list = new ArrayList();
 		list.add(getConnectionEditPart());
@@ -69,6 +70,7 @@ public class ConnectionBendpointTracker extends SimpleDragTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.SimpleDragTracker#createSourceRequest()
 	 */
+	@Override
 	protected Request createSourceRequest() {
 		BendpointRequest request = new BendpointRequest();
 		request.setType(getType());
@@ -82,6 +84,7 @@ public class ConnectionBendpointTracker extends SimpleDragTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommand()
 	 */
+	@Override
 	protected Command getCommand() {
 		return getConnectionEditPart().getCommand(getSourceRequest());
 	}
@@ -89,6 +92,7 @@ public class ConnectionBendpointTracker extends SimpleDragTracker {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		return getType().toString();
 	}
@@ -114,6 +118,7 @@ public class ConnectionBendpointTracker extends SimpleDragTracker {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Bendpoint Handle Tracker " + getCommandName();//$NON-NLS-1$
 	}
@@ -168,6 +173,7 @@ public class ConnectionBendpointTracker extends SimpleDragTracker {
 	/**
 	 * @see org.eclipse.gef.tools.SimpleDragTracker#updateSourceRequest()
 	 */
+	@Override
 	protected void updateSourceRequest() {
 		BendpointRequest request = (BendpointRequest) getSourceRequest();
 		request.setLocation(getLocation());

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionCreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionCreationTool.java
@@ -68,6 +68,7 @@ public class ConnectionCreationTool extends AbstractConnectionCreationTool {
 	 * @param button the button that was pressed
 	 * @return <code>true</code> if the button down was processed
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		if (button == 1 && stateTransition(STATE_CONNECTION_STARTED, STATE_TERMINAL))
 			return handleCreateConnection();
@@ -85,6 +86,7 @@ public class ConnectionCreationTool extends AbstractConnectionCreationTool {
 	 * 
 	 * @return <code>true</code> if this focus lost event was processed
 	 */
+	@Override
 	protected boolean handleFocusLost() {
 		if (isInState(STATE_CONNECTION_STARTED | STATE_ACCESSIBLE_DRAG_IN_PROGRESS)) {
 			eraseSourceFeedback();
@@ -102,6 +104,7 @@ public class ConnectionCreationTool extends AbstractConnectionCreationTool {
 	 * @param event the key event
 	 * @return <code>true</code> if this key down event was processed
 	 */
+	@Override
 	protected boolean handleKeyDown(KeyEvent event) {
 		if (acceptArrowKey(event)) {
 			int direction = 0;
@@ -182,6 +185,7 @@ public class ConnectionCreationTool extends AbstractConnectionCreationTool {
 	 * @see org.eclipse.gef.Tool#mouseWheelScrolled(org.eclipse.swt.widgets.Event,
 	 *      org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseWheelScrolled(Event event, EditPartViewer viewer) {
 		if (isInState(STATE_INITIAL | STATE_CONNECTION_STARTED))
 			performViewerMouseWheel(event, viewer);

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionDragCreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionDragCreationTool.java
@@ -41,6 +41,7 @@ public class ConnectionDragCreationTool extends AbstractConnectionCreationTool i
 	 * 
 	 * @see AbstractConnectionCreationTool#handleButtonDown(int)
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		super.handleButtonDown(button);
 		setState(STATE_DRAG);
@@ -54,6 +55,7 @@ public class ConnectionDragCreationTool extends AbstractConnectionCreationTool i
 	 * @param button the button that was released
 	 * @return <code>true</code> if this button up event was processed
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (isInState(STATE_CONNECTION_STARTED))
 			handleCreateConnection();
@@ -67,6 +69,7 @@ public class ConnectionDragCreationTool extends AbstractConnectionCreationTool i
 	 * 
 	 * @return <code>true</code> if the state transition completed successfully
 	 */
+	@Override
 	protected boolean handleDragStarted() {
 		return stateTransition(STATE_DRAG, STATE_CONNECTION_STARTED);
 	}
@@ -77,6 +80,7 @@ public class ConnectionDragCreationTool extends AbstractConnectionCreationTool i
 	 * 
 	 * @see AbstractTool#handleFinished()
 	 */
+	@Override
 	protected void handleFinished() {
 		if (getDomain().getActiveTool() == this)
 			super.handleFinished();

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
@@ -63,6 +63,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @return the cursor
 	 */
+	@Override
 	protected Cursor calculateCursor() {
 		if (isInState(STATE_INITIAL | STATE_DRAG | STATE_ACCESSIBLE_DRAG))
 			return getDefaultCursor();
@@ -74,6 +75,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @see DragTracker#commitDrag()
 	 */
+	@Override
 	public void commitDrag() {
 		eraseSourceFeedback();
 		eraseTargetFeedback();
@@ -85,6 +87,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @return the target request
 	 */
+	@Override
 	protected Request createTargetRequest() {
 		ReconnectRequest request = new ReconnectRequest(getCommandName());
 		request.setConnectionEditPart(getConnectionEditPart());
@@ -98,6 +101,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @see Tool#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		eraseSourceFeedback();
 		getCurrentViewer().setFocus(null);
@@ -117,6 +121,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	/**
 	 * @see AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		return commandName;
 	}
@@ -142,6 +147,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	/**
 	 * @see AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Connection Endpoint Tool";//$NON-NLS-1$
 	}
@@ -149,6 +155,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#getExclusionSet()
 	 */
+	@Override
 	protected Collection<IFigure> getExclusionSet() {
 		if (exclusionSet == null) {
 			exclusionSet = new ArrayList<>(1);
@@ -163,6 +170,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (stateTransition(STATE_DRAG_IN_PROGRESS, STATE_TERMINAL)) {
 			eraseSourceFeedback();
@@ -178,6 +186,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @return <code>true</code>
 	 */
+	@Override
 	protected boolean handleDragInProgress() {
 		updateTargetRequest();
 		updateTargetUnderMouse();
@@ -190,6 +199,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragStarted()
 	 */
+	@Override
 	protected boolean handleDragStarted() {
 		stateTransition(STATE_INITIAL, STATE_DRAG_IN_PROGRESS);
 		return false;
@@ -198,6 +208,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#handleHover()
 	 */
+	@Override
 	protected boolean handleHover() {
 		if (isInDragInProgress())
 			updateAutoexposeHelper();
@@ -211,6 +222,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleKeyDown(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyDown(KeyEvent e) {
 		if (acceptArrowKey(e)) {
 			if (stateTransition(STATE_INITIAL, STATE_ACCESSIBLE_DRAG_IN_PROGRESS)) {
@@ -334,6 +346,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#updateTargetRequest()
 	 */
+	@Override
 	protected void updateTargetRequest() {
 		ReconnectRequest request = (ReconnectRequest) getTargetRequest();
 		Point p = getLocation();

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
@@ -68,6 +68,7 @@ public class CreationTool extends TargetingTool {
 	 * @see org.eclipse.gef.tools.AbstractTool#applyProperty(java.lang.Object,
 	 *      java.lang.Object)
 	 */
+	@Override
 	protected void applyProperty(Object key, Object value) {
 		if (PROPERTY_CREATION_FACTORY.equals(key)) {
 			if (value instanceof CreationFactory)
@@ -80,6 +81,7 @@ public class CreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#calculateCursor()
 	 */
+	@Override
 	protected Cursor calculateCursor() {
 		/*
 		 * Fix for Bug# 66010 The following two lines of code were added for the case
@@ -98,6 +100,7 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#createTargetRequest()
 	 */
+	@Override
 	protected Request createTargetRequest() {
 		CreateRequest request = new CreateRequest();
 		request.setFactory(getFactory());
@@ -107,6 +110,7 @@ public class CreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.Tool#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		super.deactivate();
 		helper = null;
@@ -115,6 +119,7 @@ public class CreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		return REQ_CREATE;
 	}
@@ -132,6 +137,7 @@ public class CreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Creation Tool";//$NON-NLS-1$
 	}
@@ -155,6 +161,7 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonDown(int)
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		if (button != 1) {
 			setState(STATE_INVALID);
@@ -178,6 +185,7 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (stateTransition(STATE_DRAG | STATE_DRAG_IN_PROGRESS, STATE_TERMINAL)) {
 			eraseTargetFeedback();
@@ -196,6 +204,7 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragInProgress()
 	 */
+	@Override
 	protected boolean handleDragInProgress() {
 		if (isInState(STATE_DRAG_IN_PROGRESS)) {
 			updateTargetRequest();
@@ -208,6 +217,7 @@ public class CreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragStarted()
 	 */
+	@Override
 	protected boolean handleDragStarted() {
 		return stateTransition(STATE_DRAG, STATE_DRAG_IN_PROGRESS);
 	}
@@ -218,6 +228,7 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleFocusLost()
 	 */
+	@Override
 	protected boolean handleFocusLost() {
 		if (isInState(STATE_DRAG | STATE_DRAG_IN_PROGRESS)) {
 			eraseTargetFeedback();
@@ -231,6 +242,7 @@ public class CreationTool extends TargetingTool {
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#handleHover()
 	 */
+	@Override
 	protected boolean handleHover() {
 		if (isInState(STATE_INITIAL))
 			updateAutoexposeHelper();
@@ -243,6 +255,7 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleMove()
 	 */
+	@Override
 	protected boolean handleMove() {
 		updateTargetRequest();
 		updateTargetUnderMouse();
@@ -295,6 +308,7 @@ public class CreationTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#updateTargetRequest()
 	 */
+	@Override
 	protected void updateTargetRequest() {
 		CreateRequest createRequest = getCreateRequest();
 		if (isInState(STATE_DRAG_IN_PROGRESS)) {

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DelayedDirectEditHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DelayedDirectEditHelper.java
@@ -69,25 +69,30 @@ class DelayedDirectEditHelper implements Runnable {
 
 	void hookControl(Control control) {
 		control.addFocusListener(focus = new FocusAdapter() {
+			@Override
 			public void focusLost(FocusEvent e) {
 				abort();
 			}
 		});
 		control.addKeyListener(key = new KeyListener() {
+			@Override
 			public void keyPressed(KeyEvent e) {
 				abort();
 			}
 
+			@Override
 			public void keyReleased(KeyEvent e) {
 				abort();
 			}
 		});
 
 		control.addMouseListener(mouse = new MouseAdapter() {
+			@Override
 			public void mouseDoubleClick(MouseEvent e) {
 				abort();
 			}
 
+			@Override
 			public void mouseDown(MouseEvent e) {
 				abort();
 			}
@@ -98,6 +103,7 @@ class DelayedDirectEditHelper implements Runnable {
 	 * If this helper has not been aborted, the target editpart will be sent the
 	 * request.
 	 */
+	@Override
 	public void run() {
 		if (activeHelper == this && part.isActive() && viewer.getControl() != null
 				&& !viewer.getControl().isDisposed()) {

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DeselectAllTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DeselectAllTracker.java
@@ -31,6 +31,7 @@ public class DeselectAllTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonDown(int)
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		getCurrentViewer().deselectAll();
 		return true;

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DirectEditManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DirectEditManager.java
@@ -252,6 +252,7 @@ public abstract class DirectEditManager {
 
 	protected void hookListeners() {
 		ancestorListener = new AncestorListener.Stub() {
+			@Override
 			public void ancestorMoved(IFigure ancestor) {
 				placeCellEditor();
 			}
@@ -261,6 +262,7 @@ public abstract class DirectEditManager {
 		Control control = getControl();
 
 		controlListener = new ControlAdapter() {
+			@Override
 			public void controlMoved(ControlEvent e) {
 				// This must be handled async because during scrolling, the
 				// CellEditor moves
@@ -268,12 +270,14 @@ public abstract class DirectEditManager {
 				// cause the
 				// shadow to move twice
 				Display.getCurrent().asyncExec(new Runnable() {
+					@Override
 					public void run() {
 						placeCellEditorFrame();
 					}
 				});
 			}
 
+			@Override
 			public void controlResized(ControlEvent e) {
 				placeCellEditorFrame();
 			}
@@ -281,14 +285,17 @@ public abstract class DirectEditManager {
 		control.addControlListener(controlListener);
 
 		cellEditorListener = new ICellEditorListener() {
+			@Override
 			public void applyEditorValue() {
 				commit();
 			}
 
+			@Override
 			public void cancelEditor() {
 				bringDown();
 			}
 
+			@Override
 			public void editorValueChanged(boolean old, boolean newState) {
 				handleValueChanged();
 			}
@@ -296,6 +303,7 @@ public abstract class DirectEditManager {
 		getCellEditor().addListener(cellEditorListener);
 
 		editPartListener = new EditPartListener.Stub() {
+			@Override
 			public void partDeactivated(EditPart editpart) {
 				bringDown();
 			}
@@ -439,10 +447,12 @@ public abstract class DirectEditManager {
 	protected static class DirectEditBorder extends AbstractBorder {
 		private static final Insets insets = new Insets(1, 2, 2, 2);
 
+		@Override
 		public Insets getInsets(IFigure figure) {
 			return insets;
 		}
 
+		@Override
 		public void paint(IFigure figure, Graphics graphics, Insets insets) {
 			Rectangle rect = getPaintRectangle(figure, insets);
 			graphics.setForegroundColor(ColorConstants.white);

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
@@ -112,6 +112,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * @see #setDefaultCursor(Cursor)
 	 * @return the default cursor
 	 */
+	@Override
 	protected Cursor getDefaultCursor() {
 		if (isCloneActive())
 			return SharedCursors.CURSOR_TREE_ADD;
@@ -163,6 +164,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#commitDrag()
 	 */
+	@Override
 	public void commitDrag() {
 		eraseSourceFeedback();
 		eraseTargetFeedback();
@@ -212,6 +214,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#createOperationSet()
 	 */
+	@Override
 	protected List createOperationSet() {
 		if (getCurrentViewer() != null) {
 			List list = ToolUtilities.getSelectionWithoutDependants(getCurrentViewer());
@@ -231,6 +234,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#createTargetRequest()
 	 */
+	@Override
 	protected Request createTargetRequest() {
 		if (isCloneActive())
 			return new ChangeBoundsRequest(REQ_CLONE);
@@ -243,6 +247,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.Tool#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		eraseSourceFeedback();
 		super.deactivate();
@@ -277,6 +282,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommand()
 	 */
+	@Override
 	protected Command getCommand() {
 		CompoundCommand command = new CompoundCommand();
 		command.setDebugLabel("Drag Object Tracker");//$NON-NLS-1$
@@ -315,6 +321,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		if (isCloneActive())
 			return REQ_CLONE;
@@ -327,6 +334,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "DragEditPartsTracker:" + getCommandName();//$NON-NLS-1$
 	}
@@ -338,6 +346,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#getExclusionSet()
 	 */
+	@Override
 	protected Collection<IFigure> getExclusionSet() {
 		if (exclusionSet == null) {
 			List set = getOperationSet();
@@ -357,6 +366,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#handleAutoexpose()
 	 */
+	@Override
 	protected void handleAutoexpose() {
 		updateTargetRequest();
 		updateTargetUnderMouse();
@@ -370,6 +380,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (stateTransition(STATE_DRAG_IN_PROGRESS, STATE_TERMINAL)) {
 			eraseSourceFeedback();
@@ -386,6 +397,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragInProgress()
 	 */
+	@Override
 	protected boolean handleDragInProgress() {
 		if (isInDragInProgress()) {
 			updateTargetRequest();
@@ -404,6 +416,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#handleHover()
 	 */
+	@Override
 	protected boolean handleHover() {
 		if (isInDragInProgress())
 			updateAutoexposeHelper();
@@ -415,6 +428,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#handleInvalidInput()
 	 */
+	@Override
 	protected boolean handleInvalidInput() {
 		super.handleInvalidInput();
 		eraseSourceFeedback();
@@ -426,6 +440,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleKeyDown(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyDown(KeyEvent e) {
 		setAutoexposeHelper(null);
 		if (acceptArrowKey(e)) {
@@ -471,6 +486,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleKeyUp(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyUp(KeyEvent e) {
 		if (acceptArrowKey(e)) {
 			accStepReset();
@@ -542,6 +558,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	/**
 	 * @see org.eclipse.gef.tools.TargetingTool#setAutoexposeHelper(org.eclipse.gef.AutoexposeHelper)
 	 */
+	@Override
 	protected void setAutoexposeHelper(AutoexposeHelper helper) {
 		super.setAutoexposeHelper(helper);
 		if (helper != null && sourceRelativeStartPoint == null && isInDragInProgress()) {
@@ -569,6 +586,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#setTargetEditPart(org.eclipse.gef.EditPart)
 	 */
+	@Override
 	protected void setTargetEditPart(EditPart editpart) {
 		if (getTargetEditPart() == editpart)
 			return;
@@ -597,6 +615,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#setState(int)
 	 */
+	@Override
 	protected void setState(int state) {
 		boolean check = isInState(STATE_INITIAL);
 		super.setState(state);
@@ -619,6 +638,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.TargetingTool#updateTargetRequest()
 	 */
+	@Override
 	protected void updateTargetRequest() {
 		repairStartLocation();
 		ChangeBoundsRequest request = (ChangeBoundsRequest) getTargetRequest();

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DragTreeItemsTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DragTreeItemsTracker.java
@@ -32,6 +32,7 @@ public class DragTreeItemsTracker extends SelectEditPartTracker {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Tree Tracker: " + getCommandName();//$NON-NLS-1$
 	}
@@ -41,6 +42,7 @@ public class DragTreeItemsTracker extends SelectEditPartTracker {
 	 * 
 	 * @see org.eclipse.gef.tools.SelectEditPartTracker#performSelection()
 	 */
+	@Override
 	protected void performSelection() {
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeDragTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeDragTracker.java
@@ -21,6 +21,7 @@ public class MarqueeDragTracker extends MarqueeSelectionTool implements DragTrac
 	 * Called when the mouse button is released. Overridden to do nothing, since a
 	 * drag tracker does not need to unload when finished.
 	 */
+	@Override
 	protected void handleFinished() {
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
@@ -121,6 +121,7 @@ public class MarqueeSelectionTool extends AbstractTool {
 
 			if (schedulePaint) {
 				Display.getCurrent().timerExec(DELAY, new Runnable() {
+					@Override
 					public void run() {
 						offset++;
 						if (offset > 5)
@@ -389,6 +390,7 @@ public class MarqueeSelectionTool extends AbstractTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		return REQ_SELECTION;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/PanningSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/PanningSelectionTool.java
@@ -55,6 +55,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Panning Tool";//$NON-NLS-1$
 	}
@@ -62,6 +63,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugNameForState(int)
 	 */
+	@Override
 	protected String getDebugNameForState(int state) {
 		if (state == PAN)
 			return "Pan Initial"; //$NON-NLS-1$
@@ -76,6 +78,7 @@ public class PanningSelectionTool extends SelectionTool {
 	 * @see #setDefaultCursor(Cursor)
 	 * @return the default cursor
 	 */
+	@Override
 	protected Cursor getDefaultCursor() {
 		if (isInState(PAN | PAN_IN_PROGRESS))
 			return SharedCursors.HAND;
@@ -85,6 +88,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.SelectionTool#handleButtonDown(int)
 	 */
+	@Override
 	protected boolean handleButtonDown(int which) {
 		if (which == 1 && getCurrentViewer().getControl() instanceof FigureCanvas
 				&& stateTransition(PAN, PAN_IN_PROGRESS)) {
@@ -97,6 +101,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.SelectionTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int which) {
 		if (which == 1 && isSpaceBarDown && stateTransition(PAN_IN_PROGRESS, PAN))
 			return true;
@@ -111,6 +116,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDrag()
 	 */
+	@Override
 	protected boolean handleDrag() {
 		if (isInState(PAN_IN_PROGRESS) && getCurrentViewer().getControl() instanceof FigureCanvas) {
 			FigureCanvas canvas = (FigureCanvas) getCurrentViewer().getControl();
@@ -124,6 +130,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.SelectionTool#handleFocusLost()
 	 */
+	@Override
 	protected boolean handleFocusLost() {
 		if (isInState(PAN | PAN_IN_PROGRESS)) {
 			setState(STATE_INITIAL);
@@ -136,6 +143,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.SelectionTool#handleKeyDown(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyDown(KeyEvent e) {
 		if (acceptSpaceBar(e)) {
 			isSpaceBarDown = true;
@@ -157,6 +165,7 @@ public class PanningSelectionTool extends SelectionTool {
 	/**
 	 * @see org.eclipse.gef.tools.SelectionTool#handleKeyUp(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyUp(KeyEvent e) {
 		if (acceptSpaceBar(e)) {
 			isSpaceBarDown = false;

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
@@ -197,6 +197,7 @@ public class ResizeTracker extends SimpleDragTracker {
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		return REQ_RESIZE;
 	}
@@ -293,6 +294,7 @@ public class ResizeTracker extends SimpleDragTracker {
 	/**
 	 * @see org.eclipse.gef.tools.SimpleDragTracker#updateSourceRequest()
 	 */
+	@Override
 	protected void updateSourceRequest() {
 		ChangeBoundsRequest request = (ChangeBoundsRequest) getSourceRequest();
 		Dimension d = getDragMoveDelta();

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/SelectEditPartTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/SelectEditPartTracker.java
@@ -50,6 +50,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#calculateCursor()
 	 */
+	@Override
 	protected Cursor calculateCursor() {
 		if (isInState(STATE_INITIAL | STATE_DRAG | STATE_ACCESSIBLE_DRAG))
 			return getDefaultCursor();
@@ -59,6 +60,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		return "Select Tracker";//$NON-NLS-1$
 	}
@@ -66,6 +68,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Select Tracker";//$NON-NLS-1$
 	}
@@ -86,6 +89,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonDown(int)
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		if ((button == 3 || button == 1) && isInState(STATE_INITIAL))
 			performConditionalSelection();
@@ -109,6 +113,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (isInState(STATE_DRAG)) {
 			performSelection();
@@ -127,6 +132,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDoubleClick(int)
 	 */
+	@Override
 	protected boolean handleDoubleClick(int button) {
 		setFlag(FLAG_ENABLE_DIRECT_EDIT, false);
 		if (button == 1) {
@@ -140,6 +146,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragStarted()
 	 */
+	@Override
 	protected boolean handleDragStarted() {
 		return stateTransition(STATE_DRAG, STATE_DRAG_IN_PROGRESS);
 	}
@@ -221,6 +228,7 @@ public class SelectEditPartTracker extends TargetingTool implements DragTracker 
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#resetFlags()
 	 */
+	@Override
 	protected void resetFlags() {
 		super.resetFlags();
 		setFlag(FLAG_SELECTION_PERFORMED, false);

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/SelectionTool.java
@@ -83,6 +83,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see TargetingTool#createTargetRequest()
 	 */
+	@Override
 	protected Request createTargetRequest() {
 		SelectionRequest request = new SelectionRequest();
 		request.setType(getCommandName());
@@ -94,6 +95,7 @@ public class SelectionTool extends TargetingTool {
 	 * another tool. Use this method to do some clean-up when the tool is switched.
 	 * Sets the drag tracker to <code>null</code>.
 	 */
+	@Override
 	public void deactivate() {
 		setDragTracker(null); // deactivates the current drag tracker
 		super.deactivate();
@@ -114,6 +116,7 @@ public class SelectionTool extends TargetingTool {
 	/**
 	 * @see AbstractTool#getCommandName()
 	 */
+	@Override
 	protected String getCommandName() {
 		return REQ_SELECTION;
 	}
@@ -121,6 +124,7 @@ public class SelectionTool extends TargetingTool {
 	/**
 	 * @see AbstractTool#getDebugName()
 	 */
+	@Override
 	protected String getDebugName() {
 		return "Selection Tool";//$NON-NLS-1$
 	}
@@ -146,8 +150,10 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see TargetingTool#getTargetingConditional()
 	 */
+	@Override
 	protected EditPartViewer.Conditional getTargetingConditional() {
 		return new EditPartViewer.Conditional() {
+			@Override
 			public boolean evaluate(EditPart editpart) {
 				EditPart targetEditPart = editpart.getTargetEditPart(getTargetRequest());
 				return targetEditPart != null && targetEditPart.isSelectable();
@@ -174,6 +180,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleButtonDown(int)
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		if (!stateTransition(STATE_INITIAL, STATE_DRAG)) {
 			resetHover();
@@ -210,6 +217,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (getCurrentInput().isAnyButtonDown())
 			return false;
@@ -223,6 +231,7 @@ public class SelectionTool extends TargetingTool {
 	/**
 	 * @see AbstractTool#handleCommandStackChanged()
 	 */
+	@Override
 	protected boolean handleCommandStackChanged() {
 		if (getDragTracker() == null)
 			return super.handleCommandStackChanged();
@@ -235,6 +244,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleFocusLost()
 	 */
+	@Override
 	protected boolean handleFocusLost() {
 		if (isInState(
 				STATE_ACCESSIBLE_DRAG | STATE_ACCESSIBLE_DRAG_IN_PROGRESS | STATE_DRAG | STATE_DRAG_IN_PROGRESS)) {
@@ -251,6 +261,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleHover()
 	 */
+	@Override
 	protected boolean handleHover() {
 		setHoverActive(true);
 		showHoverFeedback();
@@ -263,6 +274,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see TargetingTool#handleHoverStop()
 	 */
+	@Override
 	protected boolean handleHoverStop() {
 		eraseHoverFeedback();
 		return true;
@@ -277,6 +289,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleKeyDown(KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyDown(KeyEvent e) {
 		resetHover();
 
@@ -331,6 +344,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleKeyUp(KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyUp(KeyEvent e) {
 		if (isInState(STATE_INITIAL) && getCurrentViewer().getKeyHandler() != null
 				&& getCurrentViewer().getKeyHandler().keyReleased(e))
@@ -347,6 +361,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleMove()
 	 */
+	@Override
 	protected boolean handleMove() {
 		if (stateTransition(STATE_ACCESSIBLE_DRAG, STATE_INITIAL))
 			setDragTracker(null);
@@ -378,6 +393,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleNativeDragFinished(DragSourceEvent)
 	 */
+	@Override
 	public boolean handleNativeDragFinished(DragSourceEvent event) {
 		if (getDragTracker() != null)
 			getDragTracker().nativeDragFinished(event, getCurrentViewer());
@@ -391,6 +407,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleNativeDragStarted(DragSourceEvent)
 	 */
+	@Override
 	public boolean handleNativeDragStarted(DragSourceEvent event) {
 		if (getDragTracker() != null)
 			getDragTracker().nativeDragStarted(event, getCurrentViewer());
@@ -453,6 +470,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#handleViewerExited()
 	 */
+	@Override
 	protected boolean handleViewerExited() {
 		if (isInState(STATE_ACCESSIBLE_DRAG | STATE_ACCESSIBLE_DRAG_IN_PROGRESS | STATE_TRAVERSE_HANDLE | STATE_DRAG
 				| STATE_DRAG_IN_PROGRESS)) {
@@ -468,6 +486,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.Tool#keyDown(KeyEvent, org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void keyDown(KeyEvent evt, EditPartViewer viewer) {
 		if (getDragTracker() != null)
 			getDragTracker().keyDown(evt, viewer);
@@ -479,6 +498,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.Tool#keyUp(KeyEvent, org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void keyUp(KeyEvent evt, EditPartViewer viewer) {
 		if (getDragTracker() != null)
 			getDragTracker().keyUp(evt, viewer);
@@ -491,6 +511,7 @@ public class SelectionTool extends TargetingTool {
 	 * @see org.eclipse.gef.Tool#mouseDown(MouseEvent,
 	 *      org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseDown(MouseEvent e, EditPartViewer viewer) {
 		super.mouseDown(e, viewer);
 		if (getDragTracker() != null)
@@ -503,6 +524,7 @@ public class SelectionTool extends TargetingTool {
 	 * @see org.eclipse.gef.Tool#mouseDoubleClick(MouseEvent,
 	 *      org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseDoubleClick(MouseEvent e, EditPartViewer viewer) {
 		super.mouseDoubleClick(e, viewer);
 		if (getDragTracker() != null)
@@ -515,6 +537,7 @@ public class SelectionTool extends TargetingTool {
 	 * @see org.eclipse.gef.Tool#mouseDrag(MouseEvent,
 	 *      org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseDrag(MouseEvent e, EditPartViewer viewer) {
 		if (getDragTracker() != null)
 			getDragTracker().mouseDrag(e, viewer);
@@ -527,6 +550,7 @@ public class SelectionTool extends TargetingTool {
 	 * @see org.eclipse.gef.Tool#mouseHover(MouseEvent,
 	 *      org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseHover(MouseEvent me, EditPartViewer viewer) {
 		if (getDragTracker() != null)
 			getDragTracker().mouseHover(me, viewer);
@@ -539,6 +563,7 @@ public class SelectionTool extends TargetingTool {
 	 * @see org.eclipse.gef.Tool#mouseMove(MouseEvent,
 	 *      org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseMove(MouseEvent me, EditPartViewer viewer) {
 		if (getDragTracker() != null)
 			getDragTracker().mouseMove(me, viewer);
@@ -550,6 +575,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see org.eclipse.gef.Tool#mouseUp(MouseEvent, org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseUp(MouseEvent e, EditPartViewer viewer) {
 		if (getDragTracker() != null)
 			getDragTracker().mouseUp(e, viewer);
@@ -563,6 +589,7 @@ public class SelectionTool extends TargetingTool {
 	 * @see org.eclipse.gef.Tool#mouseWheelScrolled(org.eclipse.swt.widgets.Event,
 	 *      org.eclipse.gef.EditPartViewer)
 	 */
+	@Override
 	public void mouseWheelScrolled(Event event, EditPartViewer viewer) {
 		if (getDragTracker() != null) {
 			getDragTracker().mouseWheelScrolled(event, viewer);
@@ -577,6 +604,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see AbstractTool#refreshCursor()
 	 */
+	@Override
 	protected void refreshCursor() {
 		// If we have a DragTracker, let it control the Cursor
 		if (getDragTracker() == null)
@@ -642,6 +670,7 @@ public class SelectionTool extends TargetingTool {
 	 * 
 	 * @see TargetingTool#updateTargetRequest()
 	 */
+	@Override
 	protected void updateTargetRequest() {
 		SelectionRequest request = (SelectionRequest) getTargetRequest();
 		request.setModifiers(getCurrentInput().getModifiers());
@@ -653,6 +682,7 @@ public class SelectionTool extends TargetingTool {
 	/**
 	 * @see AbstractTool#getDebugNameForState(int)
 	 */
+	@Override
 	protected String getDebugNameForState(int state) {
 		if (state == STATE_TRAVERSE_HANDLE)
 			return "Traverse Handle"; //$NON-NLS-1$

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/SimpleDragTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/SimpleDragTracker.java
@@ -45,6 +45,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#calculateCursor()
 	 */
+	@Override
 	protected Cursor calculateCursor() {
 		if (isInState(STATE_INITIAL | STATE_DRAG | STATE_ACCESSIBLE_DRAG))
 			return getDefaultCursor();
@@ -54,6 +55,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	/**
 	 * @see DragTracker#commitDrag()
 	 */
+	@Override
 	public void commitDrag() {
 		eraseSourceFeedback();
 		performDrag();
@@ -72,6 +74,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.Tool#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		eraseSourceFeedback();
 		sourceRequest = null;
@@ -109,6 +112,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonDown(int)
 	 */
+	@Override
 	protected boolean handleButtonDown(int button) {
 		if (button != 1) {
 			setState(STATE_INVALID);
@@ -123,6 +127,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleButtonUp(int)
 	 */
+	@Override
 	protected boolean handleButtonUp(int button) {
 		if (stateTransition(STATE_DRAG_IN_PROGRESS, STATE_TERMINAL)) {
 			eraseSourceFeedback();
@@ -134,6 +139,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragInProgress()
 	 */
+	@Override
 	protected boolean handleDragInProgress() {
 		if (isInDragInProgress()) {
 			updateSourceRequest();
@@ -148,6 +154,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleDragStarted()
 	 */
+	@Override
 	protected boolean handleDragStarted() {
 		return stateTransition(STATE_DRAG, STATE_DRAG_IN_PROGRESS);
 	}
@@ -157,6 +164,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	 * 
 	 * @return <code>true</code>
 	 */
+	@Override
 	protected boolean handleInvalidInput() {
 		eraseSourceFeedback();
 		setCurrentCommand(UnexecutableCommand.INSTANCE);
@@ -168,6 +176,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleKeyDown(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyDown(KeyEvent e) {
 		if (acceptArrowKey(e)) {
 			accStepIncrement();
@@ -201,6 +210,7 @@ public abstract class SimpleDragTracker extends AbstractTool implements DragTrac
 	/**
 	 * @see org.eclipse.gef.tools.AbstractTool#handleKeyUp(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	protected boolean handleKeyUp(KeyEvent e) {
 		if (acceptArrowKey(e)) {
 			accStepReset();

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/TargetingTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/TargetingTool.java
@@ -71,6 +71,7 @@ public abstract class TargetingTool extends AbstractTool {
 	/**
 	 * @see org.eclipse.gef.Tool#deactivate()
 	 */
+	@Override
 	public void deactivate() {
 		if (isHoverActive())
 			resetHover();
@@ -118,6 +119,7 @@ public abstract class TargetingTool extends AbstractTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#getCommand()
 	 */
+	@Override
 	protected Command getCommand() {
 		if (getTargetEditPart() == null)
 			return null;
@@ -149,6 +151,7 @@ public abstract class TargetingTool extends AbstractTool {
 	 */
 	protected EditPartViewer.Conditional getTargetingConditional() {
 		return new EditPartViewer.Conditional() {
+			@Override
 			public boolean evaluate(EditPart editpart) {
 				return editpart.getTargetEditPart(getTargetRequest()) != null;
 			}
@@ -232,6 +235,7 @@ public abstract class TargetingTool extends AbstractTool {
 	 * 
 	 * @return <code>true</code>
 	 */
+	@Override
 	protected boolean handleInvalidInput() {
 		eraseTargetFeedback();
 		setCurrentCommand(UnexecutableCommand.INSTANCE);
@@ -251,6 +255,7 @@ public abstract class TargetingTool extends AbstractTool {
 	 * 
 	 * @see org.eclipse.gef.tools.AbstractTool#handleViewerExited()
 	 */
+	@Override
 	protected boolean handleViewerExited() {
 		setTargetEditPart(null);
 		return true;
@@ -296,6 +301,7 @@ public abstract class TargetingTool extends AbstractTool {
 	 * @see org.eclipse.gef.tools.AbstractTool#resetFlags()
 	 * @see #lockTargetEditPart(EditPart)
 	 */
+	@Override
 	protected void resetFlags() {
 		setFlag(FLAG_LOCK_TARGET, false);
 		super.resetFlags();
@@ -313,6 +319,7 @@ public abstract class TargetingTool extends AbstractTool {
 	}
 
 	class QueuedAutoexpose implements Runnable {
+		@Override
 		public void run() {
 			if (exposeHelper != null)
 				doAutoexpose();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ActionBarContributor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ActionBarContributor.java
@@ -101,6 +101,7 @@ public abstract class ActionBarContributor extends EditorActionBarContributor {
 	 * 
 	 * @see org.eclipse.ui.part.EditorActionBarContributor#dispose()
 	 */
+	@Override
 	public void dispose() {
 		for (int i = 0; i < retargetActions.size(); i++) {
 			RetargetAction action = (RetargetAction) retargetActions.get(i);
@@ -134,6 +135,7 @@ public abstract class ActionBarContributor extends EditorActionBarContributor {
 	/**
 	 * @see EditorActionBarContributor#init(IActionBars)
 	 */
+	@Override
 	public void init(IActionBars bars) {
 		buildActions();
 		declareGlobalActionKeys();
@@ -143,6 +145,7 @@ public abstract class ActionBarContributor extends EditorActionBarContributor {
 	/**
 	 * @see org.eclipse.ui.IEditorActionBarContributor#setActiveEditor(IEditorPart)
 	 */
+	@Override
 	public void setActiveEditor(IEditorPart editor) {
 		ActionRegistry registry = editor.getAdapter(ActionRegistry.class);
 		IActionBars bars = getActionBars();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentAction.java
@@ -122,6 +122,7 @@ public final class AlignmentAction extends SelectionAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#calculateEnabled()
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		operationSet = null;
 		Command cmd = createAlignmentCommand();
@@ -150,6 +151,7 @@ public final class AlignmentAction extends SelectionAction {
 	/**
 	 * @see org.eclipse.gef.Disposable#dispose()
 	 */
+	@Override
 	public void dispose() {
 		operationSet = Collections.EMPTY_LIST;
 		super.dispose();
@@ -239,6 +241,7 @@ public final class AlignmentAction extends SelectionAction {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		operationSet = null;
 		execute(createAlignmentCommand());

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/Clipboard.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/Clipboard.java
@@ -32,10 +32,12 @@ public class Clipboard {
 		private final String TYPE_NAME = "org.eclipse.gef.clipboard.transfer"; //$NON-NLS-1$
 		private final int TYPE_ID = registerType(TYPE_NAME);
 
+		@Override
 		protected int[] getTypeIds() {
 			return new int[] { TYPE_ID };
 		}
 
+		@Override
 		protected String[] getTypeNames() {
 			return new String[] { TYPE_NAME };
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyTemplateAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyTemplateAction.java
@@ -51,6 +51,7 @@ public class CopyTemplateAction extends WorkbenchPartAction implements ISelectio
 	 * 
 	 * @return whether the selected EditPart is a TemplateEditPart
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		return template != null;
 	}
@@ -58,6 +59,7 @@ public class CopyTemplateAction extends WorkbenchPartAction implements ISelectio
 	/**
 	 * @see org.eclipse.gef.ui.actions.EditorPartAction#dispose()
 	 */
+	@Override
 	public void dispose() {
 		template = null;
 	}
@@ -66,6 +68,7 @@ public class CopyTemplateAction extends WorkbenchPartAction implements ISelectio
 	 * Sets the default {@link Clipboard Clipboard's} contents to be the currently
 	 * selected template.
 	 */
+	@Override
 	public void run() {
 		Clipboard.getDefault().setContents(template);
 	}
@@ -75,6 +78,7 @@ public class CopyTemplateAction extends WorkbenchPartAction implements ISelectio
 	 * 
 	 * @see ISelectionChangedListener#selectionChanged(SelectionChangedEvent)
 	 */
+	@Override
 	public void selectionChanged(SelectionChangedEvent event) {
 		ISelection s = event.getSelection();
 		if (!(s instanceof IStructuredSelection))

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CreateGuideAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CreateGuideAction.java
@@ -45,6 +45,7 @@ public class CreateGuideAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		RulerProvider provider = ((RulerEditPart) viewer.getRootEditPart().getChildren().get(0)).getRulerProvider();
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DeleteAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DeleteAction.java
@@ -70,6 +70,7 @@ public class DeleteAction extends SelectionAction {
 	 * 
 	 * @return <code>true</code> if the command should be enabled
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		Command cmd = createDeleteCommand(getSelectedObjects());
 		if (cmd == null)
@@ -106,6 +107,7 @@ public class DeleteAction extends SelectionAction {
 	/**
 	 * Initializes this action's text and images.
 	 */
+	@Override
 	protected void init() {
 		super.init();
 		setText(GEFMessages.DeleteAction_Label);
@@ -120,6 +122,7 @@ public class DeleteAction extends SelectionAction {
 	/**
 	 * Performs the delete action on the selected objects.
 	 */
+	@Override
 	public void run() {
 		execute(createDeleteCommand(getSelectedObjects()));
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DirectEditAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DirectEditAction.java
@@ -70,6 +70,7 @@ public class DirectEditAction extends SelectionAction {
 	 * 
 	 * @return <code>true</code> if enabled
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		if (getSelectedObjects().size() == 1 && (getSelectedObjects().get(0) instanceof EditPart)) {
 			EditPart part = (EditPart) getSelectedObjects().get(0);
@@ -90,6 +91,7 @@ public class DirectEditAction extends SelectionAction {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		try {
 			EditPart part = (EditPart) getSelectedObjects().get(0);
@@ -113,6 +115,7 @@ public class DirectEditAction extends SelectionAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#init()
 	 */
+	@Override
 	protected void init() {
 		super.init();
 		setText(GEFMessages.RenameAction_Label);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchHeightAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchHeightAction.java
@@ -47,6 +47,7 @@ public class MatchHeightAction extends MatchSizeAction {
 	 *                             EditPart's Figure
 	 * @return 0.
 	 */
+	@Override
 	protected double getPreciseWidthDelta(PrecisionRectangle precisePartBounds,
 			PrecisionRectangle precisePrimaryBounds) {
 		return 0;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchSizeAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchSizeAction.java
@@ -52,6 +52,7 @@ public class MatchSizeAction extends SelectionAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#calculateEnabled()
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		Command cmd = createMatchSizeCommand(getSelectedObjects());
 		if (cmd == null)
@@ -155,6 +156,7 @@ public class MatchSizeAction extends SelectionAction {
 	 * viewer, and matching the size of the selected EditPart's Figures to that of
 	 * the Primary Selection's Figure.
 	 */
+	@Override
 	public void run() {
 		execute(createMatchSizeCommand(getSelectedObjects()));
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchWidthAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/MatchWidthAction.java
@@ -47,6 +47,7 @@ public class MatchWidthAction extends MatchSizeAction {
 	 *                             EditPart's Figure
 	 * @return 0.
 	 */
+	@Override
 	protected double getPreciseHeightDelta(PrecisionRectangle precisePartBounds,
 			PrecisionRectangle precisePrimaryBounds) {
 		return 0;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteTemplateAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteTemplateAction.java
@@ -49,6 +49,7 @@ public class PasteTemplateAction extends SelectionAction {
 	 *         executable command
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#calculateEnabled()
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		// TODO Workaround for Bug 82622/39369. Should be removed when 39369 is
 		// fixed.
@@ -125,6 +126,7 @@ public class PasteTemplateAction extends SelectionAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.EditorPartAction#init()
 	 */
+	@Override
 	protected void init() {
 		setId(ActionFactory.PASTE.getId());
 		setText(GEFMessages.PasteAction_Label);
@@ -133,6 +135,7 @@ public class PasteTemplateAction extends SelectionAction {
 	/**
 	 * Executes the command returned by {@link #createPasteCommand()}.
 	 */
+	@Override
 	public void run() {
 		execute(createPasteCommand());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PrintAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PrintAction.java
@@ -40,6 +40,7 @@ public class PrintAction extends WorkbenchPartAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#calculateEnabled()
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		PrinterData[] printers = Printer.getPrinterList();
 		return printers != null && printers.length > 0;
@@ -48,6 +49,7 @@ public class PrintAction extends WorkbenchPartAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.EditorPartAction#init()
 	 */
+	@Override
 	protected void init() {
 		super.init();
 		setText(GEFMessages.PrintAction_Label);
@@ -58,6 +60,7 @@ public class PrintAction extends WorkbenchPartAction {
 	/**
 	 * @see org.eclipse.jface.action.Action#run()
 	 */
+	@Override
 	public void run() {
 		GraphicalViewer viewer = getWorkbenchPart().getAdapter(GraphicalViewer.class);
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/RedoAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/RedoAction.java
@@ -48,6 +48,7 @@ public class RedoAction extends StackAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#calculateEnabled()
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		return getCommandStack().canRedo();
 	}
@@ -55,6 +56,7 @@ public class RedoAction extends StackAction {
 	/**
 	 * Initializes this actions text and images.
 	 */
+	@Override
 	protected void init() {
 		super.init();
 		setToolTipText(MessageFormat.format(GEFMessages.RedoAction_Tooltip, new Object[] { "" }).trim()); //$NON-NLS-1$
@@ -70,6 +72,7 @@ public class RedoAction extends StackAction {
 	/**
 	 * Refreshes this action's text to use the last undone command's label.
 	 */
+	@Override
 	protected void refresh() {
 		Command redoCmd = getCommandStack().getRedoCommand();
 		setToolTipText(MessageFormat
@@ -82,6 +85,7 @@ public class RedoAction extends StackAction {
 	/**
 	 * Redoes the last command.
 	 */
+	@Override
 	public void run() {
 		getCommandStack().redo();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SaveAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SaveAction.java
@@ -33,6 +33,7 @@ public class SaveAction extends EditorPartAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#calculateEnabled()
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		return getEditorPart().isDirty();
 	}
@@ -40,6 +41,7 @@ public class SaveAction extends EditorPartAction {
 	/**
 	 * Initializes this action's text.
 	 */
+	@Override
 	protected void init() {
 		setId(ActionFactory.SAVE.getId());
 		setText(GEFMessages.SaveAction_Label);
@@ -49,6 +51,7 @@ public class SaveAction extends EditorPartAction {
 	/**
 	 * Saves the state of the associated editor.
 	 */
+	@Override
 	public void run() {
 		getEditorPart().getSite().getPage().saveEditor(getEditorPart(), false);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectionAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectionAction.java
@@ -54,6 +54,7 @@ public abstract class SelectionAction extends WorkbenchPartAction {
 	/**
 	 * @see org.eclipse.gef.Disposable#dispose()
 	 */
+	@Override
 	public void dispose() {
 		this.selection = StructuredSelection.EMPTY;
 		super.dispose();
@@ -112,6 +113,7 @@ public abstract class SelectionAction extends WorkbenchPartAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.EditorPartAction#update()
 	 */
+	@Override
 	public void update() {
 		if (provider != null)
 			setSelection(provider.getSelection());

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SetActivePaletteToolAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SetActivePaletteToolAction.java
@@ -46,6 +46,7 @@ public class SetActivePaletteToolAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		if (viewer != null) {
 			viewer.setActiveTool(entry);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ToggleGridAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ToggleGridAction.java
@@ -48,6 +48,7 @@ public class ToggleGridAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#isChecked()
 	 */
+	@Override
 	public boolean isChecked() {
 		Boolean val = (Boolean) diagramViewer.getProperty(SnapToGrid.PROPERTY_GRID_ENABLED);
 		if (val != null)
@@ -58,6 +59,7 @@ public class ToggleGridAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		boolean val = !isChecked();
 		diagramViewer.setProperty(SnapToGrid.PROPERTY_GRID_VISIBLE, Boolean.valueOf(val));

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ToggleRulerVisibilityAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ToggleRulerVisibilityAction.java
@@ -50,6 +50,7 @@ public class ToggleRulerVisibilityAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#isChecked()
 	 */
+	@Override
 	public boolean isChecked() {
 		Boolean val = ((Boolean) diagramViewer.getProperty(RulerProvider.PROPERTY_RULER_VISIBILITY));
 		if (val != null)
@@ -60,6 +61,7 @@ public class ToggleRulerVisibilityAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		diagramViewer.setProperty(RulerProvider.PROPERTY_RULER_VISIBILITY, Boolean.valueOf(!isChecked()));
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ToggleSnapToGeometryAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ToggleSnapToGeometryAction.java
@@ -47,6 +47,7 @@ public class ToggleSnapToGeometryAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#isChecked()
 	 */
+	@Override
 	public boolean isChecked() {
 		Boolean val = (Boolean) diagramViewer.getProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED);
 		if (val != null)
@@ -57,6 +58,7 @@ public class ToggleSnapToGeometryAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		diagramViewer.setProperty(SnapToGeometry.PROPERTY_SNAP_ENABLED, Boolean.valueOf(!isChecked()));
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/UndoAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/UndoAction.java
@@ -47,6 +47,7 @@ public class UndoAction extends StackAction {
 	/**
 	 * @see org.eclipse.gef.ui.actions.WorkbenchPartAction#calculateEnabled()
 	 */
+	@Override
 	protected boolean calculateEnabled() {
 		return getCommandStack().canUndo();
 	}
@@ -54,6 +55,7 @@ public class UndoAction extends StackAction {
 	/**
 	 * Initializes this action's text and images.
 	 */
+	@Override
 	protected void init() {
 		super.init();
 		setToolTipText(MessageFormat.format(GEFMessages.UndoAction_Tooltip, new Object[] { "" }).trim()); //$NON-NLS-1$
@@ -69,6 +71,7 @@ public class UndoAction extends StackAction {
 	/**
 	 * Refreshes this action's text to use the last executed command's label.
 	 */
+	@Override
 	protected void refresh() {
 		Command undoCmd = getCommandStack().getUndoCommand();
 		setToolTipText(MessageFormat
@@ -81,6 +84,7 @@ public class UndoAction extends StackAction {
 	/**
 	 * Undoes the last command.
 	 */
+	@Override
 	public void run() {
 		getCommandStack().undo();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/WorkbenchPartAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/WorkbenchPartAction.java
@@ -62,6 +62,7 @@ public abstract class WorkbenchPartAction extends Action implements Disposable, 
 	/**
 	 * Disposes the action when it is no longer needed.
 	 */
+	@Override
 	public void dispose() {
 	}
 
@@ -113,6 +114,7 @@ public abstract class WorkbenchPartAction extends Action implements Disposable, 
 	 * @see #setLazyEnablementCalculation(boolean)
 	 * @return <code>true</code> if the action is enabled
 	 */
+	@Override
 	public boolean isEnabled() {
 		if (lazyEnablement)
 			setEnabled(calculateEnabled());
@@ -162,6 +164,7 @@ public abstract class WorkbenchPartAction extends Action implements Disposable, 
 	/**
 	 * @see UpdateAction#update()
 	 */
+	@Override
 	public void update() {
 		refresh();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomAction.java
@@ -49,6 +49,7 @@ abstract class ZoomAction extends Action implements ZoomListener, Disposable {
 	/**
 	 * @see org.eclipse.gef.Disposable#dispose()
 	 */
+	@Override
 	public void dispose() {
 		zoomManager.removeZoomListener(this);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomComboContributionItem.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomComboContributionItem.java
@@ -79,19 +79,24 @@ public class ZoomComboContributionItem extends ContributionItem implements ZoomL
 		service = partService;
 		Assert.isNotNull(partService);
 		partService.addPartListener(partListener = new IPartListener() {
+			@Override
 			public void partActivated(IWorkbenchPart part) {
 				setZoomManager(part.getAdapter(ZoomManager.class));
 			}
 
+			@Override
 			public void partBroughtToTop(IWorkbenchPart p) {
 			}
 
+			@Override
 			public void partClosed(IWorkbenchPart p) {
 			}
 
+			@Override
 			public void partDeactivated(IWorkbenchPart p) {
 			}
 
+			@Override
 			public void partOpened(IWorkbenchPart p) {
 			}
 		});
@@ -142,19 +147,23 @@ public class ZoomComboContributionItem extends ContributionItem implements ZoomL
 	protected Control createControl(Composite parent) {
 		combo = new Combo(parent, SWT.DROP_DOWN);
 		combo.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				handleWidgetSelected(e);
 			}
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 				handleWidgetDefaultSelected(e);
 			}
 		});
 		combo.addFocusListener(new FocusListener() {
+			@Override
 			public void focusGained(FocusEvent e) {
 				// do nothing
 			}
 
+			@Override
 			public void focusLost(FocusEvent e) {
 				refresh(false);
 			}
@@ -170,6 +179,7 @@ public class ZoomComboContributionItem extends ContributionItem implements ZoomL
 	/**
 	 * @see org.eclipse.jface.action.ContributionItem#dispose()
 	 */
+	@Override
 	public void dispose() {
 		if (partListener == null)
 			return;
@@ -189,6 +199,7 @@ public class ZoomComboContributionItem extends ContributionItem implements ZoomL
 	 * 
 	 * @param parent The parent of the control to fill
 	 */
+	@Override
 	public final void fill(Composite parent) {
 		createControl(parent);
 	}
@@ -200,6 +211,7 @@ public class ZoomComboContributionItem extends ContributionItem implements ZoomL
 	 * @param parent The menu
 	 * @param index  Menu index
 	 */
+	@Override
 	public final void fill(Menu parent, int index) {
 		Assert.isTrue(false, "Can't add a control to a menu");//$NON-NLS-1$
 	}
@@ -214,6 +226,7 @@ public class ZoomComboContributionItem extends ContributionItem implements ZoomL
 	 * @param parent The ToolBar to add the new control to
 	 * @param index  Index
 	 */
+	@Override
 	public void fill(ToolBar parent, int index) {
 		toolitem = new ToolItem(parent, SWT.SEPARATOR, index);
 		Control control = createControl(parent);
@@ -282,6 +295,7 @@ public class ZoomComboContributionItem extends ContributionItem implements ZoomL
 	/**
 	 * @see ZoomListener#zoomChanged(double)
 	 */
+	@Override
 	public void zoomChanged(double zoom) {
 		refresh(false);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomInAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomInAction.java
@@ -34,6 +34,7 @@ public class ZoomInAction extends ZoomAction {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		zoomManager.zoomIn();
 	}
@@ -41,6 +42,7 @@ public class ZoomInAction extends ZoomAction {
 	/**
 	 * @see org.eclipse.gef.editparts.ZoomListener#zoomChanged(double)
 	 */
+	@Override
 	public void zoomChanged(double zoom) {
 		setEnabled(zoomManager.canZoomIn());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomOutAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/ZoomOutAction.java
@@ -34,6 +34,7 @@ public class ZoomOutAction extends ZoomAction {
 	/**
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		zoomManager.zoomOut();
 	}
@@ -41,6 +42,7 @@ public class ZoomOutAction extends ZoomAction {
 	/**
 	 * @see org.eclipse.gef.editparts.ZoomListener#zoomChanged(double)
 	 */
+	@Override
 	public void zoomChanged(double zoom) {
 		setEnabled(zoomManager.canZoomOut());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/console/DebugGEF.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/console/DebugGEF.java
@@ -46,6 +46,7 @@ public class DebugGEF extends ViewPart {
 	/**
 	 * @see org.eclipse.ui.IWorkbenchPart#createPartControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public void createPartControl(Composite parent) {
 		text = new Text(parent, SWT.V_SCROLL | SWT.MULTI | SWT.BORDER);
 		text.setFont(new org.eclipse.swt.graphics.Font(parent.getDisplay(), "Arial", 7, //$NON-NLS-1$
@@ -59,6 +60,7 @@ public class DebugGEF extends ViewPart {
 	/**
 	 * @see org.eclipse.ui.part.WorkbenchPart#dispose()
 	 */
+	@Override
 	public void dispose() {
 		GEF.setConsole(null);
 		super.dispose();
@@ -128,6 +130,7 @@ public class DebugGEF extends ViewPart {
 	/**
 	 * @see org.eclipse.ui.IWorkbenchPart#setFocus()
 	 */
+	@Override
 	public void setFocus() {
 		if (text != null)
 			text.setFocus();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/console/DebugGEFAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/console/DebugGEFAction.java
@@ -54,6 +54,7 @@ public class DebugGEFAction extends Action {
 	/**
 	 * @see Action#run()
 	 */
+	@Override
 	public void run() {
 		String type = getText();
 		if (type.compareTo(DEBUG_STATES) == 0) {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/ChangeIconSizeAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/ChangeIconSizeAction.java
@@ -39,6 +39,7 @@ public class ChangeIconSizeAction extends Action {
 	 * 
 	 * @see org.eclipse.jface.action.Action#run()
 	 */
+	@Override
 	public void run() {
 		prefs.setCurrentUseLargeIcons(!prefs.useLargeIcons());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/CustomizeAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/CustomizeAction.java
@@ -44,6 +44,7 @@ public class CustomizeAction extends Action {
 	 * 
 	 * @see org.eclipse.jface.action.IAction#run()
 	 */
+	@Override
 	public void run() {
 		PaletteCustomizerDialog dialog = paletteViewer.getCustomizerDialog();
 		List list = paletteViewer.getSelectedEditParts();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/DefaultPaletteViewerPreferences.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/DefaultPaletteViewerPreferences.java
@@ -79,6 +79,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 		store.addPropertyChangeListener(listener);
 
 		fontListener = new IPropertyChangeListener() {
+			@Override
 			public void propertyChange(PropertyChangeEvent event) {
 				if (JFaceResources.DIALOG_FONT.equals(event.getProperty())) {
 					if (getPreferenceStore().getString(PREFERENCE_FONT).equals(DEFAULT_FONT)) {
@@ -97,6 +98,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	 * 
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#addPropertyChangeListener(PropertyChangeListener)
 	 */
+	@Override
 	public void addPropertyChangeListener(PropertyChangeListener listener) {
 		listeners.addPropertyChangeListener(listener);
 	}
@@ -181,6 +183,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#getAutoCollapseSetting()
 	 */
+	@Override
 	public int getAutoCollapseSetting() {
 		return getPreferenceStore().getInt(PREFERENCE_AUTO_COLLAPSE);
 	}
@@ -188,6 +191,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#getFontData()
 	 */
+	@Override
 	public FontData getFontData() {
 		if (fontData == null) {
 			String value = getPreferenceStore().getString(PREFERENCE_FONT);
@@ -203,6 +207,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#getLayoutSetting()
 	 */
+	@Override
 	public int getLayoutSetting() {
 		return getPreferenceStore().getInt(PREFERENCE_LAYOUT);
 	}
@@ -210,6 +215,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#getSupportedLayoutModes()
 	 */
+	@Override
 	public int[] getSupportedLayoutModes() {
 		return supportedModes;
 	}
@@ -242,6 +248,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#isSupportedLayoutMode(int)
 	 */
+	@Override
 	public boolean isSupportedLayoutMode(int layout) {
 		for (int i = 0; i < supportedModes.length; i++) {
 			if (supportedModes[i] == layout) {
@@ -254,6 +261,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#removePropertyChangeListener(PropertyChangeListener)
 	 */
+	@Override
 	public void removePropertyChangeListener(PropertyChangeListener listener) {
 		listeners.removePropertyChangeListener(listener);
 	}
@@ -261,6 +269,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#setAutoCollapseSetting(int)
 	 */
+	@Override
 	public void setAutoCollapseSetting(int newVal) {
 		getPreferenceStore().setValue(PREFERENCE_AUTO_COLLAPSE, newVal);
 	}
@@ -268,6 +277,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#setFontData(FontData)
 	 */
+	@Override
 	public void setFontData(FontData data) {
 		fontData = data;
 		String value = data.toString();
@@ -280,6 +290,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#setLayoutSetting(int)
 	 */
+	@Override
 	public void setLayoutSetting(int newVal) {
 		getPreferenceStore().setValue(PREFERENCE_LAYOUT, newVal);
 	}
@@ -287,6 +298,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#setCurrentUseLargeIcons(boolean)
 	 */
+	@Override
 	public void setCurrentUseLargeIcons(boolean newVal) {
 		setUseLargeIcons(getLayoutSetting(), newVal);
 	}
@@ -300,6 +312,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	 * 
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#setSupportedLayoutModes(int[])
 	 */
+	@Override
 	public void setSupportedLayoutModes(int[] modes) {
 		supportedModes = modes;
 		if (!isSupportedLayoutMode(getPreferenceStore().getDefaultInt(PREFERENCE_LAYOUT))) {
@@ -314,6 +327,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#setUseLargeIcons(int,
 	 *      boolean)
 	 */
+	@Override
 	public void setUseLargeIcons(int layout, boolean newVal) {
 		getPreferenceStore().setValue(convertLayoutToPreferenceName(layout), newVal);
 	}
@@ -321,6 +335,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#useLargeIcons(int)
 	 */
+	@Override
 	public boolean useLargeIcons(int layout) {
 		return getPreferenceStore().getBoolean(convertLayoutToPreferenceName(layout));
 	}
@@ -328,6 +343,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 	/**
 	 * @see org.eclipse.gef.ui.palette.PaletteViewerPreferences#useLargeIcons()
 	 */
+	@Override
 	public boolean useLargeIcons() {
 		return useLargeIcons(getLayoutSetting());
 	}
@@ -336,6 +352,7 @@ public class DefaultPaletteViewerPreferences implements PaletteViewerPreferences
 		/**
 		 * @see org.eclipse.jface.util.IPropertyChangeListener#propertyChange(org.eclipse.jface.util.PropertyChangeEvent)
 		 */
+		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			handlePreferenceStorePropertyChanged(evt.getProperty());
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -160,10 +160,12 @@ public class FlyoutPaletteComposite extends Composite {
 	private int cachedTitleHeight = 24; // give it a default value
 
 	private IPerspectiveListener perspectiveListener = new IPerspectiveListener() {
+		@Override
 		public void perspectiveActivated(IWorkbenchPage page, IPerspectiveDescriptor perspective) {
 			handlePerspectiveActivated(page, perspective);
 		}
 
+		@Override
 		public void perspectiveChanged(IWorkbenchPage page, IPerspectiveDescriptor perspective, String changeId) {
 			handlePerspectiveChanged(page, perspective, changeId);
 		}
@@ -197,6 +199,7 @@ public class FlyoutPaletteComposite extends Composite {
 		updateState(page);
 
 		addListener(SWT.Resize, new Listener() {
+			@Override
 			public void handleEvent(Event event) {
 				Rectangle area = getClientArea();
 				/*
@@ -210,6 +213,7 @@ public class FlyoutPaletteComposite extends Composite {
 		});
 
 		listeners.addPropertyChangeListener(new PropertyChangeListener() {
+			@Override
 			public void propertyChange(PropertyChangeEvent evt) {
 				String property = evt.getPropertyName();
 				if (property.equals(PROPERTY_PALETTE_WIDTH))
@@ -326,6 +330,7 @@ public class FlyoutPaletteComposite extends Composite {
 	/**
 	 * @see Composite#layout(boolean)
 	 */
+	@Override
 	public void layout(boolean changed) {
 		if (graphicalControl == null || graphicalControl.isDisposed())
 			return;
@@ -423,6 +428,7 @@ public class FlyoutPaletteComposite extends Composite {
 	private void hookIntoWorkbench(final IWorkbenchWindow window) {
 		window.addPerspectiveListener(perspectiveListener);
 		addDisposeListener(new DisposeListener() {
+			@Override
 			public void widgetDisposed(DisposeEvent e) {
 				window.removePerspectiveListener(perspectiveListener);
 				perspectiveListener = null;
@@ -495,10 +501,12 @@ public class FlyoutPaletteComposite extends Composite {
 		Assert.isTrue(graphicalControl == null);
 		graphicalControl = graphicalViewer;
 		addListenerToCtrlHierarchy(graphicalControl, SWT.MouseEnter, new Listener() {
+			@Override
 			public void handleEvent(Event event) {
 				if (!isInState(STATE_EXPANDED))
 					return;
 				Display.getCurrent().timerExec(250, new Runnable() {
+					@Override
 					public void run() {
 						if (isDescendantOf(graphicalControl, Display.getCurrent().getCursorControl())
 								&& isInState(STATE_EXPANDED))
@@ -524,28 +532,36 @@ public class FlyoutPaletteComposite extends Composite {
 	 */
 	public void hookDropTargetListener(GraphicalViewer viewer) {
 		viewer.addDropTargetListener(new TransferDropTargetListener() {
+			@Override
 			public void dragEnter(DropTargetEvent event) {
 			}
 
+			@Override
 			public void dragLeave(DropTargetEvent event) {
 			}
 
+			@Override
 			public void dragOperationChanged(DropTargetEvent event) {
 			}
 
+			@Override
 			public void dragOver(DropTargetEvent event) {
 			}
 
+			@Override
 			public void drop(DropTargetEvent event) {
 			}
 
+			@Override
 			public void dropAccept(DropTargetEvent event) {
 			}
 
+			@Override
 			public Transfer getTransfer() {
 				return TemplateTransfer.getInstance();
 			}
 
+			@Override
 			public boolean isEnabled(DropTargetEvent event) {
 				if (isInState(STATE_EXPANDED))
 					setState(STATE_COLLAPSED);
@@ -700,6 +716,7 @@ public class FlyoutPaletteComposite extends Composite {
 			new SashDragManager();
 
 			addMouseTrackListener(new MouseTrackAdapter() {
+				@Override
 				public void mouseHover(MouseEvent e) {
 					if (isInState(STATE_COLLAPSED))
 						setState(STATE_EXPANDED);
@@ -707,18 +724,21 @@ public class FlyoutPaletteComposite extends Composite {
 			});
 
 			addListener(SWT.Paint, new Listener() {
+				@Override
 				public void handleEvent(Event event) {
 					paintSash(event.gc);
 				}
 			});
 
 			addListener(SWT.Resize, new Listener() {
+				@Override
 				public void handleEvent(Event event) {
 					layout(true);
 				}
 			});
 
 			listeners.addPropertyChangeListener(new PropertyChangeListener() {
+				@Override
 				public void propertyChange(PropertyChangeEvent evt) {
 					if (evt.getPropertyName().equals(PROPERTY_STATE))
 						updateState();
@@ -726,6 +746,7 @@ public class FlyoutPaletteComposite extends Composite {
 			});
 		}
 
+		@Override
 		public Point computeSize(int wHint, int hHint, boolean changed) {
 			if (isInState(STATE_PINNED_OPEN))
 				return new Point(3, 3);
@@ -740,6 +761,7 @@ public class FlyoutPaletteComposite extends Composite {
 			setPaletteWidth(newSize);
 		}
 
+		@Override
 		public void layout(boolean changed) {
 			if (button == null)
 				return;
@@ -796,6 +818,7 @@ public class FlyoutPaletteComposite extends Composite {
 			protected boolean mouseDown = false;
 			protected int origX;
 			protected Listener keyListener = new Listener() {
+				@Override
 				public void handleEvent(Event event) {
 					if (event.keyCode == SWT.ALT || event.keyCode == SWT.ESC) {
 						dragging = false;
@@ -811,6 +834,7 @@ public class FlyoutPaletteComposite extends Composite {
 				Sash.this.addMouseListener(this);
 			}
 
+			@Override
 			public void mouseDown(MouseEvent me) {
 				if (me.button != 1)
 					return;
@@ -820,6 +844,7 @@ public class FlyoutPaletteComposite extends Composite {
 				Display.getCurrent().addFilter(SWT.KeyDown, keyListener);
 			}
 
+			@Override
 			public void mouseMove(MouseEvent me) {
 				if (mouseDown)
 					dragging = true;
@@ -827,6 +852,7 @@ public class FlyoutPaletteComposite extends Composite {
 					handleSashDragged(me.x - origX);
 			}
 
+			@Override
 			public void mouseUp(MouseEvent me) {
 				Display.getCurrent().removeFilter(SWT.KeyDown, keyListener);
 				if (!dragging && me.button == 1) {
@@ -847,10 +873,12 @@ public class FlyoutPaletteComposite extends Composite {
 			super(PaletteMessages.RESIZE_LABEL);
 		}
 
+		@Override
 		public boolean isEnabled() {
 			return !isInState(STATE_COLLAPSED);
 		}
 
+		@Override
 		public void run() {
 			final Tracker tracker = new Tracker(FlyoutPaletteComposite.this, SWT.RIGHT | SWT.LEFT);
 			Rectangle[] rects = new Rectangle[1];
@@ -878,6 +906,7 @@ public class FlyoutPaletteComposite extends Composite {
 			ctrl.addMouseTrackListener(this);
 		}
 
+		@Override
 		public void handleEvent(Event event) {
 			dragging = true;
 			switchDock = false;
@@ -893,8 +922,10 @@ public class FlyoutPaletteComposite extends Composite {
 			tracker.setRectangles(new Rectangle[] { origBounds });
 			tracker.setStippled(true);
 			tracker.addListener(SWT.Move, new Listener() {
+				@Override
 				public void handleEvent(final Event evt) {
 					Display.getCurrent().syncExec(new Runnable() {
+						@Override
 						public void run() {
 							Control ctrl = Display.getCurrent().getCursorControl();
 							Point pt = flyout.toControl(evt.x, evt.y);
@@ -956,12 +987,15 @@ public class FlyoutPaletteComposite extends Composite {
 			tracker.dispose();
 		}
 
+		@Override
 		public void mouseEnter(MouseEvent e) {
 		}
 
+		@Override
 		public void mouseExit(MouseEvent e) {
 		}
 
+		@Override
 		public void mouseHover(MouseEvent e) {
 			/*
 			 * @TODO:Pratik Mouse hover events are received if the hover occurs just before
@@ -971,6 +1005,7 @@ public class FlyoutPaletteComposite extends Composite {
 				setState(STATE_EXPANDED);
 		}
 
+		@Override
 		public void mouseUp(MouseEvent me) {
 			if (me.button != 1)
 				return;
@@ -989,6 +1024,7 @@ public class FlyoutPaletteComposite extends Composite {
 			createComponents();
 
 			listeners.addPropertyChangeListener(new PropertyChangeListener() {
+				@Override
 				public void propertyChange(PropertyChangeEvent evt) {
 					if (evt.getPropertyName().equals(PROPERTY_STATE))
 						updateState();
@@ -999,6 +1035,7 @@ public class FlyoutPaletteComposite extends Composite {
 			});
 
 			addListener(SWT.Resize, new Listener() {
+				@Override
 				public void handleEvent(Event event) {
 					layout(true);
 				}
@@ -1012,6 +1049,7 @@ public class FlyoutPaletteComposite extends Composite {
 			button = createFlyoutControlButton(this);
 		}
 
+		@Override
 		public void layout(boolean changed) {
 			Control pCtrl = getPaletteViewerControl();
 			if (pCtrl == null || pCtrl.isDisposed())
@@ -1063,12 +1101,14 @@ public class FlyoutPaletteComposite extends Composite {
 			setForegroundColor(ColorConstants.listForeground);
 		}
 
+		@Override
 		public IFigure getToolTip() {
 			if (isTextTruncated())
 				return super.getToolTip();
 			return null;
 		}
 
+		@Override
 		protected void paintFigure(Graphics graphics) {
 
 			// paint the gradient
@@ -1108,6 +1148,7 @@ public class FlyoutPaletteComposite extends Composite {
 			provideAccSupport();
 		}
 
+		@Override
 		public Point computeSize(int wHint, int hHint, boolean changed) {
 			Dimension size = lws.getRootFigure().getPreferredSize(wHint, hHint);
 			size.union(new Dimension(wHint, hHint));
@@ -1143,6 +1184,7 @@ public class FlyoutPaletteComposite extends Composite {
 			b.setRolloverEnabled(true);
 			b.setBorder(new ButtonBorder(ButtonBorder.SCHEMES.TOOLBAR));
 			b.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent event) {
 					transferFocus = true;
 					if (isInState(STATE_COLLAPSED))
@@ -1152,6 +1194,7 @@ public class FlyoutPaletteComposite extends Composite {
 				}
 			});
 			listeners.addPropertyChangeListener(new PropertyChangeListener() {
+				@Override
 				public void propertyChange(PropertyChangeEvent evt) {
 					if (evt.getPropertyName().equals(PROPERTY_STATE)) {
 						b.setDirection(getArrowDirection());
@@ -1165,19 +1208,23 @@ public class FlyoutPaletteComposite extends Composite {
 
 		private void provideAccSupport() {
 			getAccessible().addAccessibleListener(new AccessibleAdapter() {
+				@Override
 				public void getDescription(AccessibleEvent e) {
 					e.result = PaletteMessages.ACC_DESC_PALETTE_BUTTON;
 				}
 
+				@Override
 				public void getHelp(AccessibleEvent e) {
 					getDescription(e);
 				}
 
+				@Override
 				public void getName(AccessibleEvent e) {
 					e.result = getToolTipText();
 				}
 			});
 			getAccessible().addAccessibleControlListener(new AccessibleControlAdapter() {
+				@Override
 				public void getRole(AccessibleControlEvent e) {
 					e.detail = ACC.ROLE_PUSHBUTTON;
 				}
@@ -1211,6 +1258,7 @@ public class FlyoutPaletteComposite extends Composite {
 				}
 			}
 
+			@Override
 			protected void layout() {
 				org.eclipse.draw2d.geometry.Rectangle clientArea = getBounds();
 
@@ -1219,6 +1267,7 @@ public class FlyoutPaletteComposite extends Composite {
 						ARROW_SIZE));
 			}
 
+			@Override
 			protected void paintFigure(Graphics graphics) {
 				super.paintFigure(graphics);
 
@@ -1250,6 +1299,7 @@ public class FlyoutPaletteComposite extends Composite {
 		/**
 		 * @see org.eclipse.swt.widgets.Control#computeSize(int, int, boolean)
 		 */
+		@Override
 		public Point computeSize(int wHint, int hHint, boolean changed) {
 			Dimension size = lws.getRootFigure().getPreferredSize(wHint, hHint);
 			size.union(new Dimension(wHint, hHint));
@@ -1261,10 +1311,12 @@ public class FlyoutPaletteComposite extends Composite {
 			contents.setRequestFocusEnabled(true);
 			contents.setFocusTraversable(true);
 			contents.addFocusListener(new FocusListener() {
+				@Override
 				public void focusGained(FocusEvent fe) {
 					fe.gainer.repaint();
 				}
 
+				@Override
 				public void focusLost(FocusEvent fe) {
 					fe.loser.repaint();
 				}
@@ -1284,6 +1336,7 @@ public class FlyoutPaletteComposite extends Composite {
 			manager.add(mgr);
 			setMenu(manager.createContextMenu(this));
 			mgr.addMenuListener(new IMenuListener() {
+				@Override
 				public void menuAboutToShow(IMenuManager menuMgr) {
 					IContributionItem[] items = menuMgr.getItems();
 					for (int i = 0; i < items.length; i++) {
@@ -1293,6 +1346,7 @@ public class FlyoutPaletteComposite extends Composite {
 			});
 
 			addDisposeListener(new DisposeListener() {
+				@Override
 				public void widgetDisposed(DisposeEvent e) {
 					FONT_MGR.unregister(TitleCanvas.this);
 					manager.dispose();
@@ -1302,19 +1356,23 @@ public class FlyoutPaletteComposite extends Composite {
 
 		private void provideAccSupport() {
 			getAccessible().addAccessibleListener(new AccessibleAdapter() {
+				@Override
 				public void getDescription(AccessibleEvent e) {
 					e.result = PaletteMessages.ACC_DESC_PALETTE_TITLE;
 				}
 
+				@Override
 				public void getHelp(AccessibleEvent e) {
 					getDescription(e);
 				}
 
+				@Override
 				public void getName(AccessibleEvent e) {
 					e.result = GEFMessages.Palette_Label;
 				}
 			});
 			getAccessible().addAccessibleControlListener(new AccessibleControlAdapter() {
+				@Override
 				public void getRole(AccessibleControlEvent e) {
 					e.detail = ACC.ROLE_LABEL;
 				}
@@ -1358,6 +1416,7 @@ public class FlyoutPaletteComposite extends Composite {
 		 * 
 		 * @see org.eclipse.jface.action.IAction#isChecked()
 		 */
+		@Override
 		public boolean isChecked() {
 			return dock == position;
 		}
@@ -1367,6 +1426,7 @@ public class FlyoutPaletteComposite extends Composite {
 		 * 
 		 * @see org.eclipse.jface.action.IAction#run()
 		 */
+		@Override
 		public void run() {
 			setDockLocation(position);
 		}
@@ -1377,6 +1437,7 @@ public class FlyoutPaletteComposite extends Composite {
 		private List registrants = new ArrayList();
 		private Font titleFont;
 		private final IPropertyChangeListener fontListener = new IPropertyChangeListener() {
+			@Override
 			public void propertyChange(org.eclipse.jface.util.PropertyChangeEvent event) {
 				if (fontName.equals(event.getProperty()))
 					handleFontChanged();
@@ -1450,26 +1511,32 @@ public class FlyoutPaletteComposite extends Composite {
 			prefs = preferences;
 		}
 
+		@Override
 		public int getDockLocation() {
 			return prefs.getInt(PALETTE_DOCK_LOCATION);
 		}
 
+		@Override
 		public int getPaletteState() {
 			return prefs.getInt(PALETTE_STATE);
 		}
 
+		@Override
 		public int getPaletteWidth() {
 			return prefs.getInt(PALETTE_SIZE);
 		}
 
+		@Override
 		public void setDockLocation(int location) {
 			prefs.setValue(PALETTE_DOCK_LOCATION, location);
 		}
 
+		@Override
 		public void setPaletteState(int state) {
 			prefs.setValue(PALETTE_STATE, state);
 		}
 
+		@Override
 		public void setPaletteWidth(int width) {
 			prefs.setValue(PALETTE_SIZE, width);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/LayoutAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/LayoutAction.java
@@ -117,6 +117,7 @@ public class LayoutAction extends Action implements IMenuCreator {
 	 * 
 	 * @see org.eclipse.jface.action.IMenuCreator#dispose()
 	 */
+	@Override
 	public void dispose() {
 	}
 
@@ -135,6 +136,7 @@ public class LayoutAction extends Action implements IMenuCreator {
 	/**
 	 * @see org.eclipse.jface.action.IMenuCreator#getMenu(Control)
 	 */
+	@Override
 	public Menu getMenu(Control parent) {
 		return fillMenu(new Menu(parent));
 	}
@@ -142,6 +144,7 @@ public class LayoutAction extends Action implements IMenuCreator {
 	/**
 	 * @see org.eclipse.jface.action.IMenuCreator#getMenu(Menu)
 	 */
+	@Override
 	public Menu getMenu(Menu parent) {
 		return fillMenu(new Menu(parent));
 	}
@@ -157,6 +160,7 @@ public class LayoutAction extends Action implements IMenuCreator {
 			return value;
 		}
 
+		@Override
 		public void run() {
 			prefs.setLayoutSetting(value);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteContextMenuProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteContextMenuProvider.java
@@ -48,6 +48,7 @@ public class PaletteContextMenuProvider extends ContextMenuProvider {
 	 *             can be added.
 	 * @see ContextMenuProvider#buildContextMenu(org.eclipse.jface.action.IMenuManager)
 	 */
+	@Override
 	public void buildContextMenu(IMenuManager menu) {
 		GEFActionConstants.addStandardActionGroups(menu);
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteEditPartFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteEditPartFactory.java
@@ -53,6 +53,7 @@ public class PaletteEditPartFactory implements EditPartFactory {
 	/**
 	 * @see org.eclipse.gef.EditPartFactory#createEditPart(EditPart, Object)
 	 */
+	@Override
 	public EditPart createEditPart(EditPart parentEditPart, Object model) {
 		if (model instanceof PaletteRoot)
 			return createMainPaletteEditPart(parentEditPart, model);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
@@ -56,6 +56,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 		/**
 		 * @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent)
 		 */
+		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			String property = evt.getPropertyName();
 			EditPart root = getRootEditPart().getContents();
@@ -114,6 +115,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	/**
 	 * @see org.eclipse.gef.ui.parts.GraphicalViewerImpl#createDefaultRoot()
 	 */
+	@Override
 	protected void createDefaultRoot() {
 		setRootEditPart(new SimpleRootEditPart());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PinDrawerAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PinDrawerAction.java
@@ -55,6 +55,7 @@ public class PinDrawerAction extends Action {
 	 * 
 	 * @see org.eclipse.jface.action.Action#run()
 	 */
+	@Override
 	public void run() {
 		pinnableEditPart.setPinnedOpen(!pinnableEditPart.isPinnedOpen());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/SettingsAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/SettingsAction.java
@@ -40,6 +40,7 @@ public class SettingsAction extends Action {
 	 * 
 	 * @see org.eclipse.jface.action.Action#run()
 	 */
+	@Override
 	public void run() {
 		Dialog settings = new PaletteSettingsDialog(paletteViewer.getControl().getShell(),
 				paletteViewer.getPaletteViewerPreferences());

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/DefaultEntryPage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/DefaultEntryPage.java
@@ -59,6 +59,7 @@ public class DefaultEntryPage implements EntryPage {
 	 * keystroke. So, there is no need to wait for this method to be called to
 	 * actually make the changes to the model.
 	 */
+	@Override
 	public final void apply() {
 	}
 
@@ -66,6 +67,7 @@ public class DefaultEntryPage implements EntryPage {
 	 * @see org.eclipse.gef.ui.palette.customize.EntryPage#createControl(Composite,
 	 *      PaletteEntry)
 	 */
+	@Override
 	public void createControl(Composite parent, PaletteEntry entry) {
 		this.entry = entry;
 
@@ -105,6 +107,7 @@ public class DefaultEntryPage implements EntryPage {
 		description.setLayoutData(data);
 		if (getPermission() >= PaletteEntry.PERMISSION_LIMITED_MODIFICATION) {
 			description.addModifyListener(new ModifyListener() {
+				@Override
 				public void modifyText(ModifyEvent e) {
 					handleDescriptionChanged(((Text) e.getSource()).getText());
 				}
@@ -130,6 +133,7 @@ public class DefaultEntryPage implements EntryPage {
 			hidden.setEnabled(false);
 		} else {
 			hidden.addSelectionListener(new SelectionAdapter() {
+				@Override
 				public void widgetSelected(SelectionEvent e) {
 					handleHiddenSelected(((Button) e.getSource()).getSelection());
 				}
@@ -164,6 +168,7 @@ public class DefaultEntryPage implements EntryPage {
 		Text name = createText(panel, SWT.SINGLE | SWT.BORDER, entry.getLabel());
 		if (getPermission() >= PaletteEntry.PERMISSION_LIMITED_MODIFICATION) {
 			name.addModifyListener(new ModifyListener() {
+				@Override
 				public void modifyText(ModifyEvent e) {
 					handleNameChanged(((Text) e.getSource()).getText());
 				}
@@ -200,6 +205,7 @@ public class DefaultEntryPage implements EntryPage {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.EntryPage#getControl()
 	 */
+	@Override
 	public Control getControl() {
 		return panel;
 	}
@@ -288,6 +294,7 @@ public class DefaultEntryPage implements EntryPage {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.EntryPage#setPageContainer(EntryPageContainer)
 	 */
+	@Override
 	public void setPageContainer(EntryPageContainer pageContainer) {
 		container = pageContainer;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/DrawerEntryPage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/DrawerEntryPage.java
@@ -44,6 +44,7 @@ public class DrawerEntryPage extends DefaultEntryPage {
 	 * @see org.eclipse.gef.ui.palette.customize.EntryPage#createControl(Composite,
 	 *      PaletteEntry)
 	 */
+	@Override
 	public void createControl(Composite parent, PaletteEntry entry) {
 		super.createControl(parent, entry);
 
@@ -77,6 +78,7 @@ public class DrawerEntryPage extends DefaultEntryPage {
 		b.setSelection(getDrawer().isInitiallyOpen());
 		if (getPermission() >= PaletteEntry.PERMISSION_LIMITED_MODIFICATION) {
 			b.addSelectionListener(new SelectionAdapter() {
+				@Override
 				public void widgetSelected(SelectionEvent e) {
 					handleOpenSelected(((Button) e.getSource()).getSelection());
 				}
@@ -106,6 +108,7 @@ public class DrawerEntryPage extends DefaultEntryPage {
 		pinOption.setSelection(getDrawer().isInitiallyPinned());
 		if (getPermission() >= PaletteEntry.PERMISSION_LIMITED_MODIFICATION) {
 			pinOption.addSelectionListener(new SelectionAdapter() {
+				@Override
 				public void widgetSelected(SelectionEvent e) {
 					handlePinSelected(((Button) e.getSource()).getSelection());
 				}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteContainerFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteContainerFactory.java
@@ -32,6 +32,7 @@ public abstract class PaletteContainerFactory extends PaletteEntryFactory {
 	/**
 	 * @see PaletteEntryFactory#determineContainerForNewEntry(PaletteEntry)
 	 */
+	@Override
 	protected PaletteContainer determineContainerForNewEntry(PaletteEntry selected) {
 		if (selected instanceof PaletteRoot)
 			return (PaletteContainer) selected;
@@ -45,6 +46,7 @@ public abstract class PaletteContainerFactory extends PaletteEntryFactory {
 	 * @see PaletteEntryFactory#determineIndexForNewEntry(PaletteContainer,
 	 *      PaletteEntry)
 	 */
+	@Override
 	protected int determineIndexForNewEntry(PaletteContainer parent, PaletteEntry selected) {
 		if (parent == selected) {
 			return 0;
@@ -63,6 +65,7 @@ public abstract class PaletteContainerFactory extends PaletteEntryFactory {
 	 * 
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#canCreate(PaletteEntry)
 	 */
+	@Override
 	public boolean canCreate(PaletteEntry selected) {
 		return true;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizationAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizationAction.java
@@ -34,6 +34,7 @@ public abstract class PaletteCustomizationAction extends Action {
 	/**
 	 * @see org.eclipse.jface.action.Action#setImageDescriptor(ImageDescriptor)
 	 */
+	@Override
 	public void setImageDescriptor(ImageDescriptor newImage) {
 		super.setImageDescriptor(newImage);
 		setHoverImageDescriptor(newImage);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizerDialog.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizerDialog.java
@@ -140,6 +140,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	private PaletteEntry initialSelection;
 	private PaletteRoot root;
 	private PropertyChangeListener titleUpdater = new PropertyChangeListener() {
+		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			if (title == null) {
 				return;
@@ -149,6 +150,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 		}
 	};
 	private ISelectionChangedListener pageFlippingPreventer = new ISelectionChangedListener() {
+		@Override
 		public void selectionChanged(SelectionChangedEvent event) {
 			treeviewer.removePostSelectionChangedListener(this);
 			treeviewer.setSelection(new StructuredSelection(activeEntry));
@@ -177,6 +179,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	 * 
 	 * @see Dialog#buttonPressed(int)
 	 */
+	@Override
 	protected void buttonPressed(int buttonId) {
 		if (APPLY_ID == buttonId) {
 			handleApplyPressed();
@@ -194,6 +197,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	 * @see org.eclipse.gef.ui.palette.customize.EntryPageContainer#clearProblem()
 	 * @see #showProblem(String)
 	 */
+	@Override
 	public void clearProblem() {
 		if (errorMessage != null) {
 			titleSwitcher.showPage(titlePage);
@@ -210,6 +214,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	 * 
 	 * @see org.eclipse.jface.window.Window#close()
 	 */
+	@Override
 	public boolean close() {
 		// Remove listeners
 		if (activeEntry != null) {
@@ -256,6 +261,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	/**
 	 * @see org.eclipse.jface.window.Window#configureShell(Shell)
 	 */
+	@Override
 	protected void configureShell(Shell newShell) {
 		newShell.setText(PaletteMessages.CUSTOMIZE_DIALOG_TITLE);
 		super.configureShell(newShell);
@@ -291,6 +297,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 
 		button.setData(Integer.valueOf(id));
 		button.addSelectionListener(new SelectionAdapter() {
+			@Override
 			public void widgetSelected(SelectionEvent event) {
 				buttonPressed(((Integer) event.widget.getData()).intValue());
 			}
@@ -300,6 +307,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 		if (descriptor != null) {
 			button.setImage(new Image(parent.getDisplay(), descriptor.getImageData()));
 			button.addDisposeListener(new DisposeListener() {
+				@Override
 				public void widgetDisposed(DisposeEvent e) {
 					Image img = ((Button) e.getSource()).getImage();
 					if (img != null && !img.isDisposed()) {
@@ -317,6 +325,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	 * 
 	 * @see org.eclipse.jface.dialogs.Dialog#createButtonsForButtonBar(Composite)
 	 */
+	@Override
 	protected void createButtonsForButtonBar(Composite parent) {
 		super.createButtonsForButtonBar(parent);
 		createButton(parent, APPLY_ID, PaletteMessages.APPLY_LABEL, false);
@@ -337,6 +346,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	 * 
 	 * @see org.eclipse.jface.dialogs.Dialog#createDialogArea(Composite)
 	 */
+	@Override
 	protected Control createDialogArea(Composite parent) {
 		Composite composite = (Composite) super.createDialogArea(parent);
 		GridLayout gridLayout = (GridLayout) composite.getLayout();
@@ -460,6 +470,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			IAction action = (IAction) iter.next();
 			if (action instanceof IMenuCreator)
 				outlineMenu.add(new ActionContributionItem(action) {
+					@Override
 					public boolean isDynamic() {
 						return true;
 					}
@@ -473,6 +484,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 		}
 
 		outlineMenu.addMenuListener(new IMenuListener() {
+			@Override
 			public void menuAboutToShow(IMenuManager manager) {
 				outlineMenu.update(true);
 			}
@@ -493,6 +505,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	protected Control createOutlineToolBar(Composite parent) {
 		// A customized composite for the toolbar
 		final Composite composite = new Composite(parent, SWT.NONE) {
+			@Override
 			public Rectangle getClientArea() {
 				Rectangle area = super.getClientArea();
 				area.x += 2;
@@ -502,6 +515,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 				return area;
 			}
 
+			@Override
 			public Point computeSize(int wHint, int hHint, boolean changed) {
 				Point size = super.computeSize(wHint, hHint, changed);
 				size.x += 4;
@@ -514,6 +528,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 
 		// A paint listener that draws an etched border around the toolbar
 		composite.addPaintListener(new PaintListener() {
+			@Override
 			public void paintControl(PaintEvent e) {
 				Rectangle area = composite.getBounds();
 				GC gc = e.gc;
@@ -566,6 +581,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 		data.heightHint = 200;
 		treeForViewer.setLayoutData(data);
 		TreeViewer viewer = new TreeViewer(treeForViewer) {
+			@Override
 			protected void preservingSelection(Runnable updateCode) {
 				if ((getTree().getStyle() & SWT.SINGLE) != 0)
 					updateCode.run();
@@ -578,6 +594,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 		viewer.setLabelProvider(treeViewerLabelProvider);
 		viewer.setInput(getPaletteRoot());
 		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
+			@Override
 			public void selectionChanged(SelectionChangedEvent event) {
 				handleOutlineSelectionChanged();
 			}
@@ -619,6 +636,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 		data.horizontalSpan = 2;
 		propertiesPanelContainer.setLayoutData(data);
 		propertiesPanelContainer.addListener(SWT.Resize, new Listener() {
+			@Override
 			public void handleEvent(Event event) {
 				if (activePage != null) {
 					propertiesPanelContainer.layout();
@@ -662,6 +680,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 		layout.verticalSpacing = 0;
 		errorPage.setLayout(layout);
 		Composite intermediary = new Composite(errorPage, SWT.NONE) {
+			@Override
 			public Point computeSize(int wHint, int hHint, boolean changed) {
 				Rectangle bounds = title.getBounds();
 				return new Point(bounds.width, bounds.height);
@@ -703,6 +722,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			titleImage = new Image(composite.getDisplay(),
 					ImageDescriptor.createFromFile(Internal.class, "icons/customizer_dialog_title.gif").getImageData()); //$NON-NLS-1$
 			composite.addDisposeListener(new DisposeListener() {
+				@Override
 				public void widgetDisposed(DisposeEvent e) {
 					titleImage.dispose();
 					titleImage = null;
@@ -728,6 +748,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	 * 
 	 * @see org.eclipse.jface.dialogs.Dialog#getButton(int)
 	 */
+	@Override
 	protected Button getButton(int id) {
 		Button button = null;
 		Widget widget = getWidget(id);
@@ -964,19 +985,23 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 				noSelectionPage = new EntryPage() {
 					private Text text;
 
+					@Override
 					public void apply() {
 					}
 
+					@Override
 					public void createControl(Composite parent, PaletteEntry entry) {
 						text = new Text(parent, SWT.READ_ONLY);
 						text.setFont(parent.getFont());
 						text.setText(PaletteMessages.NO_SELECTION_MADE);
 					}
 
+					@Override
 					public Control getControl() {
 						return text;
 					}
 
+					@Override
 					public void setPageContainer(EntryPageContainer pageContainer) {
 					}
 				};
@@ -1054,6 +1079,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 	 * 
 	 * @see org.eclipse.gef.ui.palette.customize.EntryPageContainer#showProblem(String)
 	 */
+	@Override
 	public void showProblem(String error) {
 		Assert.isNotNull(error);
 		errorTitle.setText(error);
@@ -1087,10 +1113,12 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			setDisabledImageDescriptor(sharedImages.getImageDescriptor(ISharedImages.IMG_TOOL_DELETE_DISABLED));
 		}
 
+		@Override
 		public void run() {
 			handleDelete();
 		}
 
+		@Override
 		public void update() {
 			boolean enabled = false;
 			PaletteEntry entry = getSelectedPaletteEntry();
@@ -1112,10 +1140,12 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			setDisabledImageDescriptor(ImageDescriptor.createFromFile(Internal.class, "icons/move_down_disabled.gif"));//$NON-NLS-1$
 		}
 
+		@Override
 		public void run() {
 			handleMoveDown();
 		}
 
+		@Override
 		public void update() {
 			boolean enabled = false;
 			PaletteEntry entry = getSelectedPaletteEntry();
@@ -1137,10 +1167,12 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			setDisabledImageDescriptor(ImageDescriptor.createFromFile(Internal.class, "icons/move_up_disabled.gif")); //$NON-NLS-1$
 		}
 
+		@Override
 		public void run() {
 			handleMoveUp();
 		}
 
+		@Override
 		public void update() {
 			boolean enabled = false;
 			PaletteEntry entry = getSelectedPaletteEntry();
@@ -1176,6 +1208,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			item.fill(parent, -1);
 		}
 
+		@Override
 		public void dispose() {
 			if (menuMgr != null) {
 				menuMgr.dispose();
@@ -1183,6 +1216,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			}
 		}
 
+		@Override
 		public Menu getMenu(Control parent) {
 			// Create the menu manager and add all the NewActions to it
 			if (menuMgr == null) {
@@ -1195,6 +1229,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			return menuMgr.getMenu();
 		}
 
+		@Override
 		public Menu getMenu(Menu parent) {
 			Menu menu = new Menu(parent);
 			for (Iterator iter = factories.iterator(); iter.hasNext();) {
@@ -1207,9 +1242,11 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			return menu;
 		}
 
+		@Override
 		public void run() {
 		}
 
+		@Override
 		public void update() {
 			boolean enabled = false;
 			PaletteEntry entry = getSelectedPaletteEntry();
@@ -1267,6 +1304,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			return factory.canCreate(entry);
 		}
 
+		@Override
 		public void run() {
 			PaletteEntry selected = getSelectedPaletteEntry();
 			if (selected == null)

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteDrawerFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteDrawerFactory.java
@@ -33,6 +33,7 @@ public class PaletteDrawerFactory extends PaletteContainerFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#createNewEntry(Shell)
 	 */
+	@Override
 	protected PaletteEntry createNewEntry(Shell shell) {
 		PaletteEntry entry = new PaletteDrawer(PaletteMessages.NEW_DRAWER_LABEL);
 		entry.setUserModificationPermission(PaletteEntry.PERMISSION_FULL_MODIFICATION);
@@ -42,6 +43,7 @@ public class PaletteDrawerFactory extends PaletteContainerFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#determineTypeForNewEntry(org.eclipse.gef.palette.PaletteEntry)
 	 */
+	@Override
 	protected Object determineTypeForNewEntry(PaletteEntry selected) {
 		return PaletteDrawer.PALETTE_TYPE_DRAWER;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteGroupFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteGroupFactory.java
@@ -33,6 +33,7 @@ public class PaletteGroupFactory extends PaletteContainerFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#createNewEntry(Shell)
 	 */
+	@Override
 	protected PaletteEntry createNewEntry(Shell shell) {
 		PaletteGroup group = new PaletteGroup(PaletteMessages.NEW_GROUP_LABEL);
 		group.setUserModificationPermission(PaletteEntry.PERMISSION_FULL_MODIFICATION);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteLabelProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteLabelProvider.java
@@ -49,6 +49,7 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	/**
 	 * @see org.eclipse.jface.viewers.IColorProvider#getBackground(Object)
 	 */
+	@Override
 	public Color getBackground(Object element) {
 		return null;
 	}
@@ -65,6 +66,7 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	/**
 	 * @see org.eclipse.jface.viewers.IColorProvider#getForeground(Object)
 	 */
+	@Override
 	public Color getForeground(Object element) {
 		PaletteEntry entry = (PaletteEntry) element;
 		if (!entry.isVisible() || !entry.getParent().isVisible()) {
@@ -76,6 +78,7 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	/**
 	 * @see org.eclipse.jface.viewers.ILabelProvider#getImage(Object)
 	 */
+	@Override
 	public Image getImage(Object element) {
 		PaletteEntry entry = (PaletteEntry) element;
 		ImageDescriptor descriptor = entry.getSmallIcon();
@@ -94,6 +97,7 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	/**
 	 * @see org.eclipse.jface.viewers.ILabelProvider#getText(Object)
 	 */
+	@Override
 	public String getText(Object element) {
 		return ((PaletteEntry) element).getLabel();
 	}
@@ -103,12 +107,14 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	 * 
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#addListener(ILabelProviderListener)
 	 */
+	@Override
 	public void addListener(ILabelProviderListener listener) {
 	}
 
 	/**
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#dispose()
 	 */
+	@Override
 	public void dispose() {
 		Iterator images = imageCache.values().iterator();
 		while (images.hasNext())
@@ -120,6 +126,7 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#isLabelProperty(Object,
 	 *      String)
 	 */
+	@Override
 	public boolean isLabelProperty(Object element, String property) {
 		return false;
 	}
@@ -129,6 +136,7 @@ class PaletteLabelProvider implements ILabelProvider, IColorProvider {
 	 * 
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#removeListener(ILabelProviderListener)
 	 */
+	@Override
 	public void removeListener(ILabelProviderListener listener) {
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteSeparatorFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteSeparatorFactory.java
@@ -34,6 +34,7 @@ public class PaletteSeparatorFactory extends PaletteEntryFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#createNewEntry(Shell)
 	 */
+	@Override
 	public PaletteEntry createNewEntry(Shell shell) {
 		PaletteSeparator separator = new PaletteSeparator();
 		return separator;
@@ -42,6 +43,7 @@ public class PaletteSeparatorFactory extends PaletteEntryFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#determineTypeForNewEntry(org.eclipse.gef.palette.PaletteEntry)
 	 */
+	@Override
 	protected Object determineTypeForNewEntry(PaletteEntry selected) {
 		return PaletteSeparator.PALETTE_TYPE_SEPARATOR;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteSettingsDialog.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteSettingsDialog.java
@@ -112,6 +112,7 @@ public class PaletteSettingsDialog extends Dialog {
 	 * 
 	 * @see Dialog#buttonPressed(int)
 	 */
+	@Override
 	protected void buttonPressed(int buttonId) {
 		Button b = getButton(buttonId);
 
@@ -168,6 +169,7 @@ public class PaletteSettingsDialog extends Dialog {
 	/**
 	 * @see org.eclipse.jface.window.Window#close()
 	 */
+	@Override
 	public boolean close() {
 		// Save or dump changes
 		// This needs to be done here and not in the handle methods because the
@@ -185,6 +187,7 @@ public class PaletteSettingsDialog extends Dialog {
 	/**
 	 * @see org.eclipse.jface.window.Window#configureShell(Shell)
 	 */
+	@Override
 	protected void configureShell(Shell newShell) {
 		newShell.setText(PaletteMessages.SETTINGS_DIALOG_TITLE);
 		super.configureShell(newShell);
@@ -220,6 +223,7 @@ public class PaletteSettingsDialog extends Dialog {
 
 		button.setData(Integer.valueOf(id));
 		button.addSelectionListener(new SelectionAdapter() {
+			@Override
 			public void widgetSelected(SelectionEvent event) {
 				buttonPressed(((Integer) event.widget.getData()).intValue());
 			}
@@ -229,6 +233,7 @@ public class PaletteSettingsDialog extends Dialog {
 		if (descriptor != null) {
 			button.setImage(new Image(parent.getDisplay(), descriptor.getImageData()));
 			button.addDisposeListener(new DisposeListener() {
+				@Override
 				public void widgetDisposed(DisposeEvent e) {
 					Image img = ((Button) e.getSource()).getImage();
 					if (img != null && !img.isDisposed()) {
@@ -306,6 +311,7 @@ public class PaletteSettingsDialog extends Dialog {
 	/**
 	 * @see org.eclipse.jface.dialogs.Dialog#createDialogArea(Composite)
 	 */
+	@Override
 	protected Control createDialogArea(Composite parent) {
 		Composite composite = (Composite) super.createDialogArea(parent);
 		GridLayout layout = (GridLayout) composite.getLayout();
@@ -596,6 +602,7 @@ public class PaletteSettingsDialog extends Dialog {
 	 * 
 	 * @see org.eclipse.jface.dialogs.Dialog#getButton(int)
 	 */
+	@Override
 	protected Button getButton(int id) {
 		Button button = null;
 		Widget widget = getWidget(id);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteStackFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteStackFactory.java
@@ -36,6 +36,7 @@ public class PaletteStackFactory extends PaletteEntryFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#canCreate(org.eclipse.gef.palette.PaletteEntry)
 	 */
+	@Override
 	public boolean canCreate(PaletteEntry selected) {
 		if (!(selected instanceof ToolEntry) || selected.getParent() instanceof PaletteStack)
 			return false;
@@ -45,6 +46,7 @@ public class PaletteStackFactory extends PaletteEntryFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#createNewEntry(Shell)
 	 */
+	@Override
 	protected PaletteEntry createNewEntry(Shell shell) {
 		return new PaletteStack(PaletteMessages.NEW_STACK_LABEL, null, null);
 	}
@@ -53,6 +55,7 @@ public class PaletteStackFactory extends PaletteEntryFactory {
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#createNewEntry(org.eclipse.swt.widgets.Shell,
 	 *      org.eclipse.gef.palette.PaletteEntry)
 	 */
+	@Override
 	public PaletteEntry createNewEntry(Shell shell, PaletteEntry selected) {
 		PaletteContainer parent = determineContainerForNewEntry(selected);
 		int index = determineIndexForNewEntry(parent, selected);
@@ -67,6 +70,7 @@ public class PaletteStackFactory extends PaletteEntryFactory {
 	/**
 	 * @see org.eclipse.gef.ui.palette.customize.PaletteEntryFactory#determineTypeForNewEntry(org.eclipse.gef.palette.PaletteEntry)
 	 */
+	@Override
 	protected Object determineTypeForNewEntry(PaletteEntry selected) {
 		return PaletteStack.PALETTE_TYPE_STACK;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteTreeProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteTreeProvider.java
@@ -37,6 +37,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	private TreeViewer viewer;
 	private PaletteRoot root;
 	private PropertyChangeListener modelListener = new PropertyChangeListener() {
+		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			handlePropertyChanged(evt);
 		}
@@ -57,6 +58,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	 * 
 	 * @see org.eclipse.jface.viewers.IContentProvider#dispose()
 	 */
+	@Override
 	public void dispose() {
 		traverseModel(root, false);
 	}
@@ -68,6 +70,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	 * 
 	 * @see org.eclipse.jface.viewers.ITreeContentProvider#getChildren(Object)
 	 */
+	@Override
 	public Object[] getChildren(Object parentElement) {
 		if (parentElement instanceof PaletteContainer) {
 			List children = ((PaletteContainer) parentElement).getChildren();
@@ -81,6 +84,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	/**
 	 * @see org.eclipse.jface.viewers.ITreeContentProvider#hasChildren(Object)
 	 */
+	@Override
 	public boolean hasChildren(Object element) {
 		return getChildren(element) != null;
 	}
@@ -90,6 +94,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	 * 
 	 * @see org.eclipse.jface.viewers.IStructuredContentProvider#getElements(Object)
 	 */
+	@Override
 	public Object[] getElements(Object inputElement) {
 		Object[] elements = getChildren(inputElement);
 		if (elements == null) {
@@ -101,6 +106,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	/**
 	 * @see org.eclipse.jface.viewers.ITreeContentProvider#getParent(Object)
 	 */
+	@Override
 	public Object getParent(Object element) {
 		return ((PaletteEntry) element).getParent();
 	}
@@ -134,6 +140,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	 * @see org.eclipse.jface.viewers.IContentProvider#inputChanged(Viewer, Object,
 	 *      Object)
 	 */
+	@Override
 	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 		if (root != null)
 			traverseModel(root, false);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteAnimator.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteAnimator.java
@@ -102,6 +102,7 @@ public class PaletteAnimator extends LayoutAnimator {
 	/**
 	 * @see org.eclipse.draw2d.Animator#playbackStarting(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void playbackStarting(IFigure figure) {
 		if (figure instanceof DrawerFigure)
 			((DrawerFigure) figure).setAnimating(true);
@@ -119,6 +120,7 @@ public class PaletteAnimator extends LayoutAnimator {
 	/**
 	 * @see org.eclipse.draw2d.Animator#init(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void init(IFigure figure) {
 		if (figure instanceof DrawerFigure) {
 			DrawerFigure drawer = (DrawerFigure) figure;
@@ -132,6 +134,7 @@ public class PaletteAnimator extends LayoutAnimator {
 	/**
 	 * @see org.eclipse.draw2d.Animator#tearDown(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void tearDown(IFigure figure) {
 		if (figure instanceof DrawerFigure)
 			((DrawerFigure) figure).setAnimating(false);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteToolbarLayout.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteToolbarLayout.java
@@ -42,6 +42,7 @@ public class PaletteToolbarLayout extends ToolbarLayout {
 	/**
 	 * @see org.eclipse.draw2d.ToolbarLayout#layout(org.eclipse.draw2d.IFigure)
 	 */
+	@Override
 	public void layout(IFigure parent) {
 		List<? extends IFigure> children = parent.getChildren();
 		List<IFigure> childrenGrabbingVertical = new ArrayList<>();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -121,12 +121,14 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setSelectionManager(SelectionManager)
 	 */
+	@Override
 	public void setSelectionManager(SelectionManager model) {
 		Assert.isNotNull(model);
 		if (selectionModel != null)
 			selectionModel.internalUninstall();
 		selectionModel = model;
 		model.internalInitialize(this, selection, new Runnable() {
+			@Override
 			public void run() {
 				fireSelectionChanged();
 			}
@@ -138,6 +140,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#addDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener)
 	 */
+	@Override
 	public void addDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener) {
 		addDragSourceListener((TransferDragSourceListener) listener);
 	}
@@ -145,6 +148,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#addDragSourceListener(TransferDragSourceListener)
 	 */
+	@Override
 	public void addDragSourceListener(TransferDragSourceListener listener) {
 		getDelegatingDragAdapter().addDragSourceListener(listener);
 		refreshDragSourceAdapter();
@@ -153,6 +157,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#addDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener)
 	 */
+	@Override
 	public void addDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener) {
 		addDropTargetListener((TransferDropTargetListener) listener);
 	}
@@ -160,6 +165,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#addDropTargetListener(TransferDropTargetListener)
 	 */
+	@Override
 	public void addDropTargetListener(TransferDropTargetListener listener) {
 		getDelegatingDropAdapter().addDropTargetListener(listener);
 		refreshDropTargetAdapter();
@@ -168,6 +174,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#addPropertyChangeListener(PropertyChangeListener)
 	 */
+	@Override
 	public void addPropertyChangeListener(PropertyChangeListener listener) {
 		if (changeSupport == null)
 			changeSupport = new PropertyChangeSupport(this);
@@ -177,6 +184,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see ISelectionProvider#addSelectionChangedListener(ISelectionChangedListener)
 	 */
+	@Override
 	public void addSelectionChangedListener(ISelectionChangedListener listener) {
 		selectionListeners.add(listener);
 	}
@@ -184,6 +192,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#appendSelection(EditPart)
 	 */
+	@Override
 	public void appendSelection(EditPart editpart) {
 		selectionModel.appendSelection(editpart);
 	}
@@ -191,11 +200,13 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#createControl(Composite)
 	 */
+	@Override
 	public abstract Control createControl(Composite parent);
 
 	/**
 	 * @see EditPartViewer#deselect(EditPart)
 	 */
+	@Override
 	public void deselect(EditPart editpart) {
 		selectionModel.deselect(editpart);
 	}
@@ -203,6 +214,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#deselectAll()
 	 */
+	@Override
 	public void deselectAll() {
 		selectionModel.deselectAll();
 	}
@@ -222,6 +234,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#findObjectAt(Point)
 	 */
+	@Override
 	public final EditPart findObjectAt(Point pt) {
 		return findObjectAtExcluding(pt, Collections.emptySet());
 	}
@@ -229,6 +242,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#findObjectAtExcluding(Point, Collection)
 	 */
+	@Override
 	public final EditPart findObjectAtExcluding(Point pt, Collection<IFigure> exclude) {
 		return findObjectAtExcluding(pt, exclude, null);
 	}
@@ -246,12 +260,14 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#flush()
 	 */
+	@Override
 	public void flush() {
 	}
 
 	/**
 	 * @see EditPartViewer#getContextMenu()
 	 */
+	@Override
 	public MenuManager getContextMenu() {
 		return contextMenu;
 	}
@@ -259,6 +275,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getContents()
 	 */
+	@Override
 	public EditPart getContents() {
 		return getRootEditPart().getContents();
 	}
@@ -266,6 +283,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getControl()
 	 */
+	@Override
 	public Control getControl() {
 		return control;
 	}
@@ -317,6 +335,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getEditDomain()
 	 */
+	@Override
 	public EditDomain getEditDomain() {
 		return domain;
 	}
@@ -324,6 +343,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getEditPartFactory()
 	 */
+	@Override
 	public EditPartFactory getEditPartFactory() {
 		return factory;
 	}
@@ -331,6 +351,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getEditPartRegistry()
 	 */
+	@Override
 	public Map getEditPartRegistry() {
 		return mapIDToEditPart;
 	}
@@ -338,6 +359,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getFocusEditPart()
 	 */
+	@Override
 	public EditPart getFocusEditPart() {
 		if (focusPart != null)
 			return focusPart;
@@ -354,6 +376,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getKeyHandler()
 	 */
+	@Override
 	public KeyHandler getKeyHandler() {
 		return keyHandler;
 	}
@@ -361,6 +384,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getProperty(String)
 	 */
+	@Override
 	public Object getProperty(String key) {
 		if (properties != null)
 			return properties.get(key);
@@ -370,6 +394,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see org.eclipse.gef.EditPartViewer#getResourceManager()
 	 */
+	@Override
 	public ResourceManager getResourceManager() {
 		if (resources != null)
 			return resources;
@@ -381,6 +406,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getRootEditPart()
 	 */
+	@Override
 	public RootEditPart getRootEditPart() {
 		return rootEditPart;
 	}
@@ -388,6 +414,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getSelectedEditParts()
 	 */
+	@Override
 	public List getSelectedEditParts() {
 		return constantSelection;
 	}
@@ -399,6 +426,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * 
 	 * @see org.eclipse.jface.viewers.ISelectionProvider#getSelection()
 	 */
+	@Override
 	public ISelection getSelection() {
 		return selectionModel.getSelection();
 	}
@@ -406,6 +434,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getSelectionManager()
 	 */
+	@Override
 	public SelectionManager getSelectionManager() {
 		return selectionModel;
 	}
@@ -413,6 +442,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#getVisualPartMap()
 	 */
+	@Override
 	public Map getVisualPartMap() {
 		return mapVisualToEditPart;
 	}
@@ -427,6 +457,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 		Assert.isTrue(control != null);
 		getSelectionManager().internalHookControl(control);
 		control.addDisposeListener(disposeListener = new DisposeListener() {
+			@Override
 			public void widgetDisposed(DisposeEvent e) {
 				handleDispose(e);
 			}
@@ -515,6 +546,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#registerAccessibleEditPart(AccessibleEditPart)
 	 */
+	@Override
 	public void registerAccessibleEditPart(AccessibleEditPart acc) {
 	}
 
@@ -522,6 +554,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @see EditPartViewer#removeDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener)
 	 * @deprecated
 	 */
+	@Override
 	public void removeDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener) {
 		removeDragSourceListener((TransferDragSourceListener) listener);
 	}
@@ -529,6 +562,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#removeDragSourceListener(TransferDragSourceListener)
 	 */
+	@Override
 	public void removeDragSourceListener(TransferDragSourceListener listener) {
 		getDelegatingDragAdapter().removeDragSourceListener(listener);
 		if (getDelegatingDragAdapter().isEmpty())
@@ -539,6 +573,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @see EditPartViewer#removeDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener)
 	 * @deprecated
 	 */
+	@Override
 	public void removeDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener) {
 		removeDropTargetListener((TransferDropTargetListener) listener);
 	}
@@ -546,6 +581,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#removeDropTargetListener(TransferDropTargetListener)
 	 */
+	@Override
 	public void removeDropTargetListener(TransferDropTargetListener listener) {
 		getDelegatingDropAdapter().removeDropTargetListener(listener);
 		if (getDelegatingDropAdapter().isEmpty())
@@ -555,6 +591,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#removePropertyChangeListener(PropertyChangeListener)
 	 */
+	@Override
 	public void removePropertyChangeListener(PropertyChangeListener listener) {
 		if (changeSupport != null) {
 			changeSupport.removePropertyChangeListener(listener);
@@ -566,6 +603,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see ISelectionProvider#removeSelectionChangedListener(ISelectionChangedListener)
 	 */
+	@Override
 	public void removeSelectionChangedListener(ISelectionChangedListener l) {
 		selectionListeners.remove(l);
 	}
@@ -573,12 +611,14 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#reveal(EditPart)
 	 */
+	@Override
 	public void reveal(EditPart part) {
 	}
 
 	/**
 	 * @see EditPartViewer#select(EditPart)
 	 */
+	@Override
 	public void select(EditPart editpart) {
 		// If selection isn't changing, do nothing.
 		if ((getSelectedEditParts().size() == 1) && (getSelectedEditParts().get(0) == editpart))
@@ -590,6 +630,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setContextMenu(MenuManager)
 	 */
+	@Override
 	public void setContextMenu(MenuManager manager) {
 		if (contextMenu != null)
 			contextMenu.dispose();
@@ -601,6 +642,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setContents(EditPart)
 	 */
+	@Override
 	public void setContents(EditPart editpart) {
 		getRootEditPart().setContents(editpart);
 	}
@@ -608,6 +650,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setContents(Object)
 	 */
+	@Override
 	public void setContents(Object contents) {
 		Assert.isTrue(getEditPartFactory() != null, "An EditPartFactory is required to call setContents(Object)");//$NON-NLS-1$
 		setContents(getEditPartFactory().createEditPart(null, contents));
@@ -616,6 +659,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setControl(Control)
 	 */
+	@Override
 	public void setControl(Control control) {
 		if (this.control != null)
 			unhookControl();
@@ -627,6 +671,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setCursor(Cursor)
 	 */
+	@Override
 	public void setCursor(Cursor cursor) {
 		if (getControl() == null || getControl().isDisposed())
 			return;
@@ -662,6 +707,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setEditDomain(EditDomain)
 	 */
+	@Override
 	public void setEditDomain(EditDomain editdomain) {
 		this.domain = editdomain;
 	}
@@ -669,6 +715,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setEditPartFactory(org.eclipse.gef.EditPartFactory)
 	 */
+	@Override
 	public void setEditPartFactory(EditPartFactory factory) {
 		this.factory = factory;
 	}
@@ -676,6 +723,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setFocus(EditPart)
 	 */
+	@Override
 	public void setFocus(EditPart part) {
 		focusPart = part;
 		getSelectionManager().setFocus(part);
@@ -684,6 +732,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setKeyHandler(KeyHandler)
 	 */
+	@Override
 	public void setKeyHandler(KeyHandler handler) {
 		keyHandler = handler;
 	}
@@ -691,6 +740,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setProperty(String, Object)
 	 */
+	@Override
 	public void setProperty(String key, Object value) {
 		if (properties == null)
 			properties = new HashMap();
@@ -707,6 +757,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setRootEditPart(RootEditPart)
 	 */
+	@Override
 	public void setRootEditPart(RootEditPart editpart) {
 		if (rootEditPart != null) {
 			if (rootEditPart.isActive())
@@ -722,6 +773,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	/**
 	 * @see EditPartViewer#setRouteEventsToEditDomain(boolean)
 	 */
+	@Override
 	public void setRouteEventsToEditDomain(boolean value) {
 	}
 
@@ -731,6 +783,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * 
 	 * @see ISelectionProvider#setSelection(ISelection)
 	 */
+	@Override
 	public void setSelection(ISelection newSelection) {
 		selectionModel.setSelection(newSelection);
 	}
@@ -758,6 +811,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * 
 	 * @see EditPartViewer#unregisterAccessibleEditPart(AccessibleEditPart)
 	 */
+	@Override
 	public void unregisterAccessibleEditPart(AccessibleEditPart acc) {
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ContentOutlinePage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ContentOutlinePage.java
@@ -47,6 +47,7 @@ public class ContentOutlinePage extends org.eclipse.ui.part.Page
 	/**
 	 * @see ISelectionProvider#addSelectionChangedListener(ISelectionChangedListener)
 	 */
+	@Override
 	public void addSelectionChangedListener(ISelectionChangedListener listener) {
 		getViewer().addSelectionChangedListener(listener);
 	}
@@ -56,6 +57,7 @@ public class ContentOutlinePage extends org.eclipse.ui.part.Page
 	 * 
 	 * @see org.eclipse.ui.part.IPage#createControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public void createControl(Composite parent) {
 		control = getViewer().createControl(parent);
 	}
@@ -63,6 +65,7 @@ public class ContentOutlinePage extends org.eclipse.ui.part.Page
 	/**
 	 * @see org.eclipse.ui.part.IPage#getControl()
 	 */
+	@Override
 	public Control getControl() {
 		return control;
 	}
@@ -72,6 +75,7 @@ public class ContentOutlinePage extends org.eclipse.ui.part.Page
 	 * 
 	 * @see org.eclipse.jface.viewers.ISelectionProvider#getSelection()
 	 */
+	@Override
 	public ISelection getSelection() {
 		// $TODO when could this even happen?
 		if (getViewer() == null)
@@ -91,6 +95,7 @@ public class ContentOutlinePage extends org.eclipse.ui.part.Page
 	/**
 	 * @see ISelectionProvider#removeSelectionChangedListener(ISelectionChangedListener)
 	 */
+	@Override
 	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
 		getViewer().removeSelectionChangedListener(listener);
 	}
@@ -98,6 +103,7 @@ public class ContentOutlinePage extends org.eclipse.ui.part.Page
 	/**
 	 * Sets focus to a part in the page.
 	 */
+	@Override
 	public void setFocus() {
 		if (getControl() != null)
 			getControl().setFocus();
@@ -106,6 +112,7 @@ public class ContentOutlinePage extends org.eclipse.ui.part.Page
 	/**
 	 * @see ISelectionProvider#setSelection(org.eclipse.jface.viewers.ISelection)
 	 */
+	@Override
 	public void setSelection(ISelection selection) {
 		if (getViewer() != null)
 			getViewer().setSelection(selection);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/DomainEventDispatcher.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/DomainEventDispatcher.java
@@ -78,6 +78,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getChildAtPoint(AccessibleControlEvent)
 		 */
+		@Override
 		public void getChildAtPoint(AccessibleControlEvent e) {
 			org.eclipse.swt.graphics.Point p = new org.eclipse.swt.graphics.Point(e.x, e.y);
 			p = getViewer().getControl().toControl(p);
@@ -92,6 +93,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getChildCount(AccessibleControlEvent)
 		 */
+		@Override
 		public void getChildCount(AccessibleControlEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -101,6 +103,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getChildren(AccessibleControlEvent)
 		 */
+		@Override
 		public void getChildren(AccessibleControlEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -110,6 +113,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getDefaultAction(AccessibleControlEvent)
 		 */
+		@Override
 		public void getDefaultAction(AccessibleControlEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -119,6 +123,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleListener#getDescription(AccessibleEvent)
 		 */
+		@Override
 		public void getDescription(AccessibleEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -128,6 +133,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getFocus(AccessibleControlEvent)
 		 */
+		@Override
 		public void getFocus(AccessibleControlEvent e) {
 			AccessibleEditPart acc = getViewer().getFocusEditPart().getAdapter(AccessibleEditPart.class);
 			if (acc != null)
@@ -137,6 +143,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleListener#getHelp(AccessibleEvent)
 		 */
+		@Override
 		public void getHelp(AccessibleEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -146,6 +153,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleListener#getKeyboardShortcut(AccessibleEvent)
 		 */
+		@Override
 		public void getKeyboardShortcut(AccessibleEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -155,6 +163,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getLocation(AccessibleControlEvent)
 		 */
+		@Override
 		public void getLocation(AccessibleControlEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -164,6 +173,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleListener#getName(AccessibleEvent)
 		 */
+		@Override
 		public void getName(AccessibleEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -173,6 +183,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getRole(AccessibleControlEvent)
 		 */
+		@Override
 		public void getRole(AccessibleControlEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -182,12 +193,14 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getSelection(AccessibleControlEvent)
 		 */
+		@Override
 		public void getSelection(AccessibleControlEvent e) {
 		}
 
 		/**
 		 * @see AccessibleControlListener#getState(AccessibleControlEvent)
 		 */
+		@Override
 		public void getState(AccessibleControlEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -197,6 +210,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		/**
 		 * @see AccessibleControlListener#getValue(AccessibleControlEvent)
 		 */
+		@Override
 		public void getValue(AccessibleControlEvent e) {
 			AccessibleEditPart acc = get(e.childID);
 			if (acc != null)
@@ -219,6 +233,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchFocusGained(org.eclipse.swt.events.FocusEvent)
 	 */
+	@Override
 	public void dispatchFocusGained(FocusEvent event) {
 		super.dispatchFocusGained(event);
 		domain.focusGained(event, viewer);
@@ -227,6 +242,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchFocusLost(org.eclipse.swt.events.FocusEvent)
 	 */
+	@Override
 	public void dispatchFocusLost(FocusEvent event) {
 		super.dispatchFocusLost(event);
 		domain.focusLost(event, viewer);
@@ -236,6 +252,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchKeyPressed(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	public void dispatchKeyPressed(org.eclipse.swt.events.KeyEvent e) {
 		if (!editorCaptured) {
 			super.dispatchKeyPressed(e);
@@ -249,6 +266,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see org.eclipse.draw2d.SWTEventDispatcher#dispatchKeyTraversed(org.eclipse.swt.events.TraverseEvent)
 	 */
+	@Override
 	public void dispatchKeyTraversed(TraverseEvent e) {
 		if (!editorCaptured) {
 			super.dispatchKeyTraversed(e);
@@ -262,6 +280,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchKeyReleased(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	public void dispatchKeyReleased(org.eclipse.swt.events.KeyEvent e) {
 		if (!editorCaptured) {
 			super.dispatchKeyReleased(e);
@@ -275,6 +294,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseDoubleClicked(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseDoubleClicked(org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMouseDoubleClicked(me);
@@ -288,6 +308,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseEntered(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseEntered(org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMouseEntered(me);
@@ -302,6 +323,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseExited(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseExited(org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMouseExited(me);
@@ -316,6 +338,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseHover(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseHover(org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMouseHover(me);
@@ -329,6 +352,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMousePressed(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMousePressed(org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMousePressed(me);
@@ -346,6 +370,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseMoved(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseMoved(org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMouseMoved(me);
@@ -363,6 +388,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#dispatchMouseReleased(org.eclipse.swt.events.MouseEvent)
 	 */
+	@Override
 	public void dispatchMouseReleased(org.eclipse.swt.events.MouseEvent me) {
 		if (!editorCaptured) {
 			super.dispatchMouseReleased(me);
@@ -404,6 +430,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	 * 
 	 * @see org.eclipse.draw2d.EventDispatcher#dispatchMouseWheelScrolled(org.eclipse.swt.widgets.Event)
 	 */
+	@Override
 	public void dispatchMouseWheelScrolled(Event evt) {
 		if (!editorCaptured)
 			super.dispatchMouseWheelScrolled(evt);
@@ -426,6 +453,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	 * 
 	 * @see org.eclipse.draw2d.EventDispatcher#getAccessibilityDispatcher()
 	 */
+	@Override
 	protected AccessibilityDispatcher getAccessibilityDispatcher() {
 		if (accessibilityDispatcher == null)
 			accessibilityDispatcher = new EditPartAccessibilityDispatcher();
@@ -456,6 +484,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see EventDispatcher#setCapture(IFigure)
 	 */
+	@Override
 	protected void setCapture(IFigure figure) {
 		super.setCapture(figure);
 		if (figure == null) {
@@ -467,6 +496,7 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 	/**
 	 * @see SWTEventDispatcher#setCursor(Cursor)
 	 */
+	@Override
 	protected void setCursor(Cursor newCursor) {
 		if (overrideCursor == null)
 			super.setCursor(newCursor);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditor.java
@@ -62,6 +62,7 @@ import org.eclipse.gef.ui.properties.UndoablePropertySheetPage;
 public abstract class GraphicalEditor extends EditorPart implements CommandStackListener, ISelectionListener {
 
 	private static class ActionIDList extends ArrayList {
+		@Override
 		public boolean add(Object o) {
 			if (o instanceof IAction) {
 				try {
@@ -97,6 +98,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * 
 	 * @param event the change event
 	 */
+	@Override
 	public void commandStackChanged(EventObject event) {
 		updateActions(stackActions);
 	}
@@ -162,6 +164,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * 
 	 * @param parent the parent composite
 	 */
+	@Override
 	public void createPartControl(Composite parent) {
 		createGraphicalViewer(parent);
 	}
@@ -169,6 +172,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	/**
 	 * @see org.eclipse.ui.IWorkbenchPart#dispose()
 	 */
+	@Override
 	public void dispose() {
 		getCommandStack().removeCommandStackListener(this);
 		getSite().getWorkbenchWindow().getSelectionService().removeSelectionListener(this);
@@ -183,6 +187,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * 
 	 * @see org.eclipse.ui.ISaveablePart#doSaveAs()
 	 */
+	@Override
 	public void doSaveAs() {
 		throw new RuntimeException("doSaveAs must be overridden"); //$NON-NLS-1$
 	}
@@ -190,6 +195,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	/**
 	 * @see org.eclipse.ui.part.WorkbenchPart#firePropertyChange(int)
 	 */
+	@Override
 	protected void firePropertyChange(int property) {
 		super.firePropertyChange(property);
 		updateActions(propertyActions);
@@ -333,6 +339,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * 
 	 * @see org.eclipse.ui.IEditorPart#init(IEditorSite, IEditorInput)
 	 */
+	@Override
 	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
 		setSite(site);
 		setInput(input);
@@ -368,6 +375,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * 
 	 * @see org.eclipse.ui.ISaveablePart#isDirty()
 	 */
+	@Override
 	public boolean isDirty() {
 		return getCommandStack().isDirty();
 	}
@@ -378,6 +386,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * 
 	 * @see org.eclipse.ui.ISaveablePart#isSaveAsAllowed()
 	 */
+	@Override
 	public boolean isSaveAsAllowed() {
 		return false;
 	}
@@ -386,6 +395,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	 * @see org.eclipse.ui.ISelectionListener#selectionChanged(IWorkbenchPart,
 	 *      ISelection)
 	 */
+	@Override
 	public void selectionChanged(IWorkbenchPart part, ISelection selection) {
 		// If not the active editor, ignore selection changed.
 		if (this.equals(getSite().getPage().getActiveEditor()))
@@ -413,6 +423,7 @@ public abstract class GraphicalEditor extends EditorPart implements CommandStack
 	/**
 	 * @see org.eclipse.ui.IWorkbenchPart#setFocus()
 	 */
+	@Override
 	public void setFocus() {
 		getGraphicalViewer().getControl().setFocus();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithFlyoutPalette.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithFlyoutPalette.java
@@ -45,6 +45,7 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 	/**
 	 * @see GraphicalEditor#initializeGraphicalViewer()
 	 */
+	@Override
 	protected void initializeGraphicalViewer() {
 		splitter.hookDropTargetListener(getGraphicalViewer());
 	}
@@ -69,6 +70,7 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 	/**
 	 * @see GraphicalEditor#createPartControl(Composite)
 	 */
+	@Override
 	public void createPartControl(Composite parent) {
 		splitter = createPaletteComposite(parent);
 		super.createPartControl(splitter);
@@ -153,6 +155,7 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 	 * 
 	 * @param ed The new EditDomain
 	 */
+	@Override
 	protected void setEditDomain(DefaultEditDomain ed) {
 		super.setEditDomain(ed);
 		getEditDomain().setPaletteRoot(getPaletteRoot());
@@ -180,6 +183,7 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 		/**
 		 * @see org.eclipse.ui.part.IPage#createControl(org.eclipse.swt.widgets.Composite)
 		 */
+		@Override
 		public void createControl(Composite parent) {
 			super.createControl(parent);
 			if (splitter != null)
@@ -189,6 +193,7 @@ public abstract class GraphicalEditorWithFlyoutPalette extends GraphicalEditor {
 		/**
 		 * @see org.eclipse.ui.part.IPage#dispose()
 		 */
+		@Override
 		public void dispose() {
 			if (splitter != null)
 				splitter.setExternalViewer(null);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithPalette.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalEditorWithPalette.java
@@ -56,6 +56,7 @@ public abstract class GraphicalEditorWithPalette extends GraphicalEditor {
 	/**
 	 * @see org.eclipse.ui.IWorkbenchPart#createPartControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public void createPartControl(Composite parent) {
 		Splitter splitter = new Splitter(parent, SWT.HORIZONTAL);
 		createPaletteViewer(splitter);
@@ -63,6 +64,7 @@ public abstract class GraphicalEditorWithPalette extends GraphicalEditor {
 		splitter.maintainSize(getPaletteViewer().getControl());
 		splitter.setFixedSize(getInitialPaletteSize());
 		splitter.addFixedSizeChangeListener(new PropertyChangeListener() {
+			@Override
 			public void propertyChange(PropertyChangeEvent evt) {
 				handlePaletteResized(((Splitter) evt.getSource()).getFixedSize());
 			}
@@ -132,6 +134,7 @@ public abstract class GraphicalEditorWithPalette extends GraphicalEditor {
 	 * 
 	 * @see org.eclipse.gef.ui.parts.GraphicalEditor#setEditDomain(org.eclipse.gef.DefaultEditDomain)
 	 */
+	@Override
 	protected void setEditDomain(DefaultEditDomain ed) {
 		super.setEditDomain(ed);
 		getEditDomain().setPaletteRoot(getPaletteRoot());

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
@@ -78,6 +78,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see org.eclipse.gef.EditPartViewer#createControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public Control createControl(Composite composite) {
 		setControl(new Canvas(composite, SWT.NO_BACKGROUND));
 		return getControl();
@@ -103,6 +104,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see AbstractEditPartViewer#handleDispose(org.eclipse.swt.events.DisposeEvent)
 	 */
+	@Override
 	protected void handleDispose(DisposeEvent e) {
 		super.handleDispose(e);
 		getLightweightSystem().getUpdateManager().dispose();
@@ -134,6 +136,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see GraphicalViewer#findHandleAt(org.eclipse.draw2d.geometry.Point)
 	 */
+	@Override
 	public Handle findHandleAt(Point p) {
 		LayerManager layermanager = (LayerManager) getEditPartRegistry().get(LayerManager.ID);
 		if (layermanager == null)
@@ -186,6 +189,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * 
 	 * @see org.eclipse.gef.EditPartViewer#flush()
 	 */
+	@Override
 	public void flush() {
 		getLightweightSystem().getUpdateManager().performUpdate();
 	}
@@ -233,6 +237,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * 
 	 * @see org.eclipse.gef.ui.parts.AbstractEditPartViewer#hookDropTarget()
 	 */
+	@Override
 	protected void hookDropTarget() {
 		// Allow the real drop targets to make their changes first.
 		super.hookDropTarget();
@@ -240,14 +245,17 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 		// Then force and update since async paints won't occurs during a Drag
 		// operation
 		getDropTarget().addDropListener(new DropTargetAdapter() {
+			@Override
 			public void dragEnter(DropTargetEvent event) {
 				flush();
 			}
 
+			@Override
 			public void dragLeave(DropTargetEvent event) {
 				flush();
 			}
 
+			@Override
 			public void dragOver(DropTargetEvent event) {
 				flush();
 			}
@@ -260,14 +268,17 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * 
 	 * @see org.eclipse.gef.ui.parts.AbstractEditPartViewer#hookControl()
 	 */
+	@Override
 	protected void hookControl() {
 		super.hookControl();
 		getLightweightSystem().setControl((Canvas) getControl());
 		getControl().addFocusListener(lFocus = new FocusListener() {
+			@Override
 			public void focusGained(FocusEvent e) {
 				handleFocusGained(e);
 			}
 
+			@Override
 			public void focusLost(FocusEvent e) {
 				handleFocusLost(e);
 			}
@@ -279,6 +290,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * 
 	 * @param acc the accessible
 	 */
+	@Override
 	public void registerAccessibleEditPart(AccessibleEditPart acc) {
 		Assert.isNotNull(acc);
 		DomainEventDispatcher domainEventDispatcher = getEventDispatcher();
@@ -294,6 +306,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * 
 	 * @see org.eclipse.gef.EditPartViewer#reveal(EditPart)
 	 */
+	@Override
 	public void reveal(EditPart part) {
 		if (part == null)
 			return;
@@ -314,10 +327,12 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * 
 	 * @see EditPartViewer#setContextMenu(org.eclipse.jface.action.MenuManager)
 	 */
+	@Override
 	public void setContextMenu(MenuManager contextMenu) {
 		super.setContextMenu(contextMenu);
 		if (contextMenu != null)
 			contextMenu.addMenuListener(new IMenuListener() {
+				@Override
 				public void menuAboutToShow(IMenuManager manager) {
 					flush();
 				}
@@ -327,6 +342,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see org.eclipse.gef.EditPartViewer#setCursor(org.eclipse.swt.graphics.Cursor)
 	 */
+	@Override
 	public void setCursor(Cursor newCursor) {
 		if (getEventDispatcher() != null)
 			getEventDispatcher().setOverrideCursor(newCursor);
@@ -338,10 +354,12 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * 
 	 * @see AbstractEditPartViewer#setDragSource(org.eclipse.swt.dnd.DragSource)
 	 */
+	@Override
 	protected void setDragSource(DragSource source) {
 		super.setDragSource(source);
 
 		class TheLastListener extends DragSourceAdapter {
+			@Override
 			public void dragStart(DragSourceEvent event) {
 				// If the EventDispatcher has captured the mouse, don't perform
 				// native drag.
@@ -359,6 +377,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 				}
 			}
 
+			@Override
 			public void dragFinished(DragSourceEvent event) {
 				getEventDispatcher().dispatchNativeDragFinished(event, GraphicalViewerImpl.this);
 			}
@@ -376,6 +395,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see org.eclipse.gef.EditPartViewer#setEditDomain(org.eclipse.gef.EditDomain)
 	 */
+	@Override
 	public void setEditDomain(EditDomain domain) {
 		super.setEditDomain(domain);
 		// Set the new event dispatcher, even if the new domain is null. This
@@ -387,6 +407,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see org.eclipse.gef.EditPartViewer#setRootEditPart(org.eclipse.gef.RootEditPart)
 	 */
+	@Override
 	public void setRootEditPart(RootEditPart editpart) {
 		super.setRootEditPart(editpart);
 		setRootFigure(((GraphicalEditPart) editpart).getFigure());
@@ -415,6 +436,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see org.eclipse.gef.EditPartViewer#setRouteEventsToEditDomain(boolean)
 	 */
+	@Override
 	public void setRouteEventsToEditDomain(boolean value) {
 		getEventDispatcher().setRouteEventsToEditor(value);
 	}
@@ -422,6 +444,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see org.eclipse.gef.ui.parts.AbstractEditPartViewer#unhookControl()
 	 */
+	@Override
 	protected void unhookControl() {
 		super.unhookControl();
 		if (lFocus != null) {
@@ -433,6 +456,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	/**
 	 * @see EditPartViewer#unregisterAccessibleEditPart(org.eclipse.gef.AccessibleEditPart)
 	 */
+	@Override
 	public void unregisterAccessibleEditPart(AccessibleEditPart acc) {
 		Assert.isNotNull(acc);
 		DomainEventDispatcher domainEventDispatcher = getEventDispatcher();
@@ -453,6 +477,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 		 * @see org.eclipse.gef.MouseWheelHandler#handleMouseWheel(org.eclipse.swt.widgets.Event,
 		 *      org.eclipse.gef.EditPartViewer)
 		 */
+		@Override
 		public void handleMouseWheel(Event event, EditPartViewer viewer) {
 			EditPart part = viewer.getFocusEditPart();
 			do {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerKeyHandler.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerKeyHandler.java
@@ -267,6 +267,7 @@ public class GraphicalViewerKeyHandler extends KeyHandler {
 	 * 
 	 * @see org.eclipse.gef.KeyHandler#keyPressed(org.eclipse.swt.events.KeyEvent)
 	 */
+	@Override
 	public boolean keyPressed(KeyEvent event) {
 		// if CTRL + SPACE is pressed, event.character == ' ' does not hold;
 		// therefore using the keyCode to decide whether SPACE was pressed (with

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ScrollingGraphicalViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ScrollingGraphicalViewer.java
@@ -48,6 +48,7 @@ public class ScrollingGraphicalViewer extends GraphicalViewerImpl {
 	/**
 	 * @see org.eclipse.gef.EditPartViewer#createControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public final Control createControl(Composite parent) {
 		setControl(new FigureCanvas(parent, getLightweightSystem()));
 		hookRootFigure();
@@ -70,6 +71,7 @@ public class ScrollingGraphicalViewer extends GraphicalViewerImpl {
 	 * 
 	 * @see org.eclipse.gef.EditPartViewer#reveal(org.eclipse.gef.EditPart)
 	 */
+	@Override
 	public void reveal(EditPart part) {
 		super.reveal(part);
 		Viewport port = getFigureCanvas().getViewport();
@@ -104,6 +106,7 @@ public class ScrollingGraphicalViewer extends GraphicalViewerImpl {
 	 * If the figure is a viewport, set the canvas' viewport, otherwise, set its
 	 * contents.
 	 */
+	@Override
 	protected void hookRootFigure() {
 		if (getFigureCanvas() == null)
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/SelectionSynchronizer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/SelectionSynchronizer.java
@@ -86,6 +86,7 @@ public class SelectionSynchronizer implements ISelectionChangedListener {
 	 * 
 	 * @param event the selection event
 	 */
+	@Override
 	public void selectionChanged(SelectionChangedEvent event) {
 		if (isDispatching)
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/Splitter.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/Splitter.java
@@ -70,6 +70,7 @@ class Splitter extends Composite {
 	}
 
 	class SashPainter implements Listener {
+		@Override
 		public void handleEvent(Event e) {
 			paint((Sash) e.widget, e.gc);
 		}
@@ -82,12 +83,14 @@ class Splitter extends Composite {
 			orientation = SWT.HORIZONTAL;
 
 		this.addListener(SWT.Resize, new Listener() {
+			@Override
 			public void handleEvent(Event e) {
 				layout(true);
 			}
 		});
 
 		sashListener = new Listener() {
+			@Override
 			public void handleEvent(Event e) {
 				onDragSash(e);
 			}
@@ -99,6 +102,7 @@ class Splitter extends Composite {
 		return style & mask;
 	}
 
+	@Override
 	public Point computeSize(int wHint, int hHint, boolean changed) {
 
 		Control[] controls = getControls(true);
@@ -138,6 +142,7 @@ class Splitter extends Composite {
 	 * side. Answer SWT.VERTICAL if the controls in the SashForm are laid out top to
 	 * bottom.
 	 */
+	@Override
 	public int getOrientation() {
 		return orientation;
 	}
@@ -171,6 +176,7 @@ class Splitter extends Composite {
 		return controls;
 	}
 
+	@Override
 	public void layout(boolean changed) {
 		Rectangle area = getClientArea();
 		if (area.width == 0 || area.height == 0)
@@ -343,6 +349,7 @@ class Splitter extends Composite {
 	 * by side. If orientation is SWT.VERTICAL, lay the controls in the SashForm out
 	 * top to bottom.
 	 */
+	@Override
 	public void setOrientation(int orientation) {
 		if (this.orientation == orientation)
 			return;
@@ -365,6 +372,7 @@ class Splitter extends Composite {
 		sashWidth = width;
 	}
 
+	@Override
 	public void setLayout(Layout layout) {
 		// SashForm does not use Layout
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
@@ -54,34 +54,42 @@ public class TreeViewer extends AbstractEditPartViewer {
 	class EventDispatcher implements MouseListener, MouseMoveListener, KeyListener, MouseTrackListener, FocusListener {
 		protected static final int ANY_BUTTON = SWT.BUTTON1 | SWT.BUTTON2 | SWT.BUTTON3;
 
+		@Override
 		public void keyPressed(KeyEvent kee) {
 			getEditDomain().keyDown(kee, TreeViewer.this);
 		}
 
+		@Override
 		public void keyReleased(KeyEvent kee) {
 			getEditDomain().keyUp(kee, TreeViewer.this);
 		}
 
+		@Override
 		public void mouseDoubleClick(MouseEvent me) {
 			getEditDomain().mouseDoubleClick(me, TreeViewer.this);
 		}
 
+		@Override
 		public void mouseDown(MouseEvent me) {
 			getEditDomain().mouseDown(me, TreeViewer.this);
 		}
 
+		@Override
 		public void mouseEnter(MouseEvent me) {
 			getEditDomain().viewerEntered(me, TreeViewer.this);
 		}
 
+		@Override
 		public void mouseExit(MouseEvent me) {
 			getEditDomain().viewerExited(me, TreeViewer.this);
 		}
 
+		@Override
 		public void mouseHover(MouseEvent me) {
 			getEditDomain().mouseHover(me, TreeViewer.this);
 		}
 
+		@Override
 		public void mouseMove(MouseEvent me) {
 			if ((me.stateMask & ANY_BUTTON) != 0)
 				getEditDomain().mouseDrag(me, TreeViewer.this);
@@ -89,14 +97,17 @@ public class TreeViewer extends AbstractEditPartViewer {
 				getEditDomain().mouseMove(me, TreeViewer.this);
 		}
 
+		@Override
 		public void mouseUp(MouseEvent me) {
 			getEditDomain().mouseUp(me, TreeViewer.this);
 		}
 
+		@Override
 		public void focusGained(FocusEvent event) {
 			getEditDomain().focusGained(event, TreeViewer.this);
 		}
 
+		@Override
 		public void focusLost(FocusEvent event) {
 			getEditDomain().focusLost(event, TreeViewer.this);
 		}
@@ -122,6 +133,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 * @param parent The parent for the Tree
 	 * @return the control
 	 */
+	@Override
 	public Control createControl(Composite parent) {
 		Tree tree = new Tree(parent, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
 		setControl(tree);
@@ -132,6 +144,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 * @see org.eclipse.gef.EditPartViewer#findObjectAtExcluding(Point, Collection,
 	 *      EditPartViewer.Conditional)
 	 */
+	@Override
 	public EditPart findObjectAtExcluding(Point pt, Collection exclude, Conditional condition) {
 		if (getControl() == null)
 			return null;
@@ -160,6 +173,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	/**
 	 * @see org.eclipse.gef.ui.parts.AbstractEditPartViewer#fireSelectionChanged()
 	 */
+	@Override
 	protected void fireSelectionChanged() {
 		super.fireSelectionChanged();
 		showSelectionInTree();
@@ -169,6 +183,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 * "Hooks up" a Control, i.e. sets it as the control for the RootTreeEditPart,
 	 * adds necessary listener for proper operation, etc.
 	 */
+	@Override
 	protected void hookControl() {
 		if (getControl() == null)
 			return;
@@ -180,6 +195,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 		tree.addKeyListener(dispatcher);
 		tree.addMouseTrackListener(dispatcher);
 		tree.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				TreeItem[] ties = tree.getSelection();
 				Object newSelection[] = new Object[ties.length];
@@ -190,6 +206,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 				ignore = false;
 			}
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 				widgetSelected(e);
 			}
@@ -202,6 +219,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	/**
 	 * @see org.eclipse.gef.ui.parts.AbstractEditPartViewer#reveal(org.eclipse.gef.EditPart)
 	 */
+	@Override
 	public void reveal(EditPart part) {
 		if (!(part instanceof TreeEditPart))
 			return;
@@ -237,6 +255,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 * etc. It does not remove the listeners because it is causing errors, although
 	 * that would be a desirable outcome.
 	 */
+	@Override
 	protected void unhookControl() {
 		if (getControl() == null)
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransfer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransfer.java
@@ -40,6 +40,7 @@ final class TreeViewerTransfer extends SimpleObjectTransfer {
 	/**
 	 * @see org.eclipse.swt.dnd.Transfer#getTypeIds()
 	 */
+	@Override
 	protected int[] getTypeIds() {
 		return new int[] { TYPEID };
 	}
@@ -47,6 +48,7 @@ final class TreeViewerTransfer extends SimpleObjectTransfer {
 	/**
 	 * @see org.eclipse.swt.dnd.Transfer#getTypeNames()
 	 */
+	@Override
 	protected String[] getTypeNames() {
 		return new String[] { TYPE_NAME };
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDragListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDragListener.java
@@ -37,10 +37,12 @@ class TreeViewerTransferDragListener extends AbstractTransferDragSourceListener 
 		super(viewer, xfer);
 	}
 
+	@Override
 	public void dragSetData(DragSourceEvent event) {
 		event.data = getViewer().getSelectedEditParts();
 	}
 
+	@Override
 	public void dragStart(DragSourceEvent event) {
 		TreeViewerTransfer.getInstance().setViewer(getViewer());
 		List selection = getViewer().getSelectedEditParts();
@@ -48,6 +50,7 @@ class TreeViewerTransferDragListener extends AbstractTransferDragSourceListener 
 		saveModelSelection(selection);
 	}
 
+	@Override
 	public void dragFinished(DragSourceEvent event) {
 		TreeViewerTransfer.getInstance().setObject(null);
 		TreeViewerTransfer.getInstance().setViewer(null);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
@@ -108,6 +108,7 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 		return result;
 	}
 
+	@Override
 	public boolean isEnabled(DropTargetEvent event) {
 		if (event.detail != DND.DROP_MOVE)
 			return false;
@@ -125,6 +126,7 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 		return source.getParent() == getTargetEditPart();
 	}
 
+	@Override
 	protected void updateTargetRequest() {
 		ChangeBoundsRequest request = (ChangeBoundsRequest) getTargetRequest();
 		request.setLocation(getDropLocation());

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/properties/SetPropertyValueCommand.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/properties/SetPropertyValueCommand.java
@@ -68,6 +68,7 @@ public class SetPropertyValueCommand extends Command {
 	/**
 	 * @see org.eclipse.gef.commands.Command#canExecute()
 	 */
+	@Override
 	public boolean canExecute() {
 		if (propertySource == null || propertyId == null) {
 			return false;
@@ -88,6 +89,7 @@ public class SetPropertyValueCommand extends Command {
 	/**
 	 * @see org.eclipse.gef.commands.Command#execute()
 	 */
+	@Override
 	public void execute() {
 		/*
 		 * Fix for bug #54250 IPropertySource.isPropertySet(String) returns false both
@@ -170,6 +172,7 @@ public class SetPropertyValueCommand extends Command {
 	/**
 	 * @see org.eclipse.gef.commands.Command#redo()
 	 */
+	@Override
 	public void redo() {
 		execute();
 	}
@@ -177,6 +180,7 @@ public class SetPropertyValueCommand extends Command {
 	/**
 	 * @see org.eclipse.gef.commands.Command#undo()
 	 */
+	@Override
 	public void undo() {
 		if (oldValue == DEFAULT_VALUE) {
 			propertySource.resetPropertyValue(propertyId);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/properties/UndoablePropertySheetEntry.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/properties/UndoablePropertySheetEntry.java
@@ -55,6 +55,7 @@ public class UndoablePropertySheetEntry extends PropertySheetEntry {
 	public UndoablePropertySheetEntry(CommandStack commandStack) {
 		this.commandStack = commandStack;
 		this.commandStackListener = new CommandStackEventListener() {
+			@Override
 			public void stackChanged(org.eclipse.gef.commands.CommandStackEvent event) {
 				if ((event.getDetail() & CommandStack.POST_MASK) != 0) {
 					refreshFromRoot();
@@ -67,6 +68,7 @@ public class UndoablePropertySheetEntry extends PropertySheetEntry {
 	/**
 	 * @see org.eclipse.ui.views.properties.PropertySheetEntry#createChildEntry()
 	 */
+	@Override
 	protected PropertySheetEntry createChildEntry() {
 		return new UndoablePropertySheetEntry();
 	}
@@ -74,6 +76,7 @@ public class UndoablePropertySheetEntry extends PropertySheetEntry {
 	/**
 	 * @see org.eclipse.ui.views.properties.IPropertySheetEntry#dispose()
 	 */
+	@Override
 	public void dispose() {
 		if (commandStack != null)
 			commandStack.removeCommandStackEventListener(commandStackListener);
@@ -97,6 +100,7 @@ public class UndoablePropertySheetEntry extends PropertySheetEntry {
 	/**
 	 * @see org.eclipse.ui.views.properties.IPropertySheetEntry#resetPropertyValue()
 	 */
+	@Override
 	public void resetPropertyValue() {
 		CompoundCommand cc = new CompoundCommand();
 		if (getParent() == null)
@@ -124,6 +128,7 @@ public class UndoablePropertySheetEntry extends PropertySheetEntry {
 	/**
 	 * @see PropertySheetEntry#valueChanged(PropertySheetEntry)
 	 */
+	@Override
 	protected void valueChanged(PropertySheetEntry child) {
 		valueChanged((UndoablePropertySheetEntry) child, new ForwardUndoCompoundCommand());
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/properties/UndoablePropertySheetPage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/properties/UndoablePropertySheetPage.java
@@ -49,6 +49,7 @@ public class UndoablePropertySheetPage extends PropertySheetPage {
 		this.commandStack = commandStack;
 		this.commandStackEventListener = new CommandStackEventListener() {
 
+			@Override
 			public void stackChanged(CommandStackEvent event) {
 				if (event.getDetail() == CommandStack.PRE_UNDO || event.getDetail() == CommandStack.PRE_REDO) {
 					// ensure the property sheet entry looses its current edit
@@ -67,6 +68,7 @@ public class UndoablePropertySheetPage extends PropertySheetPage {
 	 * 
 	 * @see org.eclipse.ui.views.properties.PropertySheetPage#dispose()
 	 */
+	@Override
 	public void dispose() {
 		if (commandStack != null)
 			commandStack.removeCommandStackEventListener(commandStackEventListener);
@@ -78,6 +80,7 @@ public class UndoablePropertySheetPage extends PropertySheetPage {
 	 * 
 	 * @see org.eclipse.ui.views.properties.PropertySheetPage#setActionBars(org.eclipse.ui.IActionBars)
 	 */
+	@Override
 	public void setActionBars(IActionBars actionBars) {
 		super.setActionBars(actionBars);
 		// register global action handlers for undo and redo

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/rulers/RulerComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/rulers/RulerComposite.java
@@ -84,6 +84,7 @@ public class RulerComposite extends Composite {
 	private boolean isRulerVisible = true;
 	private boolean needToLayout = false;
 	private Runnable runnable = new Runnable() {
+		@Override
 		public void run() {
 			layout(false);
 		}
@@ -100,6 +101,7 @@ public class RulerComposite extends Composite {
 	public RulerComposite(Composite parent, int style) {
 		super(parent, style);
 		addDisposeListener(new DisposeListener() {
+			@Override
 			public void widgetDisposed(DisposeEvent e) {
 				disposeResources();
 			}
@@ -274,6 +276,7 @@ public class RulerComposite extends Composite {
 	/**
 	 * @see org.eclipse.swt.widgets.Composite#layout(boolean)
 	 */
+	@Override
 	public void layout(boolean change) {
 		if (!layingOut && !isDisposed()) {
 			checkWidget();
@@ -315,6 +318,7 @@ public class RulerComposite extends Composite {
 		// RulerComposite
 		// is resized
 		layoutListener = new Listener() {
+			@Override
 			public void handleEvent(Event event) {
 				// @TODO:Pratik If you use Display.asyncExec(runnable) here,
 				// some flashing
@@ -331,6 +335,7 @@ public class RulerComposite extends Composite {
 		editor.getVerticalBar().addListener(SWT.Hide, layoutListener);
 
 		propertyListener = new PropertyChangeListener() {
+			@Override
 			public void propertyChange(PropertyChangeEvent evt) {
 				String property = evt.getPropertyName();
 				if (RulerProvider.PROPERTY_HORIZONTAL_RULER.equals(property)) {
@@ -425,6 +430,7 @@ public class RulerComposite extends Composite {
 		/**
 		 * @see org.eclipse.draw2d.Border#getInsets(org.eclipse.draw2d.IFigure)
 		 */
+		@Override
 		public Insets getInsets(IFigure figure) {
 			return horizontal ? H_INSETS : V_INSETS;
 		}
@@ -433,6 +439,7 @@ public class RulerComposite extends Composite {
 		 * @see org.eclipse.draw2d.Border#paint(org.eclipse.draw2d.IFigure,
 		 *      org.eclipse.draw2d.Graphics, org.eclipse.draw2d.geometry.Insets)
 		 */
+		@Override
 		public void paint(IFigure figure, Graphics graphics, Insets insets) {
 			graphics.setForegroundColor(ColorConstants.buttonDarker);
 			if (horizontal) {
@@ -463,6 +470,7 @@ public class RulerComposite extends Composite {
 		/**
 		 * @see org.eclipse.gef.EditPartViewer#appendSelection(org.eclipse.gef.EditPart)
 		 */
+		@Override
 		public void appendSelection(EditPart editpart) {
 			if (editpart instanceof RootEditPart)
 				editpart = ((RootEditPart) editpart).getContents();
@@ -479,10 +487,12 @@ public class RulerComposite extends Composite {
 			if (gep == null || !(gep instanceof GuideEditPart))
 				return null;
 			return new Handle() {
+				@Override
 				public DragTracker getDragTracker() {
 					return ((GuideEditPart) gep).getDragTracker(null);
 				}
 
+				@Override
 				public org.eclipse.draw2d.geometry.Point getAccessibleLocation() {
 					return null;
 				}
@@ -504,6 +514,7 @@ public class RulerComposite extends Composite {
 		 * 
 		 * @see org.eclipse.gef.EditPartViewer#reveal(org.eclipse.gef.EditPart)
 		 */
+		@Override
 		public void reveal(EditPart part) {
 			if (part != getContents())
 				super.reveal(part);
@@ -513,6 +524,7 @@ public class RulerComposite extends Composite {
 		 * 
 		 * @see org.eclipse.gef.ui.parts.GraphicalViewerImpl#handleFocusGained(org.eclipse.swt.events.FocusEvent)
 		 */
+		@Override
 		protected void handleFocusGained(FocusEvent fe) {
 			if (focusPart == null) {
 				setFocus(getContents());
@@ -524,6 +536,7 @@ public class RulerComposite extends Composite {
 		 * 
 		 * @see org.eclipse.gef.ui.parts.GraphicalViewerImpl#handleFocusLost(org.eclipse.swt.events.FocusEvent)
 		 */
+		@Override
 		protected void handleFocusLost(FocusEvent fe) {
 			super.handleFocusLost(fe);
 			if (focusPart == getContents()) {
@@ -550,6 +563,7 @@ public class RulerComposite extends Composite {
 			/**
 			 * @see org.eclipse.gef.KeyHandler#keyPressed(org.eclipse.swt.events.KeyEvent)
 			 */
+			@Override
 			public boolean keyPressed(KeyEvent event) {
 				if (event.keyCode == SWT.DEL) {
 					// If a guide has focus, delete it

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackInspector.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackInspector.java
@@ -33,18 +33,22 @@ public class CommandStackInspector extends PageBookView {
 	/**
 	 * @see PageBookView#createDefaultPage(org.eclipse.ui.part.PageBook)
 	 */
+	@Override
 	protected IPage createDefaultPage(PageBook book) {
 		Page page = new Page() {
 			Control control;
 
+			@Override
 			public void createControl(Composite parent) {
 				control = new Canvas(parent, SWT.NONE);
 			}
 
+			@Override
 			public Control getControl() {
 				return control;
 			}
 
+			@Override
 			public void setFocus() {
 			}
 		};
@@ -56,6 +60,7 @@ public class CommandStackInspector extends PageBookView {
 	/**
 	 * @see PageBookView#doCreatePage(org.eclipse.ui.IWorkbenchPart)
 	 */
+	@Override
 	protected PageRec doCreatePage(IWorkbenchPart part) {
 		// Try to get a custom command stack page.
 		Object obj = part.getAdapter(CommandStackInspectorPage.class);
@@ -80,6 +85,7 @@ public class CommandStackInspector extends PageBookView {
 	 * @param part the input part
 	 * @param rec  a page record for the part
 	 */
+	@Override
 	protected void doDestroyPage(IWorkbenchPart part, PageRec rec) {
 		rec.page.dispose();
 	}
@@ -87,6 +93,7 @@ public class CommandStackInspector extends PageBookView {
 	/**
 	 * @see PageBookView#getBootstrapPart()
 	 */
+	@Override
 	protected IWorkbenchPart getBootstrapPart() {
 		IWorkbenchPage persp = getSite().getWorkbenchWindow().getActivePage();
 		if (persp != null)
@@ -98,6 +105,7 @@ public class CommandStackInspector extends PageBookView {
 	/**
 	 * @see PageBookView#isImportant(org.eclipse.ui.IWorkbenchPart)
 	 */
+	@Override
 	protected boolean isImportant(IWorkbenchPart part) {
 		return part instanceof IEditorPart;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackInspectorPage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackInspectorPage.java
@@ -42,6 +42,7 @@ public class CommandStackInspectorPage extends org.eclipse.ui.part.Page {
 	/**
 	 * @see org.eclipse.ui.part.Page#createControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public void createControl(Composite composite) {
 		treeViewer = new TreeViewer(composite);
 		treeViewer.setContentProvider(new TreeContentProvider(input));
@@ -52,6 +53,7 @@ public class CommandStackInspectorPage extends org.eclipse.ui.part.Page {
 	/**
 	 * @see org.eclipse.ui.part.Page#getControl()
 	 */
+	@Override
 	public Control getControl() {
 		return treeViewer.getControl();
 	}
@@ -61,6 +63,7 @@ public class CommandStackInspectorPage extends org.eclipse.ui.part.Page {
 	 *      org.eclipse.jface.action.IToolBarManager,
 	 *      org.eclipse.jface.action.IStatusLineManager)
 	 */
+	@Override
 	public void makeContributions(IMenuManager menuManager, IToolBarManager toolBarManager,
 			IStatusLineManager statusLineManager) {
 		super.makeContributions(menuManager, toolBarManager, statusLineManager);
@@ -70,6 +73,7 @@ public class CommandStackInspectorPage extends org.eclipse.ui.part.Page {
 	/**
 	 * @see org.eclipse.ui.part.Page#setFocus()
 	 */
+	@Override
 	public void setFocus() {
 		getControl().setFocus();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackViewerAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackViewerAction.java
@@ -41,6 +41,7 @@ public class CommandStackViewerAction extends Action {
 	/**
 	 * @see Action#run()
 	 */
+	@Override
 	public void run() {
 		if (viewer == null)
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/TreeContentProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/TreeContentProvider.java
@@ -40,12 +40,14 @@ public class TreeContentProvider implements org.eclipse.jface.viewers.ITreeConte
 	/**
 	 * @see org.eclipse.jface.viewers.IContentProvider#dispose()
 	 */
+	@Override
 	public void dispose() {
 	}
 
 	/**
 	 * @see CommandStackListener#commandStackChanged(EventObject)
 	 */
+	@Override
 	public void commandStackChanged(EventObject event) {
 		viewer.refresh();
 	}
@@ -53,6 +55,7 @@ public class TreeContentProvider implements org.eclipse.jface.viewers.ITreeConte
 	/**
 	 * @see org.eclipse.jface.viewers.ITreeContentProvider#getChildren(java.lang.Object)
 	 */
+	@Override
 	public Object[] getChildren(Object o) {
 		if (o instanceof CompoundCommand) {
 			return ((CompoundCommand) o).getChildren();
@@ -63,6 +66,7 @@ public class TreeContentProvider implements org.eclipse.jface.viewers.ITreeConte
 	/**
 	 * @see org.eclipse.jface.viewers.IStructuredContentProvider#getElements(java.lang.Object)
 	 */
+	@Override
 	public Object[] getElements(Object o) {
 		if (o instanceof CommandStack) {
 			return ((CommandStack) o).getCommands();
@@ -75,6 +79,7 @@ public class TreeContentProvider implements org.eclipse.jface.viewers.ITreeConte
 	/**
 	 * @see TreeContentProvider#getParent(Object)
 	 */
+	@Override
 	public Object getParent(Object child) {
 		return null;
 	}
@@ -82,6 +87,7 @@ public class TreeContentProvider implements org.eclipse.jface.viewers.ITreeConte
 	/**
 	 * @see org.eclipse.jface.viewers.ITreeContentProvider#hasChildren(java.lang.Object)
 	 */
+	@Override
 	public boolean hasChildren(Object o) {
 		return o instanceof CompoundCommand;
 	}
@@ -90,6 +96,7 @@ public class TreeContentProvider implements org.eclipse.jface.viewers.ITreeConte
 	 * @see org.eclipse.jface.viewers.IContentProvider#inputChanged(Viewer, Object,
 	 *      Object)
 	 */
+	@Override
 	public void inputChanged(Viewer v, Object o, Object n) {
 		viewer = v;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/TreeLabelProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/TreeLabelProvider.java
@@ -49,18 +49,21 @@ public class TreeLabelProvider implements org.eclipse.jface.viewers.ILabelProvid
 	/**
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#addListener(ILabelProviderListener)
 	 */
+	@Override
 	public void addListener(ILabelProviderListener l) {
 	}
 
 	/**
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#dispose()
 	 */
+	@Override
 	public void dispose() {
 	}
 
 	/**
 	 * @see org.eclipse.jface.viewers.ILabelProvider#getImage(java.lang.Object)
 	 */
+	@Override
 	public Image getImage(Object o) {
 		if (o instanceof Command) {
 			Command command = (Command) o;
@@ -88,6 +91,7 @@ public class TreeLabelProvider implements org.eclipse.jface.viewers.ILabelProvid
 	/**
 	 * @see ILabelProvider#getText(java.lang.Object)
 	 */
+	@Override
 	public String getText(Object o) {
 		if (o instanceof CommandStack)
 			return "Command Stack";//$NON-NLS-1$
@@ -112,6 +116,7 @@ public class TreeLabelProvider implements org.eclipse.jface.viewers.ILabelProvid
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#isLabelProperty(java.lang.Object,
 	 *      java.lang.String)
 	 */
+	@Override
 	public boolean isLabelProperty(Object element, String property) {
 		return false;
 	}
@@ -119,6 +124,7 @@ public class TreeLabelProvider implements org.eclipse.jface.viewers.ILabelProvid
 	/**
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#removeListener(org.eclipse.jface.viewers.ILabelProviderListener)
 	 */
+	@Override
 	public void removeListener(ILabelProviderListener l) {
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteView.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteView.java
@@ -41,11 +41,13 @@ public class PaletteView extends PageBookView {
 	public static final String ID = "org.eclipse.gef.ui.palette_view"; //$NON-NLS-1$
 
 	private IPerspectiveListener perspectiveListener = new IPerspectiveListener() {
+		@Override
 		public void perspectiveChanged(IWorkbenchPage page, IPerspectiveDescriptor perspective, String changeId) {
 		}
 
 		// fix for bug 109245 and 69098 - fake a partActivated when the
 		// perpsective is switched
+		@Override
 		public void perspectiveActivated(IWorkbenchPage page, IPerspectiveDescriptor perspective) {
 			viewInPage = page.findViewReference(ID) != null;
 			// getBootstrapPart could return null; but isImportant() can handle
@@ -59,6 +61,7 @@ public class PaletteView extends PageBookView {
 	 * 
 	 * @see org.eclipse.ui.part.PageBookView#createDefaultPage(org.eclipse.ui.part.PageBook)
 	 */
+	@Override
 	protected IPage createDefaultPage(PageBook book) {
 		MessagePage page = new MessagePage();
 		initPage(page);
@@ -73,6 +76,7 @@ public class PaletteView extends PageBookView {
 	 * 
 	 * @see org.eclipse.ui.IWorkbenchPart#createPartControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public void createPartControl(Composite parent) {
 		super.createPartControl(parent);
 		getSite().getPage().getWorkbenchWindow().addPerspectiveListener(perspectiveListener);
@@ -83,6 +87,7 @@ public class PaletteView extends PageBookView {
 	 * 
 	 * @see org.eclipse.ui.IWorkbenchPart#dispose()
 	 */
+	@Override
 	public void dispose() {
 		getSite().getPage().getWorkbenchWindow().removePerspectiveListener(perspectiveListener);
 		super.dispose();
@@ -91,6 +96,7 @@ public class PaletteView extends PageBookView {
 	/**
 	 * @see org.eclipse.ui.part.PageBookView#doCreatePage(org.eclipse.ui.IWorkbenchPart)
 	 */
+	@Override
 	protected PageRec doCreatePage(IWorkbenchPart part) {
 		// Try to get a custom palette page
 		PalettePage page = part.getAdapter(PalettePage.class);
@@ -108,6 +114,7 @@ public class PaletteView extends PageBookView {
 	 * @see PageBookView#doDestroyPage(org.eclipse.ui.IWorkbenchPart,
 	 *      org.eclipse.ui.part.PageBookView.PageRec)
 	 */
+	@Override
 	protected void doDestroyPage(IWorkbenchPart part, PageRec rec) {
 		rec.page.dispose();
 	}
@@ -117,6 +124,7 @@ public class PaletteView extends PageBookView {
 	 * 
 	 * @see PageBookView#getBootstrapPart()
 	 */
+	@Override
 	protected IWorkbenchPart getBootstrapPart() {
 		IWorkbenchPage page = getSite().getPage();
 		if (page != null)
@@ -129,6 +137,7 @@ public class PaletteView extends PageBookView {
 	 * 
 	 * @see PageBookView#isImportant(org.eclipse.ui.IWorkbenchPart)
 	 */
+	@Override
 	protected boolean isImportant(IWorkbenchPart part) {
 		// Workaround for Bug# 69098 -- This should be removed when/if Bug#
 		// 70510 is fixed

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteViewerPage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteViewerPage.java
@@ -57,6 +57,7 @@ public class PaletteViewerPage extends Page implements PalettePage, IAdaptable {
 	 * 
 	 * @see Page#createControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public void createControl(Composite parent) {
 		viewer = provider.createPaletteViewer(parent);
 	}
@@ -66,6 +67,7 @@ public class PaletteViewerPage extends Page implements PalettePage, IAdaptable {
 	 * 
 	 * @see Page#dispose()
 	 */
+	@Override
 	public void dispose() {
 		if (provider.getEditDomain().getPaletteViewer() == viewer)
 			provider.getEditDomain().setPaletteViewer(null);
@@ -92,6 +94,7 @@ public class PaletteViewerPage extends Page implements PalettePage, IAdaptable {
 	 * @return the palette viewer's control
 	 * @see Page#getControl()
 	 */
+	@Override
 	public Control getControl() {
 		return viewer.getControl();
 	}
@@ -101,6 +104,7 @@ public class PaletteViewerPage extends Page implements PalettePage, IAdaptable {
 	 * 
 	 * @see Page#setFocus()
 	 */
+	@Override
 	public void setFocus() {
 		getControl().setFocus();
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/EntityConnectionData.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/EntityConnectionData.java
@@ -40,6 +40,7 @@ public final class EntityConnectionData {
 	 * 
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof EntityConnectionData)) {
 			return false;
@@ -53,6 +54,7 @@ public final class EntityConnectionData {
 	 * 
 	 * @see java.lang.Object#hashCode()
 	 */
+	@Override
 	public int hashCode() {
 		return this.source.hashCode() + this.dest.hashCode();
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
@@ -70,12 +70,14 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 		hookControl(this.graph);
 	}
 
+	@Override
 	protected void hookControl(Control control) {
 		super.hookControl(control);
 
 		selectionChangedListeners = new ArrayList();
 		getGraphControl().addSelectionListener(new SelectionAdapter() {
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				Iterator iterator = selectionChangedListeners.iterator();
 
@@ -93,15 +95,18 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 
 		control.addMouseListener(new MouseListener() {
 
+			@Override
 			public void mouseDoubleClick(MouseEvent e) {
 				DoubleClickEvent doubleClickEvent = new DoubleClickEvent(GraphViewer.this, getSelection());
 				fireDoubleClick(doubleClickEvent);
 			}
 
+			@Override
 			public void mouseDown(MouseEvent e) {
 
 			}
 
+			@Override
 			public void mouseUp(MouseEvent e) {
 
 			}
@@ -124,6 +129,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * @see org.eclipse.zest.core.viewer.internal.AbstractStructuredGraphViewer#
 	 * getGraphControl()
 	 */
+	@Override
 	public Graph getGraphControl() {
 		return super.getGraphControl();
 	};
@@ -134,6 +140,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * @param algorithm the algorithm to layout the nodes
 	 * @param runLayout if the layout should be run
 	 */
+	@Override
 	public void setLayoutAlgorithm(LayoutAlgorithm algorithm, boolean runLayout) {
 		graph.setLayoutAlgorithm(algorithm, runLayout);
 	}
@@ -144,6 +151,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * @see org.eclipse.zest.core.viewer.internal.AbstractStructuredGraphViewer#
 	 * setLayoutAlgorithm(org.eclipse.zest.layouts.LayoutAlgorithm)
 	 */
+	@Override
 	public void setLayoutAlgorithm(LayoutAlgorithm algorithm) {
 		super.setLayoutAlgorithm(algorithm);
 	}
@@ -154,11 +162,13 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * @see org.eclipse.zest.core.viewers.AbstractStructuredGraphViewer#setNodeStyle
 	 * (int)
 	 */
+	@Override
 	public void setNodeStyle(int nodeStyle) {
 		super.setNodeStyle(nodeStyle);
 		this.graph.setNodeStyle(nodeStyle);
 	}
 
+	@Override
 	public void setContentProvider(IContentProvider contentProvider) {
 		if (contentProvider instanceof IGraphContentProvider) {
 			modelFactory = null;
@@ -196,23 +206,28 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	/**
 	 * Applys the current layout to the viewer
 	 */
+	@Override
 	public void applyLayout() {
 		graph.applyLayout();
 	}
 
+	@Override
 	protected void setSelectionToWidget(List l, boolean reveal) {
 		GraphItem[] listOfItems = findItems(l);
 		graph.setSelection(listOfItems);
 	}
 
+	@Override
 	public Control getControl() {
 		return graph;
 	}
 
+	@Override
 	public Object[] getNodeElements() {
 		return super.getNodeElements();
 	}
 
+	@Override
 	public Object[] getConnectionElements() {
 		return super.getConnectionElements();
 	}
@@ -224,6 +239,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * org.eclipse.zest.core.viewer.internal.AbstractStructuredGraphViewer#reveal
 	 * (java.lang.Object)
 	 */
+	@Override
 	public void reveal(Object element) {
 		super.reveal(element);
 	}
@@ -234,6 +250,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * @see org.eclipse.zest.core.viewer.internal.AbstractStructuredGraphViewer#
 	 * setConnectionStyle(int)
 	 */
+	@Override
 	public void setConnectionStyle(int connectionStyle) {
 		super.setConnectionStyle(connectionStyle);
 	}
@@ -245,16 +262,19 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * org.eclipse.zest.core.viewer.internal.AbstractStructuredGraphViewer#unReveal
 	 * (java.lang.Object)
 	 */
+	@Override
 	public void unReveal(Object element) {
 		super.unReveal(element);
 	}
 
+	@Override
 	public void addSelectionChangedListener(ISelectionChangedListener listener) {
 		if (!selectionChangedListeners.contains(listener)) {
 			selectionChangedListeners.add(listener);
 		}
 	}
 
+	@Override
 	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
 		if (selectionChangedListeners.contains(listener)) {
 			selectionChangedListeners.remove(listener);
@@ -263,6 +283,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 
 	// @tag zest.bug.156286-Zooming.fix.experimental : expose the zoom manager
 	// for new actions.
+	@Override
 	protected ZoomManager getZoomManager() {
 		if (zoomManager == null) {
 			zoomManager = new ZoomManager(getGraphControl().getRootLayer(), getGraphControl().getViewport());
@@ -275,6 +296,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * 
 	 * @see org.eclipse.zest.core.viewers.AbstractStructuredGraphViewer#getFactory()
 	 */
+	@Override
 	protected IStylingGraphModelFactory getFactory() {
 		if (modelFactory == null) {
 			if (getContentProvider() instanceof IGraphContentProvider) {
@@ -294,6 +316,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * @see org.eclipse.zest.core.viewers.AbstractStructuredGraphViewer#
 	 * getLayoutAlgorithm()
 	 */
+	@Override
 	protected LayoutAlgorithm getLayoutAlgorithm() {
 		return graph.getLayoutAlgorithm();
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IGraphContentProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IGraphContentProvider.java
@@ -50,6 +50,7 @@ public interface IGraphContentProvider extends IStructuredContentProvider {
 	 * @input the input model object.
 	 * @return all the relationships in the graph for the given input.
 	 */
+	@Override
 	public Object[] getElements(Object input);
 
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IGraphEntityContentProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IGraphEntityContentProvider.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.viewers.IStructuredContentProvider;
  */
 public interface IGraphEntityContentProvider extends IStructuredContentProvider {
 
+	@Override
 	public Object[] getElements(Object inputElement);
 
 	/**

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/ZoomContributionViewItem.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/ZoomContributionViewItem.java
@@ -57,6 +57,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 	private Combo combo;
 	private Menu fMenu;
 	private MenuAdapter menuAdapter = new MenuAdapter() {
+		@Override
 		public void menuShown(MenuEvent e) {
 			refresh(true);
 		}
@@ -81,6 +82,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 	 * org.eclipse.jface.action.ContributionItem#fill(org.eclipse.swt.widgets.Menu,
 	 * int)
 	 */
+	@Override
 	public void fill(Menu menu, int index) {
 		if (this.fMenu == null || this.fMenu != menu) {
 			if (this.fMenu != null) {
@@ -98,6 +100,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 	 * @see org.eclipse.jface.action.ContributionItem#fill(org.eclipse.swt.widgets.
 	 * CoolBar, int)
 	 */
+	@Override
 	public void fill(CoolBar parent, int index) {
 		CoolItem item = new CoolItem(parent, SWT.DROP_DOWN);
 		Combo combo = createCombo(parent);
@@ -110,6 +113,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 	 * @see org.eclipse.jface.action.ContributionItem#fill(org.eclipse.swt.widgets.
 	 * ToolBar, int)
 	 */
+	@Override
 	public void fill(ToolBar parent, int index) {
 		ToolItem item = new ToolItem(parent, SWT.SEPARATOR, index);
 		Combo combo = createCombo(parent);
@@ -131,6 +135,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 			 * org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events
 			 * .SelectionEvent)
 			 */
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				int selection = combo.getSelectionIndex();
 				if (selection > 0) {
@@ -180,6 +185,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 				item.setText(zoomLevels[i]);
 				item.setData(this);
 				item.addSelectionListener(new SelectionAdapter() {
+					@Override
 					public void widgetSelected(SelectionEvent e) {
 						MenuItem source = (MenuItem) e.getSource();
 						doZoom(source.getText());
@@ -225,6 +231,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 	 * 
 	 * @see org.eclipse.gef.editparts.ZoomListener#zoomChanged(double)
 	 */
+	@Override
 	public void zoomChanged(double z) {
 		refresh(false);
 	}
@@ -235,6 +242,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 	 * @see org.eclipse.jface.action.ContributionItem#dispose()
 	 */
 
+	@Override
 	public void dispose() {
 		if (combo != null) {
 			combo = null;

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
@@ -87,6 +87,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 		 * 
 		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
 		 */
+		@Override
 		public int compare(Object arg0, Object arg1) {
 			if (arg0 instanceof GraphNode && arg1 instanceof GraphConnection) {
 				return 1;
@@ -340,6 +341,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * @see org.eclipse.jface.viewers.StructuredViewer#internalRefresh(java.lang.
 	 * Object)
 	 */
+	@Override
 	protected void internalRefresh(Object element) {
 		if (getInput() == null) {
 			return;
@@ -355,6 +357,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 		getGraphControl().getLightweightSystem().getUpdateManager().performUpdate();
 	}
 
+	@Override
 	protected void doUpdateItem(Widget item, Object element, boolean fullMap) {
 		if (item == getGraphControl()) {
 			getFactory().update(getNodesArray(getGraphControl()));
@@ -370,6 +373,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * @see org.eclipse.jface.viewers.StructuredViewer#doFindInputItem(java.lang.
 	 * Object)
 	 */
+	@Override
 	protected Widget doFindInputItem(Object element) {
 
 		if (element == getInput() && element instanceof Widget) {
@@ -383,6 +387,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * 
 	 * @see org.eclipse.jface.viewers.StructuredViewer#doFindItem(java.lang.Object)
 	 */
+	@Override
 	protected Widget doFindItem(Object element) {
 		Widget node = (Widget) nodesMap.get(element);
 		Widget connection = (Widget) connectionsMap.get(element);
@@ -394,6 +399,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * 
 	 * @see org.eclipse.jface.viewers.StructuredViewer#getSelectionFromWidget()
 	 */
+	@Override
 	protected List getSelectionFromWidget() {
 		List internalSelection = getWidgetSelection();
 		LinkedList externalSelection = new LinkedList();
@@ -427,6 +433,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * @see org.eclipse.jface.viewers.StructuredViewer#setSelectionToWidget(java.
 	 * util.List, boolean)
 	 */
+	@Override
 	protected void setSelectionToWidget(List l, boolean reveal) {
 		Graph control = (Graph) getControl();
 		List selection = new LinkedList();
@@ -460,6 +467,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * @see org.eclipse.jface.viewers.Viewer#inputChanged(java.lang.Object,
 	 * java.lang.Object)
 	 */
+	@Override
 	protected void inputChanged(Object input, Object oldInput) {
 		IStylingGraphModelFactory factory = getFactory();
 		factory.setConnectionStyle(getConnectionStyle());
@@ -586,6 +594,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * @see
 	 * org.eclipse.jface.viewers.StructuredViewer#getRawChildren(java.lang.Object )
 	 */
+	@Override
 	protected Object[] getRawChildren(Object parent) {
 		if (parent == getInput()) {
 			// get the children from the model.
@@ -614,6 +623,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	/**
 	 * 
 	 */
+	@Override
 	public void reveal(Object element) {
 		Widget[] items = this.findItems(element);
 		for (int i = 0; i < items.length; i++) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStylingModelFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStylingModelFactory.java
@@ -129,6 +129,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 		}
 	}
 
+	@Override
 	public StructuredViewer getViewer() {
 		return viewer;
 	}
@@ -139,6 +140,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	 * @see org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#
 	 * getLabelProvider()
 	 */
+	@Override
 	public IBaseLabelProvider getLabelProvider() {
 		return viewer.getLabelProvider();
 	}
@@ -149,6 +151,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	 * @see org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#
 	 * getContentProvider()
 	 */
+	@Override
 	public IStructuredContentProvider getContentProvider() {
 		return (IStructuredContentProvider) viewer.getContentProvider();
 	}
@@ -160,6 +163,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	 * createConnection(org.eclipse.zest.core.internal.graphmodel.GraphModel,
 	 * java.lang.Object, java.lang.Object, java.lang.Object)
 	 */
+	@Override
 	public GraphConnection createConnection(Graph graph, Object element, Object source, Object dest) {
 		if (source == null || dest == null) {
 			return null;
@@ -238,6 +242,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 		return node;
 	}
 
+	@Override
 	public GraphNode createNode(Graph graph, Object element) {
 		IFigure nodeFigure = null;
 		if (getLabelProvider() instanceof IFigureProvider) {
@@ -246,6 +251,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 		return this.createNode(graph, element, nodeFigure);
 	}
 
+	@Override
 	public void setConnectionStyle(int style) {
 		this.connectionStyle = style;
 	}
@@ -253,10 +259,12 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	/**
 	 * @return the connectionStyle
 	 */
+	@Override
 	public int getConnectionStyle() {
 		return connectionStyle;
 	}
 
+	@Override
 	public void setNodeStyle(int style) {
 		this.nodeStyle = style;
 	}
@@ -268,6 +276,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	/**
 	 * @return the nodeStyle
 	 */
+	@Override
 	public int getNodeStyle() {
 		return nodeStyle;
 	}
@@ -276,6 +285,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	 * Default implementation simply restyles the item, regardless of the
 	 * properties.
 	 */
+	@Override
 	public void update(GraphItem item) {
 		styleItem(item);
 	}
@@ -284,6 +294,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	 * Default implementation simply restyles the items, regardless of the
 	 * properties.
 	 */
+	@Override
 	public void update(GraphItem[] items) {
 		for (int i = 0; i < items.length; i++) {
 			styleItem(items[i]);
@@ -296,6 +307,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	 * @see org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#
 	 * refreshGraph(org.eclipse.zest.core.internal.graphmodel.GraphModel)
 	 */
+	@Override
 	public void refreshGraph(Graph graph) {
 		// with this kind of graph, it is just as easy and cost-effective to
 		// rebuild the whole thing.
@@ -407,6 +419,7 @@ public abstract class AbstractStylingModelFactory implements IStylingGraphModelF
 	 * org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#refresh
 	 * (org.eclipse.zest.core.internal.graphmodel.GraphModel, java.lang.Object)
 	 */
+	@Override
 	public void refresh(Graph graph, Object element) {
 		refresh(graph, element, false);
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityFactory.java
@@ -42,6 +42,7 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 	 * @see org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#
 	 * createGraphModel()
 	 */
+	@Override
 	public Graph createGraphModel(Graph model) {
 		doBuildGraph(model);
 		return model;
@@ -53,6 +54,7 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 	 * @see org.eclipse.zest.core.internal.graphmodel.AbstractStylingModelFactory
 	 * #doBuildGraph(org.eclipse.zest.core.internal.graphmodel.GraphModel)
 	 */
+	@Override
 	protected void doBuildGraph(Graph model) {
 		super.doBuildGraph(model);
 		Object inputElement = getViewer().getInput();
@@ -112,6 +114,7 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 	 * org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#refresh
 	 * (org.eclipse.zest.core.internal.graphmodel.GraphModel, java.lang.Object)
 	 */
+	@Override
 	public void refresh(Graph graph, Object element, boolean refreshLabels) {
 		if (element == null) {
 			return;
@@ -212,6 +215,7 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 	 * (org.eclipse.zest.core.internal.graphmodel.GraphModel, java.lang.Object,
 	 * boolean)
 	 */
+	@Override
 	public void refresh(Graph graph, Object element) {
 		refresh(graph, element, false);
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityRelationshipFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityRelationshipFactory.java
@@ -40,6 +40,7 @@ public class GraphModelEntityRelationshipFactory extends AbstractStylingModelFac
 	 * @see org.eclipse.zest.core.internal.graphmodel.AbstractStylingModelFactory
 	 * #createGraphModel()
 	 */
+	@Override
 	public Graph createGraphModel(Graph model) {
 		doBuildGraph(model);
 		return model;
@@ -51,6 +52,7 @@ public class GraphModelEntityRelationshipFactory extends AbstractStylingModelFac
 	 * @see org.eclipse.zest.core.internal.graphmodel.AbstractStylingModelFactory
 	 * #doBuildGraph(org.eclipse.zest.core.internal.graphmodel.GraphModel)
 	 */
+	@Override
 	protected void doBuildGraph(Graph model) {
 		super.doBuildGraph(model);
 		Object[] nodes = getContentProvider().getElements(getViewer().getInput());
@@ -114,6 +116,7 @@ public class GraphModelEntityRelationshipFactory extends AbstractStylingModelFac
 	 * org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#refresh
 	 * (org.eclipse.zest.core.internal.graphmodel.GraphModel, java.lang.Object)
 	 */
+	@Override
 	public void refresh(Graph graph, Object element) {
 		refresh(graph, element, false);
 	}
@@ -126,6 +129,7 @@ public class GraphModelEntityRelationshipFactory extends AbstractStylingModelFac
 	 * (org.eclipse.zest.core.internal.graphmodel.GraphModel, java.lang.Object,
 	 * boolean)
 	 */
+	@Override
 	public void refresh(Graph graph, Object element, boolean updateLabels) {
 		// with this kind of graph, it is just as easy and cost-effective to
 		// rebuild the whole thing.

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelFactory.java
@@ -38,6 +38,7 @@ public class GraphModelFactory extends AbstractStylingModelFactory {
 	 * 
 	 * @see ca.uvic.cs.zest.internal.graphmodel.IGraphModelFactory#createModel()
 	 */
+	@Override
 	public Graph createGraphModel(Graph model) {
 		doBuildGraph(model);
 		return model;
@@ -49,6 +50,7 @@ public class GraphModelFactory extends AbstractStylingModelFactory {
 	 * @see org.eclipse.zest.core.internal.graphmodel.AbstractStylingModelFactory#
 	 * doBuildGraph(org.eclipse.zest.core.internal.graphmodel.GraphModel)
 	 */
+	@Override
 	protected void doBuildGraph(Graph model) {
 		super.doBuildGraph(model);
 		// make the model have the same styles as the viewer
@@ -112,6 +114,7 @@ public class GraphModelFactory extends AbstractStylingModelFactory {
 	 * org.eclipse.zest.core.internal.graphmodel.IStylingGraphModelFactory#refresh(
 	 * org.eclipse.zest.core.internal.graphmodel.GraphModel, java.lang.Object)
 	 */
+	@Override
 	public void refresh(Graph graph, Object element) {
 		refresh(graph, element, false);
 	}
@@ -124,6 +127,7 @@ public class GraphModelFactory extends AbstractStylingModelFactory {
 	 * org.eclipse.zest.core.internal.graphmodel.GraphModel, java.lang.Object,
 	 * boolean)
 	 */
+	@Override
 	public void refresh(Graph graph, Object element, boolean updateLabels) {
 		GraphConnection conn = viewer.getGraphModelConnection(element);
 		if (conn == null) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/CGraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/CGraphNode.java
@@ -25,35 +25,43 @@ public class CGraphNode extends GraphNode {
 		super(graphModel, style, figure);
 	}
 
+	@Override
 	public IFigure getFigure() {
 		return super.getFigure();
 	}
 
+	@Override
 	protected IFigure createFigureForModel() {
 		this.figure = (IFigure) this.getData();
 		return this.figure;
 	}
 
+	@Override
 	public void setBackgroundColor(Color c) {
 		getFigure().setBackgroundColor(c);
 	}
 
+	@Override
 	public void setFont(Font font) {
 		getFigure().setFont(font);
 	}
 
+	@Override
 	public Color getBackgroundColor() {
 		return getFigure().getBackgroundColor();
 	}
 
+	@Override
 	public Font getFont() {
 		return getFigure().getFont();
 	}
 
+	@Override
 	public Color getForegroundColor() {
 		return getFigure().getForegroundColor();
 	}
 
+	@Override
 	protected void updateFigureForModel(IFigure currentFigure) {
 		// Undefined
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -147,6 +147,7 @@ public class Graph extends FigureCanvas implements IContainer {
 		// @tag CGraph.workaround : this allows me to handle mouse events
 		// outside of the canvas
 		this.getLightweightSystem().setEventDispatcher(new SWTEventDispatcher() {
+			@Override
 			public void dispatchMouseMoved(org.eclipse.swt.events.MouseEvent me) {
 				super.dispatchMouseMoved(me);
 
@@ -243,6 +244,7 @@ public class Graph extends FigureCanvas implements IContainer {
 	 * 
 	 * @return List of GraphModelNode objects
 	 */
+	@Override
 	public List<? extends GraphNode> getNodes() {
 		return nodes;
 	}
@@ -386,6 +388,7 @@ public class Graph extends FigureCanvas implements IContainer {
 	 * only if the view is visible. Otherwise it will be deferred until after the
 	 * view is available.
 	 */
+	@Override
 	public void applyLayout() {
 		if (!hasPendingLayoutRequest) {
 			hasPendingLayoutRequest = true;
@@ -407,6 +410,7 @@ public class Graph extends FigureCanvas implements IContainer {
 	/**
 	 * @param algorithm
 	 */
+	@Override
 	public void setLayoutAlgorithm(LayoutAlgorithm algorithm, boolean applyLayout) {
 		this.layoutAlgorithm = algorithm;
 		if (applyLayout) {
@@ -426,10 +430,12 @@ public class Graph extends FigureCanvas implements IContainer {
 	public IFigure getFigureAt(int x, int y) {
 		return this.getContents().findFigureAt(x, y, new TreeSearch() {
 
+			@Override
 			public boolean accept(IFigure figure) {
 				return true;
 			}
 
+			@Override
 			public boolean prune(IFigure figure) {
 				IFigure parent = figure.getParent();
 				// @tag TODO Zest : change these to from getParent to
@@ -482,6 +488,7 @@ public class Graph extends FigureCanvas implements IContainer {
 			this.graph = graph;
 		}
 
+		@Override
 		public void mouseDragged(org.eclipse.draw2d.MouseEvent me) {
 			if (!isDragging) {
 				return;
@@ -540,14 +547,17 @@ public class Graph extends FigureCanvas implements IContainer {
 			// oldLocation = mousePoint;
 		}
 
+		@Override
 		public void mouseEntered(org.eclipse.draw2d.MouseEvent me) {
 
 		}
 
+		@Override
 		public void mouseExited(org.eclipse.draw2d.MouseEvent me) {
 
 		}
 
+		@Override
 		public void mouseHover(org.eclipse.draw2d.MouseEvent me) {
 
 		}
@@ -557,6 +567,7 @@ public class Graph extends FigureCanvas implements IContainer {
 		 * fisheye(ing) nodes. This means whenever the mouse moves we check if we need
 		 * to fisheye on a node or not.
 		 */
+		@Override
 		public void mouseMoved(org.eclipse.draw2d.MouseEvent me) {
 			Point mousePoint = new Point(me.x, me.y);
 			getRootLayer().translateToRelative(mousePoint);
@@ -609,10 +620,12 @@ public class Graph extends FigureCanvas implements IContainer {
 			}
 		}
 
+		@Override
 		public void mouseDoubleClicked(org.eclipse.draw2d.MouseEvent me) {
 
 		}
 
+		@Override
 		public void mousePressed(org.eclipse.draw2d.MouseEvent me) {
 			isDragging = true;
 			Point mousePoint = new Point(me.x, me.y);
@@ -709,6 +722,7 @@ public class Graph extends FigureCanvas implements IContainer {
 
 		}
 
+		@Override
 		public void mouseReleased(org.eclipse.draw2d.MouseEvent me) {
 			isDragging = false;
 
@@ -1116,10 +1130,12 @@ public class Graph extends FigureCanvas implements IContainer {
 		MyRunnable myRunnable = new MyRunnable() {
 			boolean isVisible;
 
+			@Override
 			public boolean isVisible() {
 				return this.isVisible;
 			}
 
+			@Override
 			public void run() {
 				isVisible = Graph.this.isVisible();
 			}
@@ -1250,11 +1266,13 @@ public class Graph extends FigureCanvas implements IContainer {
 		this.getRootLayer().getUpdateManager().performUpdate();
 	}
 
+	@Override
 	public Graph getGraph() {
 		// @tag refactor : Is this method really needed
 		return this.getGraphModel();
 	}
 
+	@Override
 	public int getItemType() {
 		return GraphItem.GRAPH;
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -164,6 +164,7 @@ public class GraphConnection extends GraphItem {
 
 	}
 
+	@Override
 	public void dispose() {
 		super.dispose();
 		this.isDisposed = true;
@@ -178,6 +179,7 @@ public class GraphConnection extends GraphItem {
 		}
 	}
 
+	@Override
 	public boolean isDisposed() {
 		return isDisposed;
 	}
@@ -212,6 +214,7 @@ public class GraphConnection extends GraphItem {
 	 * 
 	 * @return String
 	 */
+	@Override
 	public String toString() {
 		String arrow = (isBidirectionalInLayout() ? " <--> " : " --> ");
 		String src = (sourceNode != null ? sourceNode.getText() : "null");
@@ -418,6 +421,7 @@ public class GraphConnection extends GraphItem {
 	/**
 	 * Highlights this node. Uses the default highlight color.
 	 */
+	@Override
 	public void highlight() {
 		if (highlighted) {
 			return;
@@ -430,6 +434,7 @@ public class GraphConnection extends GraphItem {
 	/**
 	 * Unhighlights this node. Uses the default color.
 	 */
+	@Override
 	public void unhighlight() {
 		if (!highlighted) {
 			return;
@@ -453,6 +458,7 @@ public class GraphConnection extends GraphItem {
 	 * 
 	 * @return The graph model that this connection is contained in
 	 */
+	@Override
 	public Graph getGraphModel() {
 		return this.graphModel;
 	}
@@ -488,6 +494,7 @@ public class GraphConnection extends GraphItem {
 	 * 
 	 * @see org.eclipse.mylar.zest.core.widgets.IGraphItem#getItemType()
 	 */
+	@Override
 	public int getItemType() {
 		return CONNECTION;
 	}
@@ -498,6 +505,7 @@ public class GraphConnection extends GraphItem {
 	 * @see org.eclipse.mylar.zest.core.internal.graphmodel.GraphItem#setVisible(
 	 * boolean)
 	 */
+	@Override
 	public void setVisible(boolean visible) {
 		// graphModel.addRemoveFigure(this, visible);
 		if (getSource().isVisible() && getDestination().isVisible() && visible) {
@@ -527,6 +535,7 @@ public class GraphConnection extends GraphItem {
 	 * 
 	 * @see org.eclipse.mylar.zest.core.widgets.IGraphItem#isVisible()
 	 */
+	@Override
 	public boolean isVisible() {
 		return visible;
 	}
@@ -536,6 +545,7 @@ public class GraphConnection extends GraphItem {
 	 * 
 	 * @see org.eclipse.swt.widgets.Item#setText(java.lang.String)
 	 */
+	@Override
 	public void setText(String string) {
 		super.setText(string);
 
@@ -651,6 +661,7 @@ public class GraphConnection extends GraphItem {
 			sourceAnchor = new LoopAnchor(getSource().getFigure());
 			targetAnchor = new LoopAnchor(getDestination().getFigure());
 			labelLocator = new MidpointLocator(connectionFigure, 0) {
+				@Override
 				protected Point getReferencePoint() {
 					Point p = Point.SINGLETON;
 					p.x = getConnection().getPoints().getPoint(getIndex()).x;
@@ -699,44 +710,54 @@ public class GraphConnection extends GraphItem {
 
 		Object layoutInformation = null;
 
+		@Override
 		public void clearBendPoints() {
 			// @tag TODO : add bendpoints
 		}
 
+		@Override
 		public LayoutEntity getDestinationInLayout() {
 			return getDestination().getLayoutEntity();
 		}
 
+		@Override
 		public Object getLayoutInformation() {
 			return layoutInformation;
 		}
 
+		@Override
 		public LayoutEntity getSourceInLayout() {
 			return getSource().getLayoutEntity();
 		}
 
+		@Override
 		public void populateLayoutConstraint(LayoutConstraint constraint) {
 			graphModel.invokeConstraintAdapters(GraphConnection.this, constraint);
 		}
 
+		@Override
 		public void setBendPoints(LayoutBendPoint[] bendPoints) {
 			// @tag TODO : add bendpoints
 		}
 
+		@Override
 		public void setLayoutInformation(Object layoutInformation) {
 			this.layoutInformation = layoutInformation;
 		}
 
+		@Override
 		public Object getGraphData() {
 			return GraphConnection.this;
 		}
 
+		@Override
 		public void setGraphData(Object o) {
 
 		}
 
 	}
 
+	@Override
 	IFigure getFigure() {
 		return this.getConnectionFigure();
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
@@ -111,6 +111,7 @@ public class GraphContainer extends GraphNode implements IContainer {
 	 * 
 	 * /** Gets the figure for this container.
 	 */
+	@Override
 	public IFigure getNodeFigure() {
 		return this.nodeFigure;
 	}
@@ -517,10 +518,12 @@ public class GraphContainer extends GraphNode implements IContainer {
 	/**
 	 * Gets the graph that this container has been added to.
 	 */
+	@Override
 	public Graph getGraph() {
 		return this.graph.getGraph();
 	}
 
+	@Override
 	public int getItemType() {
 		return CONTAINER;
 	}
@@ -528,6 +531,7 @@ public class GraphContainer extends GraphNode implements IContainer {
 	/**
 	 * 
 	 */
+	@Override
 	public void setLayoutAlgorithm(LayoutAlgorithm algorithm, boolean applyLayout) {
 		this.layoutAlgorithm = algorithm;
 		if (applyLayout) {
@@ -536,6 +540,7 @@ public class GraphContainer extends GraphNode implements IContainer {
 
 	}
 
+	@Override
 	public void applyLayout() {
 		if ((this.getNodes().size() == 0)) {
 			return;
@@ -617,6 +622,7 @@ public class GraphContainer extends GraphNode implements IContainer {
 	/***************************************************************************
 	 * NON API MEMBERS
 	 **************************************************************************/
+	@Override
 	protected void initFigure() {
 		setModelFigure(createContainerFigure());
 		if (graph.getHideNodesEnabled()) {
@@ -765,6 +771,7 @@ public class GraphContainer extends GraphNode implements IContainer {
 		return containerFigure;
 	}
 
+	@Override
 	protected void updateFigureForModel(IFigure currentFigure) {
 
 		expandGraphLabel.setTextT(getText());
@@ -861,10 +868,12 @@ public class GraphContainer extends GraphNode implements IContainer {
 		// Containers cannot be added to other containers (yet)
 	}
 
+	@Override
 	public List getNodes() {
 		return this.childNodes;
 	}
 
+	@Override
 	void paint() {
 		Iterator iterator = getNodes().iterator();
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphItem.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphItem.java
@@ -51,6 +51,7 @@ public abstract class GraphItem extends Item {
 	 * 
 	 * @see org.eclipse.swt.widgets.Widget#dispose()
 	 */
+	@Override
 	public void dispose() {
 		// @tag zest.bug.167132-ListenerDispose : remove all listeners.
 		// pcsDelegate = new PropertyChangeSupport(this);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -179,6 +179,7 @@ public class GraphNode extends GraphItem {
 	/**
 	 * A simple toString that we can use for debugging
 	 */
+	@Override
 	public String toString() {
 		return "GraphModelNode: " + getText();
 	}
@@ -192,6 +193,7 @@ public class GraphNode extends GraphItem {
 	 * 
 	 * @see org.eclipse.mylar.zest.core.widgets.GraphItem#dispose()
 	 */
+	@Override
 	public void dispose() {
 		if (isFisheyeEnabled) {
 			this.fishEye(false, false);
@@ -222,6 +224,7 @@ public class GraphNode extends GraphItem {
 	 * 
 	 * @see org.eclipse.swt.widgets.Widget#isDisposed()
 	 */
+	@Override
 	public boolean isDisposed() {
 		return isDisposed;
 	}
@@ -425,6 +428,7 @@ public class GraphNode extends GraphItem {
 	 * source and destination connections are also highlighted, and the adjacent
 	 * nodes are highlighted too in a different color.
 	 */
+	@Override
 	public void highlight() {
 		if (highlighted == HIGHLIGHT_ON) {
 			return;
@@ -452,6 +456,7 @@ public class GraphNode extends GraphItem {
 	/**
 	 * Restores the nodes original background color and border width.
 	 */
+	@Override
 	public void unhighlight() {
 
 		// @tag ADJACENT : Removed highlight adjacent
@@ -568,6 +573,7 @@ public class GraphNode extends GraphItem {
 	 * 
 	 * @see org.eclipse.swt.widgets.Item#setText(java.lang.String)
 	 */
+	@Override
 	public void setText(String string) {
 		if (string == null) {
 			string = "";
@@ -584,6 +590,7 @@ public class GraphNode extends GraphItem {
 	 * 
 	 * @see org.eclipse.swt.widgets.Item#setImage(org.eclipse.swt.graphics.Image)
 	 */
+	@Override
 	public void setImage(Image image) {
 		super.setImage(image);
 		if (nodeFigure != null) {
@@ -596,6 +603,7 @@ public class GraphNode extends GraphItem {
 	 * 
 	 * @return The graph model that this node is contained in
 	 */
+	@Override
 	public Graph getGraphModel() {
 		return this.graph;
 	}
@@ -656,6 +664,7 @@ public class GraphNode extends GraphItem {
 		return this.nodeFigure;
 	}
 
+	@Override
 	public void setVisible(boolean visible) {
 		// graph.addRemoveFigure(this, visible);
 		this.visible = visible;
@@ -701,6 +710,7 @@ public class GraphNode extends GraphItem {
 		return this.hideNodeHelper;
 	}
 
+	@Override
 	public int getStyle() {
 		return super.getStyle() | this.getNodeStyle();
 	}
@@ -873,6 +883,7 @@ public class GraphNode extends GraphItem {
 		return label;
 	}
 
+	@Override
 	public boolean isVisible() {
 		return visible;
 	}
@@ -925,6 +936,7 @@ public class GraphNode extends GraphItem {
 	 * 
 	 * @see org.eclipse.mylar.zest.core.widgets.IGraphItem#getItemType()
 	 */
+	@Override
 	public int getItemType() {
 		return NODE;
 	}
@@ -932,43 +944,53 @@ public class GraphNode extends GraphItem {
 	class LayoutGraphNode implements LayoutEntity {
 		Object layoutInformation = null;
 
+		@Override
 		public double getHeightInLayout() {
 			return getSize().height;
 		}
 
+		@Override
 		public Object getLayoutInformation() {
 			return layoutInformation;
 		}
 
+		@Override
 		public String toString() {
 			return getText();
 		}
 
+		@Override
 		public double getWidthInLayout() {
 			return getSize().width;
 		}
 
+		@Override
 		public double getXInLayout() {
 			return getLocation().x;
 		}
 
+		@Override
 		public double getYInLayout() {
 			return getLocation().y;
 		}
 
+		@Override
 		public void populateLayoutConstraint(LayoutConstraint constraint) {
 			invokeLayoutListeners(constraint);
 		}
 
+		@Override
 		public void setLayoutInformation(Object internalEntity) {
 			this.layoutInformation = internalEntity;
 
 		}
 
+		@Override
 		public void setLocationInLayout(double x, double y) {
 			setLocation(x, y);
 		}
 
+		@Override
 		public void setSizeInLayout(double width, double height) {
 			setSize(width, height);
 		}
@@ -976,6 +998,7 @@ public class GraphNode extends GraphItem {
 		/**
 		 * Compares two nodes.
 		 */
+		@Override
 		public int compareTo(Object otherNode) {
 			int rv = 0;
 			if (otherNode instanceof GraphNode) {
@@ -987,10 +1010,12 @@ public class GraphNode extends GraphItem {
 			return rv;
 		}
 
+		@Override
 		public Object getGraphData() {
 			return GraphNode.this;
 		}
 
+		@Override
 		public void setGraphData(Object o) {
 			// TODO Auto-generated method stub
 
@@ -1004,6 +1029,7 @@ public class GraphNode extends GraphItem {
 	 * 
 	 * @return modelFigure.
 	 */
+	@Override
 	IFigure getFigure() {
 		if (this.modelFigure == null) {
 			initFigure();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AligningBendpointLocator.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AligningBendpointLocator.java
@@ -99,6 +99,7 @@ public class AligningBendpointLocator extends AbstractLocator {
 	 * 
 	 * @see org.eclipse.draw2d.ConnectionLocator#getReferencePoint()
 	 */
+	@Override
 	protected Point getReferencePoint() {
 		PointList points = getConnection().getPoints();
 		Point p = points.getMidpoint().getCopy();
@@ -133,6 +134,7 @@ public class AligningBendpointLocator extends AbstractLocator {
 	 * 
 	 * @param target The figure to relocate
 	 */
+	@Override
 	public void relocate(IFigure target) {
 		Dimension prefSize = target.getPreferredSize();
 		Point center = getReferencePoint();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AspectRatioFreeformLayer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AspectRatioFreeformLayer.java
@@ -41,6 +41,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		// setOpaque(false);
 	}
 
+	@Override
 	protected boolean isValidationRoot() {
 		return true;
 	}
@@ -63,6 +64,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 	 * return true; }
 	 */
 
+	@Override
 	public double getScale() {
 		// TODO Auto-generated method stub
 		throw new RuntimeException("Operation not supported");
@@ -71,6 +73,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		// throw new RuntimeException("Operation Not supported");
 	}
 
+	@Override
 	public void setScale(double scale) {
 		// super.setScale( scale );
 		this.widthScale = scale;
@@ -85,6 +88,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 	 * @see org.eclipse.draw2d.Figure#getClientArea()
 	 */
 
+	@Override
 	public Rectangle getClientArea(Rectangle rect) {
 		// return super.getClientArea(rect);
 
@@ -95,6 +99,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		return rect;
 	}
 
+	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
 		Dimension d = super.getPreferredSize(wHint, hHint);
 		int w = getInsets().getWidth();
@@ -102,6 +107,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		return d.getExpanded(-w, -h).scale(widthScale, heigthScale).expand(w, h);
 	}
 
+	@Override
 	public void translateFromParent(Translatable t) {
 		super.translateFromParent(t);
 		// t.performScale(1/widthScale);
@@ -141,6 +147,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		// t.performScale(1/widthScale);
 	}
 
+	@Override
 	public void translateToParent(Translatable t) {
 		// t.performScale(widthScale);
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/CachedLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/CachedLabel.java
@@ -55,6 +55,7 @@ public abstract class CachedLabel extends Label {
 	 * 
 	 * @see org.eclipse.draw2d.Label#setIcon(org.eclipse.swt.graphics.Image)
 	 */
+	@Override
 	public void setIcon(Image image) {
 		updateInvalidation();
 		super.setIcon(image);
@@ -66,6 +67,7 @@ public abstract class CachedLabel extends Label {
 	 * @see
 	 * org.eclipse.draw2d.Figure#setForegroundColor(org.eclipse.swt.graphics.Color)
 	 */
+	@Override
 	public void setForegroundColor(Color fg) {
 		updateInvalidation();
 		super.setForegroundColor(fg);
@@ -77,6 +79,7 @@ public abstract class CachedLabel extends Label {
 	 * @see
 	 * org.eclipse.draw2d.Figure#setBackgroundColor(org.eclipse.swt.graphics.Color)
 	 */
+	@Override
 	public void setBackgroundColor(Color bg) {
 		updateInvalidation();
 		super.setBackgroundColor(bg);
@@ -87,6 +90,7 @@ public abstract class CachedLabel extends Label {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#setFont(org.eclipse.swt.graphics.Font)
 	 */
+	@Override
 	public void setFont(Font f) {
 		updateInvalidation();
 		super.setFont(f);
@@ -97,6 +101,7 @@ public abstract class CachedLabel extends Label {
 	 * 
 	 * @see org.eclipse.draw2d.Label#setText(java.lang.String)
 	 */
+	@Override
 	public void setText(String s) {
 		updateInvalidation();
 		super.setText(s);
@@ -107,6 +112,7 @@ public abstract class CachedLabel extends Label {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#setSize(int, int)
 	 */
+	@Override
 	public void setSize(int w, int h) {
 		updateInvalidation();
 
@@ -122,6 +128,7 @@ public abstract class CachedLabel extends Label {
 	 * @see
 	 * org.eclipse.draw2d.Figure#setBounds(org.eclipse.draw2d.geometry.Rectangle)
 	 */
+	@Override
 	public void setBounds(Rectangle rect) {
 		boolean resize = (rect.width != bounds.width) || (rect.height != bounds.height);
 
@@ -151,6 +158,7 @@ public abstract class CachedLabel extends Label {
 	 */
 	static Rectangle tempRect = new Rectangle();
 
+	@Override
 	protected void paintFigure(Graphics graphics) {
 		if (graphics.getClass() == ScaledGraphics.class) {
 			if (((ScaledGraphics) graphics).getAbsoluteScale() < 0.30) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
@@ -86,6 +86,7 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 	 * @see org.eclipse.draw2d.ActionListener#actionPerformed(org.eclipse.draw2d.
 	 * ActionEvent)
 	 */
+	@Override
 	public void actionPerformed(ActionEvent event) {
 		if (state == OPEN) {
 			container.close(true);
@@ -120,6 +121,7 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 			 * 
 			 * @see org.eclipse.draw2d.Label#paintFigure(org.eclipse.draw2d.Graphics)
 			 */
+			@Override
 			protected void paintFigure(Graphics graphics) {
 				if (isOpaque()) {
 					super.paintFigure(graphics);
@@ -188,6 +190,7 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 	 * 
 	 * @see org.eclipse.draw2d.Label#paintFigure(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	public void paint(Graphics graphics) {
 
 		int blue = getBackgroundColor().getBlue();
@@ -274,11 +277,13 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 		// adjustBoundsToFit();
 	}
 
+	@Override
 	public void setLocation(Point p) {
 		// TODO Auto-generated method stub
 		super.setLocation(p);
 	}
 
+	@Override
 	public void setBounds(Rectangle rect) {
 		// TODO Auto-generated method stub
 		super.setBounds(rect);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
@@ -103,6 +103,7 @@ public class GraphLabel extends CachedLabel {
 	 * 
 	 * @see org.eclipse.draw2d.Figure#setFont(org.eclipse.swt.graphics.Font)
 	 */
+	@Override
 	public void setFont(Font f) {
 		super.setFont(f);
 		adjustBoundsToFit();
@@ -134,6 +135,7 @@ public class GraphLabel extends CachedLabel {
 	 * 
 	 * @see org.eclipse.draw2d.Label#paintFigure(org.eclipse.draw2d.Graphics)
 	 */
+	@Override
 	public void paint(Graphics graphics) {
 		int blue = getBackgroundColor().getBlue();
 		blue = (int) (blue - (blue * 0.20));
@@ -204,6 +206,7 @@ public class GraphLabel extends CachedLabel {
 		lightenColor.dispose();
 	}
 
+	@Override
 	protected Color getBackgroundTextColor() {
 		return getBackgroundColor();
 	}
@@ -216,6 +219,7 @@ public class GraphLabel extends CachedLabel {
 	 * 
 	 * @see org.eclipse.draw2d.Label#invalidate()
 	 */
+	@Override
 	public void invalidate() {
 		if (!painting) {
 			super.invalidate();
@@ -227,6 +231,7 @@ public class GraphLabel extends CachedLabel {
 	 * 
 	 * @see org.eclipse.draw2d.Label#setText(java.lang.String)
 	 */
+	@Override
 	public void setText(String s) {
 		if (!s.equals("")) {
 			super.setText(s);
@@ -242,6 +247,7 @@ public class GraphLabel extends CachedLabel {
 	 * 
 	 * @see org.eclipse.draw2d.Label#setIcon(org.eclipse.swt.graphics.Image)
 	 */
+	@Override
 	public void setIcon(Image image) {
 		super.setIcon(image);
 		// adjustBoundsToFit();
@@ -271,6 +277,7 @@ public class GraphLabel extends CachedLabel {
 		this.arcWidth = arcWidth;
 	}
 
+	@Override
 	public void setBounds(Rectangle rect) {
 		// TODO Auto-generated method stub
 		super.setBounds(rect);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/PolylineArcConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/PolylineArcConnection.java
@@ -44,6 +44,7 @@ public class PolylineArcConnection extends PolylineConnection {
 	 * @see
 	 * org.eclipse.draw2d.Polyline#setPoints(org.eclipse.draw2d.geometry.PointList )
 	 */
+	@Override
 	public void setPoints(PointList points) {
 		updateArc(points);
 	}
@@ -52,6 +53,7 @@ public class PolylineArcConnection extends PolylineConnection {
 	 * This method is not supported by this kind of connection. Points are
 	 * calculated based on the arc definition.
 	 */
+	@Override
 	public void addPoint(Point pt) {
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/RoundedChopboxAnchor.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/RoundedChopboxAnchor.java
@@ -42,6 +42,7 @@ public class RoundedChopboxAnchor extends ChopboxAnchor {
 	 * 
 	 * @return Point
 	 */
+	@Override
 	public Point getLocation(Point reference) {
 		Point p = super.getLocation(reference);
 		Rectangle bounds = getBox();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/XYScaledGraphics.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/XYScaledGraphics.java
@@ -60,10 +60,12 @@ public class XYScaledGraphics extends ScaledGraphics {
 			this.height = height;
 		}
 
+		@Override
 		public boolean equals(Object obj) {
 			return (((FontKey) obj).font.equals(font) && ((FontKey) obj).height == height);
 		}
 
+		@Override
 		public int hashCode() {
 			return font.hashCode() ^ height;
 		}
@@ -170,6 +172,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#clipRect(Rectangle) */
+	@Override
 	public void clipRect(Rectangle r) {
 		graphics.clipRect(zoomClipRect(r));
 	}
@@ -179,6 +182,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#dispose() */
+	@Override
 	public void dispose() {
 		// Remove all states from the stack
 		while (stackPointer > 0) {
@@ -195,6 +199,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#drawArc(int, int, int, int, int, int) */
+	@Override
 	public void drawArc(int x, int y, int w, int h, int offset, int sweep) {
 		Rectangle z = zoomRect(x, y, w, h);
 		if (z.isEmpty() || sweep == 0) {
@@ -204,11 +209,13 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#drawFocus(int, int, int, int) */
+	@Override
 	public void drawFocus(int x, int y, int w, int h) {
 		graphics.drawFocus(zoomRect(x, y, w, h));
 	}
 
 	/** @see Graphics#drawImage(Image, int, int) */
+	@Override
 	public void drawImage(Image srcImage, int x, int y) {
 		org.eclipse.swt.graphics.Rectangle size = srcImage.getBounds();
 		double imageZoom = Math.min(xZoom, yZoom);
@@ -219,6 +226,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#drawImage(Image, int, int, int, int, int, int, int, int) */
+	@Override
 	public void drawImage(Image srcImage, int sx, int sy, int sw, int sh, int tx, int ty, int tw, int th) {
 		// "t" == target rectangle, "s" = source
 
@@ -229,6 +237,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#drawLine(int, int, int, int) */
+	@Override
 	public void drawLine(int x1, int y1, int x2, int y2) {
 		graphics.drawLine((int) (Math.floor((x1 * xZoom + fractionalX))),
 				(int) (Math.floor((y1 * yZoom + fractionalY))), (int) (Math.floor((x2 * xZoom + fractionalX))),
@@ -236,11 +245,13 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#drawOval(int, int, int, int) */
+	@Override
 	public void drawOval(int x, int y, int w, int h) {
 		graphics.drawOval(zoomRect(x, y, w, h));
 	}
 
 	/** @see Graphics#drawPoint(int, int) */
+	@Override
 	public void drawPoint(int x, int y) {
 		graphics.drawPoint((int) Math.floor(x * xZoom + fractionalX), (int) Math.floor(y * yZoom + fractionalY));
 	}
@@ -248,11 +259,13 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#drawPolygon(int[])
 	 */
+	@Override
 	public void drawPolygon(int[] points) {
 		graphics.drawPolygon(zoomPointList(points));
 	}
 
 	/** @see Graphics#drawPolygon(PointList) */
+	@Override
 	public void drawPolygon(PointList points) {
 		graphics.drawPolygon(zoomPointList(points.toIntArray()));
 	}
@@ -260,27 +273,32 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#drawPolyline(int[])
 	 */
+	@Override
 	public void drawPolyline(int[] points) {
 		graphics.drawPolyline(zoomPointList(points));
 	}
 
 	/** @see Graphics#drawPolyline(PointList) */
+	@Override
 	public void drawPolyline(PointList points) {
 		graphics.drawPolyline(zoomPointList(points.toIntArray()));
 	}
 
 	/** @see Graphics#drawRectangle(int, int, int, int) */
+	@Override
 	public void drawRectangle(int x, int y, int w, int h) {
 		graphics.drawRectangle(zoomRect(x, y, w, h));
 	}
 
 	/** @see Graphics#drawRoundRectangle(Rectangle, int, int) */
+	@Override
 	public void drawRoundRectangle(Rectangle r, int arcWidth, int arcHeight) {
 		graphics.drawRoundRectangle(zoomRect(r.x, r.y, r.width, r.height), (int) (arcWidth * xZoom),
 				(int) (arcHeight * yZoom));
 	}
 
 	/** @see Graphics#drawString(String, int, int) */
+	@Override
 	public void drawString(String s, int x, int y) {
 		if (allowText) {
 			graphics.drawString(s, zoomTextPoint(x, y));
@@ -288,6 +306,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#drawText(String, int, int) */
+	@Override
 	public void drawText(String s, int x, int y) {
 		if (allowText) {
 			graphics.drawText(s, zoomTextPoint(x, y));
@@ -297,6 +316,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#drawText(String, int, int, int)
 	 */
+	@Override
 	public void drawText(String s, int x, int y, int style) {
 		if (allowText) {
 			graphics.drawText(s, zoomTextPoint(x, y), style);
@@ -306,6 +326,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#drawTextLayout(TextLayout, int, int, int, int, Color, Color)
 	 */
+	@Override
 	public void drawTextLayout(TextLayout layout, int x, int y, int selectionStart, int selectionEnd,
 			Color selectionForeground, Color selectionBackground) {
 		TextLayout scaled = zoomTextLayout(layout);
@@ -316,6 +337,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#fillArc(int, int, int, int, int, int) */
+	@Override
 	public void fillArc(int x, int y, int w, int h, int offset, int sweep) {
 		Rectangle z = zoomFillRect(x, y, w, h);
 		if (z.isEmpty() || sweep == 0) {
@@ -325,11 +347,13 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#fillGradient(int, int, int, int, boolean) */
+	@Override
 	public void fillGradient(int x, int y, int w, int h, boolean vertical) {
 		graphics.fillGradient(zoomFillRect(x, y, w, h), vertical);
 	}
 
 	/** @see Graphics#fillOval(int, int, int, int) */
+	@Override
 	public void fillOval(int x, int y, int w, int h) {
 		graphics.fillOval(zoomFillRect(x, y, w, h));
 	}
@@ -337,27 +361,32 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#fillPolygon(int[])
 	 */
+	@Override
 	public void fillPolygon(int[] points) {
 		graphics.fillPolygon(zoomPointList(points));
 	}
 
 	/** @see Graphics#fillPolygon(PointList) */
+	@Override
 	public void fillPolygon(PointList points) {
 		graphics.fillPolygon(zoomPointList(points.toIntArray()));
 	}
 
 	/** @see Graphics#fillRectangle(int, int, int, int) */
+	@Override
 	public void fillRectangle(int x, int y, int w, int h) {
 		graphics.fillRectangle(zoomFillRect(x, y, w, h));
 	}
 
 	/** @see Graphics#fillRoundRectangle(Rectangle, int, int) */
+	@Override
 	public void fillRoundRectangle(Rectangle r, int arcWidth, int arcHeight) {
 		graphics.fillRoundRectangle(zoomFillRect(r.x, r.y, r.width, r.height), (int) (arcWidth * xZoom),
 				(int) (arcHeight * yZoom));
 	}
 
 	/** @see Graphics#fillString(String, int, int) */
+	@Override
 	public void fillString(String s, int x, int y) {
 		if (allowText) {
 			graphics.fillString(s, zoomTextPoint(x, y));
@@ -365,6 +394,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#fillText(String, int, int) */
+	@Override
 	public void fillText(String s, int x, int y) {
 		if (allowText) {
 			graphics.fillText(s, zoomTextPoint(x, y));
@@ -374,6 +404,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getAbsoluteScale()
 	 */
+	@Override
 	public double getAbsoluteScale() {
 		return xZoom * graphics.getAbsoluteScale();
 	}
@@ -381,6 +412,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getAlpha()
 	 */
+	@Override
 	public int getAlpha() {
 		return graphics.getAlpha();
 	}
@@ -388,11 +420,13 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getAntialias()
 	 */
+	@Override
 	public int getAntialias() {
 		return graphics.getAntialias();
 	}
 
 	/** @see Graphics#getBackgroundColor() */
+	@Override
 	public Color getBackgroundColor() {
 		return graphics.getBackgroundColor();
 	}
@@ -421,6 +455,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#getClip(Rectangle) */
+	@Override
 	public Rectangle getClip(Rectangle rect) {
 		graphics.getClip(rect);
 		int x = (int) (rect.x / xZoom);
@@ -441,21 +476,25 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getFillRule()
 	 */
+	@Override
 	public int getFillRule() {
 		return graphics.getFillRule();
 	}
 
 	/** @see Graphics#getFont() */
+	@Override
 	public Font getFont() {
 		return getLocalFont();
 	}
 
 	/** @see Graphics#getFontMetrics() */
+	@Override
 	public FontMetrics getFontMetrics() {
 		return FigureUtilities.getFontMetrics(localFont);
 	}
 
 	/** @see Graphics#getForegroundColor() */
+	@Override
 	public Color getForegroundColor() {
 		return graphics.getForegroundColor();
 	}
@@ -463,6 +502,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getInterpolation()
 	 */
+	@Override
 	public int getInterpolation() {
 		return graphics.getInterpolation();
 	}
@@ -470,6 +510,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getLineCap()
 	 */
+	@Override
 	public int getLineCap() {
 		return graphics.getLineCap();
 	}
@@ -477,16 +518,19 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getLineJoin()
 	 */
+	@Override
 	public int getLineJoin() {
 		return graphics.getLineJoin();
 	}
 
 	/** @see Graphics#getLineStyle() */
+	@Override
 	public int getLineStyle() {
 		return graphics.getLineStyle();
 	}
 
 	/** @see Graphics#getLineWidth() */
+	@Override
 	public int getLineWidth() {
 		return getLocalLineWidth();
 	}
@@ -502,16 +546,19 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#getTextAntialias()
 	 */
+	@Override
 	public int getTextAntialias() {
 		return graphics.getTextAntialias();
 	}
 
 	/** @see Graphics#getXORMode() */
+	@Override
 	public boolean getXORMode() {
 		return graphics.getXORMode();
 	}
 
 	/** @see Graphics#popState() */
+	@Override
 	public void popState() {
 		graphics.popState();
 		stackPointer--;
@@ -519,6 +566,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#pushState() */
+	@Override
 	public void pushState() {
 		State s;
 		if (stack.size() > stackPointer) {
@@ -541,6 +589,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#restoreState() */
+	@Override
 	public void restoreState() {
 		graphics.restoreState();
 		restoreLocalState((State) stack.get(stackPointer - 1));
@@ -552,6 +601,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	/** @see Graphics#scale(double) */
+	@Override
 	public void scale(double amount) {
 		// setScale(zoom * amount);
 		throw new RuntimeException("Operation not supported, use scale(x, y)");
@@ -560,6 +610,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#setAlpha(int)
 	 */
+	@Override
 	public void setAlpha(int alpha) {
 		graphics.setAlpha(alpha);
 	}
@@ -567,16 +618,19 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#setAntialias(int)
 	 */
+	@Override
 	public void setAntialias(int value) {
 		graphics.setAntialias(value);
 	}
 
 	/** @see Graphics#setBackgroundColor(Color) */
+	@Override
 	public void setBackgroundColor(Color rgb) {
 		graphics.setBackgroundColor(rgb);
 	}
 
 	/** @see Graphics#setClip(Rectangle) */
+	@Override
 	public void setClip(Rectangle r) {
 		graphics.setClip(zoomClipRect(r));
 	}
@@ -584,16 +638,19 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#setFillRule(int)
 	 */
+	@Override
 	public void setFillRule(int rule) {
 		graphics.setFillRule(rule);
 	}
 
 	/** @see Graphics#setFont(Font) */
+	@Override
 	public void setFont(Font f) {
 		setLocalFont(f);
 	}
 
 	/** @see Graphics#setForegroundColor(Color) */
+	@Override
 	public void setForegroundColor(Color rgb) {
 		graphics.setForegroundColor(rgb);
 	}
@@ -601,6 +658,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see org.eclipse.draw2d.Graphics#setInterpolation(int)
 	 */
+	@Override
 	public void setInterpolation(int interpolation) {
 		graphics.setInterpolation(interpolation);
 	}
@@ -608,6 +666,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#setLineCap(int)
 	 */
+	@Override
 	public void setLineCap(int cap) {
 		graphics.setLineCap(cap);
 	}
@@ -615,6 +674,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#setLineDash(int[])
 	 */
+	@Override
 	public void setLineDash(int[] dash) {
 		graphics.setLineDash(dash);
 	}
@@ -622,16 +682,19 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#setLineJoin(int)
 	 */
+	@Override
 	public void setLineJoin(int join) {
 		graphics.setLineJoin(join);
 	}
 
 	/** @see Graphics#setLineStyle(int) */
+	@Override
 	public void setLineStyle(int style) {
 		graphics.setLineStyle(style);
 	}
 
 	/** @see Graphics#setLineWidth(int) */
+	@Override
 	public void setLineWidth(int width) {
 		setLocalLineWidth(width);
 	}
@@ -669,16 +732,19 @@ public class XYScaledGraphics extends ScaledGraphics {
 	/**
 	 * @see Graphics#setTextAntialias(int)
 	 */
+	@Override
 	public void setTextAntialias(int value) {
 		graphics.setTextAntialias(value);
 	}
 
 	/** @see Graphics#setXORMode(boolean) */
+	@Override
 	public void setXORMode(boolean b) {
 		graphics.setXORMode(b);
 	}
 
 	/** @see Graphics#translate(int, int) */
+	@Override
 	public void translate(int dx, int dy) {
 		// fractionalX/Y is the fractional part left over from previous
 		// translates that gets lost in the integer approximation.

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet1.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet1.java
@@ -44,6 +44,7 @@ public class GraphJFaceSnippet1 {
 	 */
 	static class MyContentProvider implements IGraphEntityContentProvider {
 
+		@Override
 		public Object[] getConnectedTo(Object entity) {
 			if (entity.equals("First")) {
 				return new Object[] { "Second" };
@@ -57,6 +58,7 @@ public class GraphJFaceSnippet1 {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object inputElement) {
 			return new String[] { "First", "Second", "Third" };
 		}
@@ -65,10 +67,12 @@ public class GraphJFaceSnippet1 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 
 		}
@@ -77,6 +81,7 @@ public class GraphJFaceSnippet1 {
 	static class MyLabelProvider extends LabelProvider {
 		final Image image = Display.getDefault().getSystemImage(SWT.ICON_WARNING);
 
+		@Override
 		public Image getImage(Object element) {
 			if (element instanceof String) {
 				return image;
@@ -84,6 +89,7 @@ public class GraphJFaceSnippet1 {
 			return null;
 		}
 
+		@Override
 		public String getText(Object element) {
 			if (element instanceof String) {
 				return element.toString();
@@ -107,6 +113,7 @@ public class GraphJFaceSnippet1 {
 		button.setText("Reload");
 		button.addSelectionListener(new SelectionAdapter() {
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				viewer.setInput(new Object());
 			}
@@ -118,6 +125,7 @@ public class GraphJFaceSnippet1 {
 		viewer.setLabelProvider(new MyLabelProvider());
 		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm(LayoutStyles.NO_LAYOUT_NODE_RESIZING));
 		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
+			@Override
 			public void selectionChanged(SelectionChangedEvent event) {
 				System.out.println("Selection changed: " + (event.getSelection()));
 			}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet2.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet2.java
@@ -38,6 +38,7 @@ public class GraphJFaceSnippet2 {
 
 	static class MyContentProvider implements IGraphContentProvider {
 
+		@Override
 		public Object getDestination(Object rel) {
 			if ("Rock2Paper".equals(rel)) {
 				return "Rock";
@@ -49,10 +50,12 @@ public class GraphJFaceSnippet2 {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object input) {
 			return new Object[] { "Rock2Paper", "Paper2Scissors", "Scissors2Rock" };
 		}
 
+		@Override
 		public Object getSource(Object rel) {
 			if ("Rock2Paper".equals(rel)) {
 				return "Paper";
@@ -68,9 +71,11 @@ public class GraphJFaceSnippet2 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 		}
 
@@ -79,6 +84,7 @@ public class GraphJFaceSnippet2 {
 	static class MyLabelProvider extends LabelProvider {
 		final Image image = Display.getDefault().getSystemImage(SWT.ICON_WARNING);
 
+		@Override
 		public Image getImage(Object element) {
 			if (element.equals("Rock") || element.equals("Paper") || element.equals("Scissors")) {
 				return image;
@@ -86,6 +92,7 @@ public class GraphJFaceSnippet2 {
 			return null;
 		}
 
+		@Override
 		public String getText(Object element) {
 			return element.toString();
 		}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet3.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet3.java
@@ -49,12 +49,14 @@ public class GraphJFaceSnippet3 {
 
 		private StringTokenizer graph;
 
+		@Override
 		public Object getDestination(Object rel) {
 			String string = (String) rel;
 			String[] parts = string.split(" ");
 			return parts[2];
 		}
 
+		@Override
 		public Object[] getElements(Object input) {
 			ArrayList listOfEdges = new ArrayList();
 			while (graph.hasMoreTokens()) {
@@ -63,6 +65,7 @@ public class GraphJFaceSnippet3 {
 			return listOfEdges.toArray();
 		}
 
+		@Override
 		public Object getSource(Object rel) {
 			String string = (String) rel;
 			String[] parts = string.split(" ");
@@ -73,10 +76,12 @@ public class GraphJFaceSnippet3 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 			if (newInput != null) {
 				graph = new StringTokenizer((String) newInput, "\n");

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet4.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet4.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.Shell;
 public class GraphJFaceSnippet4 {
 	static class MyContentProvider implements IGraphContentProvider {
 
+		@Override
 		public Object getDestination(Object rel) {
 			if ("Rock2Paper".equals(rel)) {
 				return "Rock";
@@ -40,10 +41,12 @@ public class GraphJFaceSnippet4 {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object input) {
 			return new Object[] { "Rock2Paper", "Paper2Scissors", "Scissors2Rock" };
 		}
 
+		@Override
 		public Object getSource(Object rel) {
 			if ("Rock2Paper".equals(rel)) {
 				return "Paper";
@@ -59,9 +62,11 @@ public class GraphJFaceSnippet4 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 		}
 
@@ -70,6 +75,7 @@ public class GraphJFaceSnippet4 {
 	static class MyLabelProvider extends LabelProvider {
 		final Image image = Display.getDefault().getSystemImage(SWT.ICON_WARNING);
 
+		@Override
 		public Image getImage(Object element) {
 			if (element.equals("Rock") || element.equals("Paper") || element.equals("Scissors")) {
 				return image;
@@ -77,6 +83,7 @@ public class GraphJFaceSnippet4 {
 			return null;
 		}
 
+		@Override
 		public String getText(Object element) {
 			return element.toString();
 		}
@@ -101,6 +108,7 @@ public class GraphJFaceSnippet4 {
 		viewer.setInput(new Object());
 		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
 
+			@Override
 			public void selectionChanged(SelectionChangedEvent event) {
 				System.out
 						.println("Selection Changed: " + selectionToString((StructuredSelection) event.getSelection()));

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet5.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet5.java
@@ -35,6 +35,7 @@ public class GraphJFaceSnippet5 {
 
 		Object[] elements = new Object[] { "Rock2Paper", "Paper2Scissors", "Scissors2Rock" };
 
+		@Override
 		public Object getDestination(Object rel) {
 			if ("Rock2Paper".equals(rel)) {
 				return "Rock";
@@ -46,10 +47,12 @@ public class GraphJFaceSnippet5 {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object input) {
 			return elements;
 		}
 
+		@Override
 		public Object getSource(Object rel) {
 			if ("Rock2Paper".equals(rel)) {
 				return "Paper";
@@ -69,9 +72,11 @@ public class GraphJFaceSnippet5 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 		}
 
@@ -84,10 +89,12 @@ public class GraphJFaceSnippet5 {
 
 		}
 
+		@Override
 		public String getText(Object element) {
 			return element.toString();
 		}
 
+		@Override
 		public Image getImage(Object element) {
 			return image;
 		}
@@ -122,6 +129,7 @@ public class GraphJFaceSnippet5 {
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("Refresh");
 		button.addSelectionListener(new SelectionAdapter() {
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				contentProvider.setElements(new Object[] { "Rock2Paper", "Scissors2Paper", "Scissors2Rock" });
 				viewer.refresh();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet6.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet6.java
@@ -43,6 +43,7 @@ public class GraphJFaceSnippet6 {
 
 	static class MyContentProvider implements IGraphEntityContentProvider, INestedContentProvider {
 
+		@Override
 		public Object[] getConnectedTo(Object entity) {
 			if (entity.equals("First")) {
 				return new Object[] { "Second" };
@@ -59,6 +60,7 @@ public class GraphJFaceSnippet6 {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object inputElement) {
 			return new String[] { "First", "Second", "Third" };
 		}
@@ -67,19 +69,23 @@ public class GraphJFaceSnippet6 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 
 		}
 
+		@Override
 		public Object[] getChildren(Object element) {
 			// TODO Auto-generated method stub
 			return new Object[] { "rock", "paper", "scissors" };
 		}
 
+		@Override
 		public boolean hasChildren(Object element) {
 			// TODO Auto-generated method stub
 			if (element.equals("First"))
@@ -92,6 +98,7 @@ public class GraphJFaceSnippet6 {
 	static class MyLabelProvider extends LabelProvider {
 		final Image image = Display.getDefault().getSystemImage(SWT.ICON_WARNING);
 
+		@Override
 		public Image getImage(Object element) {
 			if (element.equals("Rock") || element.equals("Paper") || element.equals("Scissors")) {
 				return image;
@@ -99,6 +106,7 @@ public class GraphJFaceSnippet6 {
 			return null;
 		}
 
+		@Override
 		public String getText(Object element) {
 			if (element instanceof EntityConnectionData)
 				return "";
@@ -128,9 +136,11 @@ public class GraphJFaceSnippet6 {
 		button.setText("push");
 		button.addSelectionListener(new SelectionListener() {
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				viewer.setInput(new Object());
 			}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet7.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet7.java
@@ -68,6 +68,7 @@ public class GraphJFaceSnippet7 {
 
 	static class MyContentProvider implements IGraphEntityContentProvider, INestedContentProvider {
 
+		@Override
 		public Object[] getConnectedTo(Object entity) {
 			if (entity.equals("First")) {
 				return new Object[] { "Second" };
@@ -84,6 +85,7 @@ public class GraphJFaceSnippet7 {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object inputElement) {
 			return new String[] { "First", "Second", "Third" };
 		}
@@ -92,19 +94,23 @@ public class GraphJFaceSnippet7 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 
 		}
 
+		@Override
 		public Object[] getChildren(Object element) {
 			// TODO Auto-generated method stub
 			return new Object[] { "rock", "paper", "scissors" };
 		}
 
+		@Override
 		public boolean hasChildren(Object element) {
 			// TODO Auto-generated method stub
 			if (element.equals("First"))
@@ -117,6 +123,7 @@ public class GraphJFaceSnippet7 {
 	static class MyLabelProvider extends LabelProvider implements IFigureProvider {
 		final Image image = Display.getDefault().getSystemImage(SWT.ICON_WARNING);
 
+		@Override
 		public Image getImage(Object element) {
 			if (element.equals("Rock") || element.equals("Paper") || element.equals("Scissors")) {
 				return image;
@@ -124,12 +131,14 @@ public class GraphJFaceSnippet7 {
 			return null;
 		}
 
+		@Override
 		public String getText(Object element) {
 			if (element instanceof EntityConnectionData)
 				return "";
 			return element.toString();
 		}
 
+		@Override
 		public IFigure getFigure(Object element) {
 			Font classFont = new Font(null, "Arial", 12, SWT.BOLD);
 			Image classImage = new Image(Display.getDefault(),
@@ -164,9 +173,11 @@ public class GraphJFaceSnippet7 {
 		button.setText("push");
 		button.addSelectionListener(new SelectionListener() {
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				viewer.setInput(new Object());
 			}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet8.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet8.java
@@ -36,6 +36,7 @@ public class GraphJFaceSnippet8 {
 
 	static class MyContentProvider implements IGraphEntityContentProvider {
 
+		@Override
 		public Object[] getConnectedTo(Object entity) {
 			if (entity.equals("First")) {
 				return new Object[] { "First", "Second" };
@@ -49,6 +50,7 @@ public class GraphJFaceSnippet8 {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object inputElement) {
 			return new String[] { "First", "Second", "Third" };
 		}
@@ -57,10 +59,12 @@ public class GraphJFaceSnippet8 {
 			return 0;
 		}
 
+		@Override
 		public void dispose() {
 
 		}
 
+		@Override
 		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 
 		}
@@ -68,14 +72,17 @@ public class GraphJFaceSnippet8 {
 
 	static class MyLabelProvider extends LabelProvider implements ISelfStyleProvider {
 
+		@Override
 		public Image getImage(Object element) {
 			return null;
 		}
 
+		@Override
 		public String getText(Object element) {
 			return element.toString();
 		}
 
+		@Override
 		public void selfStyleConnection(Object element, GraphConnection connection) {
 			connection.setLineStyle(SWT.LINE_CUSTOM);
 			PolylineConnection pc = (PolylineConnection) connection.getConnectionFigure();
@@ -86,6 +93,7 @@ public class GraphJFaceSnippet8 {
 
 		private PolygonDecoration createDecoration(final Color color) {
 			PolygonDecoration decoration = new PolygonDecoration() {
+				@Override
 				protected void fillShape(Graphics g) {
 					g.setBackgroundColor(color);
 					super.fillShape(g);
@@ -96,6 +104,7 @@ public class GraphJFaceSnippet8 {
 			return decoration;
 		}
 
+		@Override
 		public void selfStyleNode(Object element, GraphNode node) {
 		}
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/AnimationSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/AnimationSnippet.java
@@ -39,9 +39,11 @@ public class AnimationSnippet {
 		final GraphNode n2 = new GraphNode(g, SWT.NONE, "Rock");
 
 		b.addSelectionListener(new SelectionListener() {
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				Animation.markBegin();
 				n2.setLocation(0, 0);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
@@ -42,6 +42,7 @@ public class CustomLayout {
 			private int totalSteps;
 			private int currentStep;
 
+			@Override
 			protected void applyLayoutInternal(InternalNode[] entitiesToLayout,
 					InternalRelationship[] relationshipsToConsider, double boundsX, double boundsY, double boundsWidth,
 					double boundsHeight) {
@@ -61,28 +62,34 @@ public class CustomLayout {
 				fireProgressEnded(totalSteps);
 			}
 
+			@Override
 			protected int getCurrentLayoutStep() {
 				return 0;
 			}
 
+			@Override
 			protected int getTotalNumberOfLayoutSteps() {
 				return totalSteps;
 			}
 
+			@Override
 			protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
 				return true;
 			}
 
+			@Override
 			protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 					InternalRelationship[] relationshipsToConsider) {
 				// Do nothing
 			}
 
+			@Override
 			protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout,
 					InternalRelationship[] relationshipsToConsider, double x, double y, double width, double height) {
 				// do nothing
 			}
 
+			@Override
 			public void setLayoutArea(double x, double y, double width, double height) {
 				// do nothing
 			}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet10.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet10.java
@@ -57,6 +57,7 @@ public class GraphSnippet10 {
 		button.addSelectionListener(new SelectionAdapter() {
 			int count = 0;
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				count = ++count % 16;
 				if (count > 8) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet12.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet12.java
@@ -104,6 +104,7 @@ public class GraphSnippet12 {
 		final Graph g = new Graph(shell, SWT.NONE);
 		g.addSelectionListener(new SelectionListener() {
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				Iterator iter = g.getSelection().iterator();
 				while (iter.hasNext()) {
@@ -126,6 +127,7 @@ public class GraphSnippet12 {
 				}
 			}
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 				// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet13.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet13.java
@@ -109,6 +109,7 @@ public class GraphSnippet13 {
 		final Graph g = new Graph(shell, SWT.NONE);
 		g.addSelectionListener(new SelectionListener() {
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				Iterator iter = g.getSelection().iterator();
 				while (iter.hasNext()) {
@@ -131,6 +132,7 @@ public class GraphSnippet13 {
 				}
 			}
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 				// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet3.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet3.java
@@ -44,6 +44,7 @@ public class GraphSnippet3 {
 
 		Graph g = new Graph(shell, SWT.NONE);
 		g.addSelectionListener(new SelectionAdapter() {
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				System.out.println(((Graph) e.widget).getSelection());
 			}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet5.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet5.java
@@ -83,6 +83,7 @@ public class GraphSnippet5 {
 
 		g.addKeyListener(new KeyAdapter() {
 
+			@Override
 			public void keyPressed(KeyEvent e) {
 				boolean complete = false;
 				if (e.keyCode == BACKSPACE) {
@@ -116,6 +117,7 @@ public class GraphSnippet5 {
 		});
 
 		g.addPaintListener(new PaintListener() {
+			@Override
 			public void paintControl(PaintEvent e) {
 				e.gc.setFont(font);
 				e.gc.setClipping((Region) null);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet7.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet7.java
@@ -52,6 +52,7 @@ public class GraphSnippet7 {
 
 		g.addMouseMoveListener(new MouseMoveListener() {
 
+			@Override
 			public void mouseMove(MouseEvent e) {
 				// Get the figure at the current mouse location
 				Object o = g.getFigureAt(e.x, e.y);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
@@ -88,6 +88,7 @@ public class GraphSnippet8 {
 
 		TreeLayoutAlgorithm treeLayoutAlgorithm = new TreeLayoutAlgorithm(LayoutStyles.NO_LAYOUT_NODE_RESIZING);
 		Filter filter = new Filter() {
+			@Override
 			public boolean isObjectFiltered(LayoutItem item) {
 
 				// Get the "Connection" from the Layout Item

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
@@ -57,6 +57,7 @@ public class LayoutExample {
 
 		ConstraintAdapter constraintAdapters = new ConstraintAdapter() {
 
+			@Override
 			public void populateConstraint(Object object, LayoutConstraint constraint) {
 				if (constraint instanceof BasicEdgeConstraints) {
 					BasicEdgeConstraints basicEdgeConstraints = (BasicEdgeConstraints) constraint;

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/PaintSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/PaintSnippet.java
@@ -70,10 +70,12 @@ public class PaintSnippet {
 
 		b.addSelectionListener(new SelectionListener() {
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 
 			}
 
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 
 				Point size = new Point(g.getContents().getSize().width, g.getContents().getSize().height);
@@ -87,6 +89,7 @@ public class PaintSnippet {
 				Shell popup = new Shell(shell);
 				popup.setText("Image");
 				popup.addListener(SWT.Close, new Listener() {
+					@Override
 					public void handleEvent(Event e) {
 						image.dispose();
 					}
@@ -95,6 +98,7 @@ public class PaintSnippet {
 				Canvas canvas = new Canvas(popup, SWT.NONE);
 				canvas.setBounds(10, 10, size.x + 10, size.y + 10);
 				canvas.addPaintListener(new PaintListener() {
+					@Override
 					public void paintControl(PaintEvent e) {
 						e.gc.drawImage(image, 0, 0);
 					}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
@@ -126,6 +126,7 @@ public class ZoomSnippet {
 		g.addKeyListener(new KeyListener() {
 			boolean flip = true;
 
+			@Override
 			public void keyPressed(KeyEvent e) {
 
 				if (g.getSelection().size() == 1) {
@@ -142,6 +143,7 @@ public class ZoomSnippet {
 
 			}
 
+			@Override
 			public void keyReleased(KeyEvent e) {
 				// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/CompartmentFigure.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/CompartmentFigure.java
@@ -28,10 +28,12 @@ public class CompartmentFigure extends Figure {
 	}
 
 	class CompartmentFigureBorder extends AbstractBorder {
+		@Override
 		public Insets getInsets(IFigure figure) {
 			return new Insets(1, 0, 0, 0);
 		}
 
+		@Override
 		public void paint(IFigure figure, Graphics graphics, Insets insets) {
 			graphics.drawLine(getPaintRectangle(figure, insets).getTopLeft(), tempRect.getTopRight());
 		}

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/UMLExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/UMLExample.java
@@ -86,6 +86,7 @@ public class UMLExample {
 			super(graphModel, style, figure);
 		}
 
+		@Override
 		protected IFigure createFigureForModel() {
 			return (IFigure) this.getData();
 		}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
@@ -72,6 +72,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 			this.externalComparator = externalComparator;
 		}
 
+		@Override
 		public int compare(Object o1, Object o2) {
 			InternalNode internalNode1 = (InternalNode) o1;
 			InternalNode internalNode2 = (InternalNode) o2;
@@ -140,6 +141,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @param entity
 	 */
+	@Override
 	public void addEntity(LayoutEntity entity) {
 		if ((entity != null) && !entitiesToAdd.contains(entity)) {
 			entitiesToAdd.add(entity);
@@ -152,6 +154,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @param relationship
 	 */
+	@Override
 	public void addRelationship(LayoutRelationship relationship) {
 		if ((relationship != null) && !relationshipsToAdd.contains(relationship)) {
 			relationshipsToAdd.add(relationship);
@@ -164,6 +167,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @param entity The entity to remove
 	 */
+	@Override
 	public void removeEntity(LayoutEntity entity) {
 		if ((entity != null) && !entitiesToRemove.contains(entity)) {
 			entitiesToRemove.add(entity);
@@ -176,6 +180,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @param relationship The relationship to remove.
 	 */
+	@Override
 	public void removeRelationship(LayoutRelationship relationship) {
 		if ((relationship != null) && !relationshipsToRemove.contains(relationship)) {
 			relationshipsToRemove.add(relationship);
@@ -187,6 +192,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @param relationships
 	 */
+	@Override
 	public void removeRelationships(List relationships) {
 		// note we don't check if the relationshipsToRemove contains
 		// any of the objects in relationships.
@@ -199,6 +205,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @param style
 	 */
+	@Override
 	public void setStyle(int style) {
 		this.layout_styles = style;
 	}
@@ -208,6 +215,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @return
 	 */
+	@Override
 	public int getStyle() {
 		return this.layout_styles;
 	}
@@ -369,6 +377,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * 
 	 * @return boolean if the layout algorithm is running
 	 */
+	@Override
 	public synchronized boolean isRunning() {
 		return !layoutStopped;
 	}
@@ -377,6 +386,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * Stops the current layout from running. All layout algorithms should
 	 * constantly check isLayoutRunning
 	 */
+	@Override
 	public synchronized void stop() {
 		layoutStopped = true;
 		postLayoutAlgorithm(internalNodes, internalRelationships);
@@ -468,6 +478,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	/**
 	 * This actually applies the layout
 	 */
+	@Override
 	public synchronized void applyLayout(final LayoutEntity[] entitiesToLayout,
 			final LayoutRelationship[] relationshipsToConsider, final double x, final double y, final double width,
 			final double height, boolean asynchronous, boolean continuous) throws InvalidLayoutConfiguration {
@@ -489,6 +500,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 
 			Thread thread = new Thread(new Runnable() {
 
+				@Override
 				public void run() {
 					setupLayout(entitiesToLayout, relationshipsToConsider, x, y, width, height);
 					preLayoutAlgorithm(internalNodes, internalRelationships, internalX, internalY, internalWidth,
@@ -642,6 +654,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	/**
 	 * Filters the entities and relationships to apply the layout on
 	 */
+	@Override
 	public void setFilter(Filter filter) {
 		this.filter = filter;
 	}
@@ -650,6 +663,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * Determines the order in which the objects should be displayed. Note: Some
 	 * algorithms force a specific order.
 	 */
+	@Override
 	public void setComparator(Comparator comparator) {
 		this.comparator = new InternalComparator(comparator);
 	}
@@ -986,6 +1000,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	/**
 	 * Set the width to height ratio you want the entities to use
 	 */
+	@Override
 	public void setEntityAspectRatio(double ratio) {
 		widthToHeightRatio = ratio;
 	}
@@ -994,6 +1009,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * Returns the width to height ratio this layout will use to set the size of the
 	 * entities.
 	 */
+	@Override
 	public double getEntityAspectRatio() {
 		return widthToHeightRatio;
 	}
@@ -1003,6 +1019,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * relieve some of the mystery, the layout algorithm will notify each
 	 * ProgressListener of its progress.
 	 */
+	@Override
 	public void addProgressListener(ProgressListener listener) {
 		if (!progressListeners.contains(listener)) {
 			progressListeners.add(listener);
@@ -1013,6 +1030,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 	 * Removes the given progress listener, preventing it from receiving any more
 	 * updates.
 	 */
+	@Override
 	public void removeProgressListener(ProgressListener listener) {
 		if (progressListeners.contains(listener)) {
 			progressListeners.remove(listener);

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/CompositeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/CompositeLayoutAlgorithm.java
@@ -27,6 +27,7 @@ public class CompositeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		this(0, algoirthms);
 	}
 
+	@Override
 	protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 
@@ -46,33 +47,39 @@ public class CompositeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		// updateLayoutLocations(entitiesToLayout);
 	}
 
+	@Override
 	protected int getCurrentLayoutStep() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	@Override
 	protected int getTotalNumberOfLayoutSteps() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
 		// TODO Auto-generated method stub
 		return true;
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/ContinuousLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/ContinuousLayoutAlgorithm.java
@@ -53,6 +53,7 @@ public abstract class ContinuousLayoutAlgorithm extends AbstractLayoutAlgorithm 
 		}
 	}
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		this.setBounds(x, y, width, height);
 
@@ -73,6 +74,7 @@ public abstract class ContinuousLayoutAlgorithm extends AbstractLayoutAlgorithm 
 	 * Calculates and applies the positions of the given entities based on a spring
 	 * layout using the given relationships.
 	 */
+	@Override
 	protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
@@ -27,6 +27,7 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 
 	class ExtendedDirectedGraphLayout extends DirectedGraphLayout {
 
+		@Override
 		public void visit(DirectedGraph graph) {
 			Field field;
 			try {
@@ -57,6 +58,7 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		super(styles);
 	}
 
+	@Override
 	protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 		HashMap mapping = new HashMap(entitiesToLayout.length);
@@ -91,33 +93,39 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		updateLayoutLocations(entitiesToLayout);
 	}
 
+	@Override
 	protected int getCurrentLayoutStep() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	@Override
 	protected int getTotalNumberOfLayoutSteps() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
 		// TODO Auto-generated method stub
 		return true;
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
@@ -26,6 +26,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 
 	protected int rowPadding = 0;
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		throw new RuntimeException("Operation not implemented");
 	}
@@ -52,11 +53,13 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		this(LayoutStyles.NONE);
 	}
 
+	@Override
 	protected int getCurrentLayoutStep() {
 		// TODO: This isn't right
 		return 0;
 	}
 
+	@Override
 	protected int getTotalNumberOfLayoutSteps() {
 		return totalProgress;
 	}
@@ -64,6 +67,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	/**
 	 * 
 	 */
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 
@@ -122,6 +126,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 *                          the endpoints for each relationship in
 	 *                          relationshipsToConsider
 	 */
+	@Override
 	protected synchronized void applyLayoutInternal(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider, double boundsX, double boundsY, double boundsWidth,
 			double boundsHeight) {
@@ -144,6 +149,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		fireProgressEvent(totalProgress, totalProgress);
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 
@@ -235,6 +241,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		this.rowPadding = rowPadding;
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous)
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
@@ -32,6 +32,7 @@ public class HorizontalLayoutAlgorithm extends GridLayoutAlgorithm {
 	 * Calculates and returns an array containing the number of columns, followed by
 	 * the number of rows
 	 */
+	@Override
 	protected int[] calculateNumberOfRowsAndCols(int numChildren, double boundX, double boundY, double boundWidth,
 			double boundHeight) {
 		int rows = 1;
@@ -40,6 +41,7 @@ public class HorizontalLayoutAlgorithm extends GridLayoutAlgorithm {
 		return result;
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous) {
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
@@ -33,6 +33,7 @@ public class HorizontalShift extends AbstractLayoutAlgorithm {
 		super(styles);
 	}
 
+	@Override
 	protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 
@@ -45,6 +46,7 @@ public class HorizontalShift extends AbstractLayoutAlgorithm {
 
 		Collections.sort(row, new Comparator() {
 
+			@Override
 			public int compare(Object arg0, Object arg1) {
 				// TODO Auto-generated method stub
 				List a0 = (List) arg0;
@@ -60,6 +62,7 @@ public class HorizontalShift extends AbstractLayoutAlgorithm {
 		while (iterator.hasNext()) {
 			List currentRow = (List) iterator.next();
 			Collections.sort(currentRow, new Comparator() {
+				@Override
 				public int compare(Object arg0, Object arg1) {
 					return (int) (((InternalNode) arg1).getLayoutEntity().getYInLayout()
 							- ((InternalNode) arg0).getLayoutEntity().getYInLayout());
@@ -100,32 +103,38 @@ public class HorizontalShift extends AbstractLayoutAlgorithm {
 		list.add(newRow);
 	}
 
+	@Override
 	protected int getCurrentLayoutStep() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	@Override
 	protected int getTotalNumberOfLayoutSteps() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
 		// TODO Auto-generated method stub
 		return true;
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		// TODO Auto-generated method stub
 	}
 
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
@@ -38,12 +38,14 @@ public class HorizontalTreeLayoutAlgorithm extends TreeLayoutAlgorithm {
 		super(styles);
 	}
 
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// NOTE: width and height are swtiched here when calling super method
 		super.preLayoutAlgorithm(entitiesToLayout, relationshipsToConsider, x, y, height, width);
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		// swap x->y and width->height
@@ -55,6 +57,7 @@ public class HorizontalTreeLayoutAlgorithm extends TreeLayoutAlgorithm {
 		super.postLayoutAlgorithm(entitiesToLayout, relationshipsToConsider);
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous)
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
@@ -48,10 +48,12 @@ public class RadialLayoutAlgorithm extends TreeLayoutAlgorithm {
 		endDegree = MAX_DEGREES;
 	}
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		throw new RuntimeException("Operation not implemented");
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous)
 			return false;
@@ -67,6 +69,7 @@ public class RadialLayoutAlgorithm extends TreeLayoutAlgorithm {
 
 	DisplayIndependentRectangle layoutBounds = null;
 
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
@@ -74,6 +77,7 @@ public class RadialLayoutAlgorithm extends TreeLayoutAlgorithm {
 		super.preLayoutAlgorithm(entitiesToLayout, relationshipsToConsider, x, y, width, height);
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		roots = treeLayout.getRoots();
@@ -123,6 +127,7 @@ public class RadialLayoutAlgorithm extends TreeLayoutAlgorithm {
 	 * nodes or not. If the size is not included, the bounds will only be guaranteed
 	 * to include the center of each node.
 	 */
+	@Override
 	protected DisplayIndependentRectangle getLayoutBounds(InternalNode[] entitiesToLayout, boolean includeNodeSize) {
 		DisplayIndependentRectangle layoutBounds = super.getLayoutBounds(entitiesToLayout, includeNodeSize);
 		DisplayIndependentPoint centerPoint = (roots != null) ? determineCenterPoint(roots)

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SpringLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SpringLayoutAlgorithm.java
@@ -193,6 +193,7 @@ public class SpringLayoutAlgorithm extends ContinuousLayoutAlgorithm {
 		this(LayoutStyles.NONE);
 	}
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		bounds = new DisplayIndependentRectangle(x, y, width, height);
 	}
@@ -366,6 +367,7 @@ public class SpringLayoutAlgorithm extends ContinuousLayoutAlgorithm {
 
 	private long startTime = 0;
 
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// TODO: Filter out any non-wanted entities and relationships
@@ -393,6 +395,7 @@ public class SpringLayoutAlgorithm extends ContinuousLayoutAlgorithm {
 		startTime = date.getTime();
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		reset(entitiesToLayout);
@@ -538,6 +541,7 @@ public class SpringLayoutAlgorithm extends ContinuousLayoutAlgorithm {
 
 	}
 
+	@Override
 	protected boolean performAnotherNonContinuousIteration() {
 		setSprIterationsBasedOnTime();
 		if (iteration <= sprIterations && largestMovement >= sprMove)
@@ -546,14 +550,17 @@ public class SpringLayoutAlgorithm extends ContinuousLayoutAlgorithm {
 			return false;
 	}
 
+	@Override
 	protected int getCurrentLayoutStep() {
 		return iteration;
 	}
 
+	@Override
 	protected int getTotalNumberOfLayoutSteps() {
 		return sprIterations;
 	}
 
+	@Override
 	protected void computeOneIteration(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		if (bounds == null)
@@ -785,6 +792,7 @@ public class SpringLayoutAlgorithm extends ContinuousLayoutAlgorithm {
 		return doubleWeight;
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous)
 			return true;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
@@ -81,15 +81,18 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	///// Public Methods /////
 	/////////////////////////////////////////////////////////////////////////
 
+	@Override
 	public void setLayoutArea(double x, double y, double width, double height) {
 		throw new RuntimeException();
 	}
 
+	@Override
 	protected int getCurrentLayoutStep() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
+	@Override
 	protected int getTotalNumberOfLayoutSteps() {
 		return 4;
 	}
@@ -114,6 +117,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 *                          the endpoints for each relationship in
 	 *                          relationshipsToConsider
 	 */
+	@Override
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// Filter unwanted entities and relationships
@@ -139,6 +143,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 
 	}
 
+	@Override
 	protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 
@@ -157,6 +162,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 	}
 
+	@Override
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		updateLayoutLocations(entitiesToLayout);
@@ -323,6 +329,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 			// children
 			// TODO: SLOW
 			Collections.sort(children, new Comparator() {
+				@Override
 				public int compare(Object o1, Object o2) {
 					InternalNode node1 = (InternalNode) o1;
 					InternalNode node2 = (InternalNode) o2;
@@ -583,6 +590,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		throw new RuntimeException("Couldn't find index of internal node: " + nodeToFind);
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous) {
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
@@ -33,6 +33,7 @@ public class VerticalLayoutAlgorithm extends GridLayoutAlgorithm {
 	 * Calculates and returns an array containing the number of columns, followed by
 	 * the number of rows
 	 */
+	@Override
 	protected int[] calculateNumberOfRowsAndCols(int numChildren, double boundX, double boundY, double boundWidth,
 			double boundHeight) {
 		int cols = 1;
@@ -41,6 +42,7 @@ public class VerticalLayoutAlgorithm extends GridLayoutAlgorithm {
 		return result;
 	}
 
+	@Override
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous)
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
@@ -36,6 +36,7 @@ public class DynamicScreen {
 	}
 
 	class XComparator implements Comparator {
+		@Override
 		public int compare(Object arg0, Object arg1) {
 			InternalNode n1 = (InternalNode) arg0;
 			InternalNode n2 = (InternalNode) arg1;
@@ -51,6 +52,7 @@ public class DynamicScreen {
 	}
 
 	class YComparator implements Comparator {
+		@Override
 		public int compare(Object arg0, Object arg1) {
 			InternalNode n1 = (InternalNode) arg0;
 			InternalNode n2 = (InternalNode) arg1;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEdgeConstraints.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEdgeConstraints.java
@@ -24,6 +24,7 @@ public class BasicEdgeConstraints implements LayoutConstraint {
 	 * 
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
+	@Override
 	public void clear() {
 		this.isBiDirectional = false;
 		this.weight = 1;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEntityConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEntityConstraint.java
@@ -34,6 +34,7 @@ public class BasicEntityConstraint implements LayoutConstraint {
 	 * 
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
+	@Override
 	public void clear() {
 		this.hasPreferredLocation = false;
 		this.hasPreferredSize = false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/EntityPriorityConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/EntityPriorityConstraint.java
@@ -25,6 +25,7 @@ public class EntityPriorityConstraint implements LayoutConstraint {
 	 * 
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
+	@Override
 	public void clear() {
 		this.priority = 1.0;
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LabelLayoutConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LabelLayoutConstraint.java
@@ -24,6 +24,7 @@ public class LabelLayoutConstraint implements LayoutConstraint {
 	 * 
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
+	@Override
 	public void clear() {
 		label = null;
 		pointSize = 1;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/BendPoint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/BendPoint.java
@@ -30,10 +30,12 @@ public class BendPoint extends DisplayIndependentPoint implements LayoutBendPoin
 		this.isControlPoint = isControlPoint;
 	}
 
+	@Override
 	public double getX() {
 		return x;
 	}
 
+	@Override
 	public double getY() {
 		return y;
 	}
@@ -46,6 +48,7 @@ public class BendPoint extends DisplayIndependentPoint implements LayoutBendPoin
 		this.y = y;
 	}
 
+	@Override
 	public boolean getIsControlPoint() {
 		return isControlPoint;
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/DisplayIndependentDimension.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/DisplayIndependentDimension.java
@@ -28,6 +28,7 @@ public class DisplayIndependentDimension {
 		this.height = dimension.height;
 	}
 
+	@Override
 	public String toString() {
 		return "(" + width + ", " + height + ")";
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/DisplayIndependentPoint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/DisplayIndependentPoint.java
@@ -18,6 +18,7 @@ package org.eclipse.zest.layouts.dataStructures;
 public class DisplayIndependentPoint {
 	public double x, y;
 
+	@Override
 	public boolean equals(Object o) {
 		DisplayIndependentPoint that = (DisplayIndependentPoint) o;
 		if (this.x == that.x && this.y == that.y)
@@ -36,6 +37,7 @@ public class DisplayIndependentPoint {
 		this.y = point.y;
 	}
 
+	@Override
 	public String toString() {
 		return "(" + x + ", " + y + ")";
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/DisplayIndependentRectangle.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/DisplayIndependentRectangle.java
@@ -40,6 +40,7 @@ public class DisplayIndependentRectangle {
 		this.height = rect.height;
 	}
 
+	@Override
 	public String toString() {
 		return "(" + x + ", " + y + ", " + width + ", " + height + ")";
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
@@ -175,6 +175,7 @@ public class InternalNode implements Comparable, LayoutEntity {
 	 * 
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 */
+	@Override
 	public int compareTo(Object arg0) {
 		return 0;
 	}
@@ -184,6 +185,7 @@ public class InternalNode implements Comparable, LayoutEntity {
 	 * 
 	 * @see java.lang.Object#toString()
 	 */
+	@Override
 	public String toString() {
 		return (entity != null ? entity.toString() : "");
 	}
@@ -194,41 +196,49 @@ public class InternalNode implements Comparable, LayoutEntity {
 	double layoutY;
 	Object layoutInfo;
 
+	@Override
 	public double getHeightInLayout() {
 		// TODO Auto-generated method stub
 		return layoutHeight;
 	}
 
+	@Override
 	public Object getLayoutInformation() {
 		// TODO Auto-generated method stub
 		return this.layoutInfo;
 	}
 
+	@Override
 	public double getWidthInLayout() {
 		// TODO Auto-generated method stub
 		return layoutWidth;
 	}
 
+	@Override
 	public double getXInLayout() {
 		// TODO Auto-generated method stub
 		return layoutX;
 	}
 
+	@Override
 	public double getYInLayout() {
 		// TODO Auto-generated method stub
 		return layoutY;
 	}
 
+	@Override
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	public void setLayoutInformation(Object internalEntity) {
 		this.layoutInfo = internalEntity;
 
 	}
 
+	@Override
 	public void setLocationInLayout(double x, double y) {
 		// TODO Auto-generated method stub
 		this.layoutX = x;
@@ -236,15 +246,18 @@ public class InternalNode implements Comparable, LayoutEntity {
 
 	}
 
+	@Override
 	public void setSizeInLayout(double width, double height) {
 		this.layoutWidth = width;
 		this.layoutHeight = height;
 	}
 
+	@Override
 	public Object getGraphData() {
 		return null;
 	}
 
+	@Override
 	public void setGraphData(Object o) {
 		// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
@@ -91,45 +91,54 @@ public class InternalRelationship implements LayoutRelationship {
 		return this.bendPoints;
 	}
 
+	@Override
 	public void clearBendPoints() {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	public LayoutEntity getDestinationInLayout() {
 		// TODO Auto-generated method stub
 		return destination;
 	}
 
+	@Override
 	public Object getLayoutInformation() {
 		// TODO Auto-generated method stub
 		return layoutInfo;
 	}
 
+	@Override
 	public LayoutEntity getSourceInLayout() {
 		// TODO Auto-generated method stub
 		return source;
 	}
 
+	@Override
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	public void setBendPoints(LayoutBendPoint[] bendPoints) {
 		// TODO Auto-generated method stub
 
 	}
 
+	@Override
 	public void setLayoutInformation(Object layoutInformation) {
 		this.layoutInfo = layoutInformation;
 
 	}
 
+	@Override
 	public Object getGraphData() {
 		return null;
 	}
 
+	@Override
 	public void setGraphData(Object o) {
 
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleFilter.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleFilter.java
@@ -22,6 +22,7 @@ public class SimpleFilter implements Filter {
 	/**
 	 * Doesn't filter anything
 	 */
+	@Override
 	public boolean isObjectFiltered(LayoutItem object) {
 		return false;
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleGraph.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleGraph.java
@@ -40,6 +40,7 @@ public class SimpleGraph implements LayoutGraph {
 	 * 
 	 * @param node The node to add.
 	 */
+	@Override
 	public void addEntity(LayoutEntity node) {
 		if (node instanceof SimpleNode) {
 			objectsToNodes.put(((SimpleNode) node).getRealObject(), node);
@@ -112,6 +113,7 @@ public class SimpleGraph implements LayoutGraph {
 	 * @see ca.uvic.cs.chisel.layouts.LayoutGraph#addRelationship(ca.uvic.cs.chisel.
 	 * layouts.LayoutRelationship)
 	 */
+	@Override
 	public void addRelationship(LayoutRelationship relationship) {
 		relationships.add(relationship);
 	}
@@ -121,6 +123,7 @@ public class SimpleGraph implements LayoutGraph {
 	 * using addNode. Note that any manipulation to this graph was done on the
 	 * SimpleNodes, not the real objects. You must still manipulate them yourself.
 	 */
+	@Override
 	public List getEntities() {
 		return new ArrayList(objectsToNodes.values());
 	}
@@ -129,6 +132,7 @@ public class SimpleGraph implements LayoutGraph {
 	 * Returns a list of SimpleRelationships that represent the objects added to
 	 * this graph using addRelationship.
 	 */
+	@Override
 	public List getRelationships() {
 		return relationships;
 	}
@@ -138,6 +142,7 @@ public class SimpleGraph implements LayoutGraph {
 	 * 
 	 * @return boolean if all edges are bidirectional.
 	 */
+	@Override
 	public boolean isBidirectional() {
 		boolean isBidirectional = true;
 		for (Iterator iter = relationships.iterator(); iter.hasNext();) {

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleNode.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleNode.java
@@ -65,6 +65,7 @@ public class SimpleNode implements LayoutEntity {
 	}
 
 	class UniqueCompare implements Comparator {
+		@Override
 		public int compare(Object o1, Object o2) {
 			// TODO this may not always be a unique comparison
 			return o1.toString().compareTo(o2.toString());
@@ -172,6 +173,7 @@ public class SimpleNode implements LayoutEntity {
 		return height;
 	}
 
+	@Override
 	public void setSizeInLayout(double width, double height) {
 		if (!ignoreInLayout) {
 			this.width = width;
@@ -184,6 +186,7 @@ public class SimpleNode implements LayoutEntity {
 		this.y = y;
 	}
 
+	@Override
 	public void setLocationInLayout(double x, double y) {
 		if (!ignoreInLayout) {
 			this.x = x;
@@ -207,6 +210,7 @@ public class SimpleNode implements LayoutEntity {
 		return attributes.get(attribute);
 	}
 
+	@Override
 	public boolean equals(Object object) {
 		boolean result = false;
 		if (object instanceof SimpleNode) {
@@ -216,15 +220,18 @@ public class SimpleNode implements LayoutEntity {
 		return result;
 	}
 
+	@Override
 	public int hashCode() {
 		return realObject.hashCode();
 	}
 
 	// all objects are equal
+	@Override
 	public int compareTo(Object arg0) {
 		return 0;
 	}
 
+	@Override
 	public String toString() {
 		return realObject.toString();
 	}
@@ -264,6 +271,7 @@ public class SimpleNode implements LayoutEntity {
 	 * 
 	 * @see ca.uvic.cs.chisel.layouts.LayoutEntity#getInternalEntity()
 	 */
+	@Override
 	public Object getLayoutInformation() {
 		return internalNode;
 	}
@@ -274,6 +282,7 @@ public class SimpleNode implements LayoutEntity {
 	 * @see
 	 * ca.uvic.cs.chisel.layouts.LayoutEntity#setInternalEntity(java.lang.Object)
 	 */
+	@Override
 	public void setLayoutInformation(Object internalEntity) {
 		this.internalNode = internalEntity;
 	}
@@ -281,6 +290,7 @@ public class SimpleNode implements LayoutEntity {
 	/**
 	 * Populate the specified layout constraint
 	 */
+	@Override
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
 		if (constraint instanceof LabelLayoutConstraint) {
 			LabelLayoutConstraint labelConstraint = (LabelLayoutConstraint) constraint;
@@ -294,26 +304,32 @@ public class SimpleNode implements LayoutEntity {
 		}
 	}
 
+	@Override
 	public double getHeightInLayout() {
 		return this.height;
 	}
 
+	@Override
 	public double getWidthInLayout() {
 		return this.width;
 	}
 
+	@Override
 	public double getXInLayout() {
 		return this.x;
 	}
 
+	@Override
 	public double getYInLayout() {
 		return this.y;
 	}
 
+	@Override
 	public Object getGraphData() {
 		return null;
 	}
 
+	@Override
 	public void setGraphData(Object o) {
 
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleRelationship.java
@@ -121,6 +121,7 @@ public class SimpleRelationship implements LayoutRelationship {
 	 * 
 	 * @return The sourceEntity.
 	 */
+	@Override
 	public LayoutEntity getSourceInLayout() {
 		return sourceEntity;
 	}
@@ -131,6 +132,7 @@ public class SimpleRelationship implements LayoutRelationship {
 	 * 
 	 * @return The destinationEntity of this SimpleRelation.
 	 */
+	@Override
 	public LayoutEntity getDestinationInLayout() {
 		return destinationEntity;
 	}
@@ -169,6 +171,7 @@ public class SimpleRelationship implements LayoutRelationship {
 		return attributes.get(attribute);
 	}
 
+	@Override
 	public String toString() {
 		String arrow = (isBidirectionalInLayout() ? " <-> " : " -> ");
 		return "(" + sourceEntity + arrow + destinationEntity + ")";
@@ -222,6 +225,7 @@ public class SimpleRelationship implements LayoutRelationship {
 	 * 
 	 * @see ca.uvic.cs.chisel.layouts.LayoutRelationship#getInternalRelationship()
 	 */
+	@Override
 	public Object getLayoutInformation() {
 		return internalRelationship;
 	}
@@ -233,10 +237,12 @@ public class SimpleRelationship implements LayoutRelationship {
 	 * ca.uvic.cs.chisel.layouts.LayoutRelationship#setInternalRelationship(java.
 	 * lang.Object)
 	 */
+	@Override
 	public void setLayoutInformation(Object layoutInformation) {
 		this.internalRelationship = layoutInformation;
 	}
 
+	@Override
 	public void setBendPoints(LayoutBendPoint[] bendPoints) {
 		this.bendPoints = bendPoints;
 	}
@@ -245,6 +251,7 @@ public class SimpleRelationship implements LayoutRelationship {
 		return this.bendPoints;
 	}
 
+	@Override
 	public void clearBendPoints() {
 		this.bendPoints = new BendPoint[0];
 	}
@@ -263,6 +270,7 @@ public class SimpleRelationship implements LayoutRelationship {
 	/**
 	 * Populate the specified layout constraint
 	 */
+	@Override
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
 		if (constraint instanceof LabelLayoutConstraint) {
 			LabelLayoutConstraint labelConstraint = (LabelLayoutConstraint) constraint;
@@ -274,10 +282,12 @@ public class SimpleRelationship implements LayoutRelationship {
 		}
 	}
 
+	@Override
 	public Object getGraphData() {
 		return null;
 	}
 
+	@Override
 	public void setGraphData(Object o) {
 
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleUses/SimpleSwingExample.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleUses/SimpleSwingExample.java
@@ -154,6 +154,7 @@ public class SimpleSwingExample {
 
 		createMainPanel();
 		mainFrame.addWindowListener(new WindowAdapter() {
+			@Override
 			public void windowClosing(WindowEvent e) {
 				stop();
 				mainFrame.dispose();
@@ -169,6 +170,7 @@ public class SimpleSwingExample {
 
 		btnStop = new JButton("Stop");
 		btnStop.addActionListener(new ActionListener() {
+			@Override
 			public void actionPerformed(ActionEvent e) {
 				stop();
 			}
@@ -177,6 +179,7 @@ public class SimpleSwingExample {
 
 		JButton btnCreateGraph = new JButton("New graph");
 		btnCreateGraph.addActionListener(new ActionListener() {
+			@Override
 			public void actionPerformed(ActionEvent e) {
 				stop();
 				createGraph(true);
@@ -185,6 +188,7 @@ public class SimpleSwingExample {
 		toolBar.add(btnCreateGraph);
 		JButton btnCreateTree = new JButton("New tree");
 		btnCreateTree.addActionListener(new ActionListener() {
+			@Override
 			public void actionPerformed(ActionEvent e) {
 				stop();
 				createGraph(false);
@@ -204,6 +208,7 @@ public class SimpleSwingExample {
 		try {
 			SwingUtilities.invokeAndWait(new Runnable() {
 
+				@Override
 				public void run() {
 					SPRING = new SpringLayoutAlgorithm(LayoutStyles.NONE);
 					TREE_VERT = new TreeLayoutAlgorithm(LayoutStyles.NONE);
@@ -216,6 +221,7 @@ public class SimpleSwingExample {
 					SPRING.setIterations(1000);
 					// initialize layouts
 					TREE_VERT.setComparator(new Comparator() {
+						@Override
 						public int compare(Object o1, Object o2) {
 							if (o1 instanceof Comparable && o2 instanceof Comparable) {
 								return ((Comparable) o1).compareTo(o2);
@@ -240,6 +246,7 @@ public class SimpleSwingExample {
 						// ((Boolean)algorithmAnimates.get(i)).booleanValue();
 						JButton algorithmButton = new JButton(algorithmName);
 						algorithmButton.addActionListener(new ActionListener() {
+							@Override
 							public void actionPerformed(ActionEvent e) {
 								currentLayoutAlgorithm = algorithm;
 								currentLayoutAlgorithmName = algorithmName;
@@ -277,6 +284,7 @@ public class SimpleSwingExample {
 		final boolean continuous = btnContinuous.isSelected();
 		final boolean asynchronous = btnAsynchronous.isSelected();
 		ProgressListener progressListener = new ProgressListener() {
+			@Override
 			public void progressUpdated(final ProgressEvent e) {
 				// if (asynchronous) {
 				updateGUI();
@@ -286,6 +294,7 @@ public class SimpleSwingExample {
 				lblProgress.paintImmediately(0, 0, lblProgress.getWidth(), lblProgress.getHeight());
 			}
 
+			@Override
 			public void progressStarted(ProgressEvent e) {
 				if (!asynchronous) {
 					mainFrame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
@@ -294,6 +303,7 @@ public class SimpleSwingExample {
 				lblProgress.paintImmediately(0, 0, lblProgress.getWidth(), lblProgress.getHeight());
 			}
 
+			@Override
 			public void progressEnded(ProgressEvent e) {
 				lblProgress.setText("Layout completed ...");
 				lblProgress.paintImmediately(0, 0, lblProgress.getWidth(), lblProgress.getHeight());
@@ -312,6 +322,7 @@ public class SimpleSwingExample {
 			final LayoutRelationship[] layoutRelationships = new LayoutRelationship[relationships.size()];
 			relationships.toArray(layoutRelationships);
 			SwingUtilities.invokeLater(new Runnable() {
+				@Override
 				public void run() {
 					try {
 						currentLayoutAlgorithm.applyLayout(layoutEntities, layoutRelationships, 0, 0,
@@ -344,6 +355,7 @@ public class SimpleSwingExample {
 		mainFrame.getContentPane().add(new JScrollPane(mainPanel), BorderLayout.CENTER);
 
 		mainPanel.addMouseListener(new MouseAdapter() {
+			@Override
 			public void mousePressed(MouseEvent e) {
 				selectedEntity = null;
 				for (Iterator iter = entities.iterator(); iter.hasNext() && selectedEntity == null;) {
@@ -368,6 +380,7 @@ public class SimpleSwingExample {
 				updateGUI();
 			}
 
+			@Override
 			public void mouseReleased(MouseEvent e) {
 				selectedEntity = null;
 				mouseDownPoint = null;
@@ -377,6 +390,7 @@ public class SimpleSwingExample {
 		});
 
 		mainPanel.addMouseMotionListener(new MouseMotionListener() {
+			@Override
 			public void mouseDragged(MouseEvent e) {
 				// if (selectedEntity != null) {
 				// //TODO: Add mouse moving
@@ -386,6 +400,7 @@ public class SimpleSwingExample {
 				// }
 			}
 
+			@Override
 			public void mouseMoved(MouseEvent e) {
 			}
 		});
@@ -525,6 +540,7 @@ public class SimpleSwingExample {
 
 		private static final long serialVersionUID = 1;
 
+		@Override
 		protected void paintChildren(Graphics g) {
 			if (g instanceof Graphics2D && RENDER_HIGH_QUALITY) {
 				((Graphics2D) g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphSelectionTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphSelectionTests.java
@@ -139,10 +139,12 @@ public class GraphSelectionTests extends Assert {
 
 	private SelectionListener setupListener(final List events) {
 		return new SelectionListener() {
+			@Override
 			public void widgetSelected(SelectionEvent e) {
 				events.add(e);
 			}
 
+			@Override
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 		};

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphViewerTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/GraphViewerTests.java
@@ -103,6 +103,7 @@ public class GraphViewerTests extends Assert {
 	public void testPostSelectionListener() {
 		final List selected = new ArrayList();
 		viewer.addPostSelectionChangedListener(new ISelectionChangedListener() {
+			@Override
 			public void selectionChanged(SelectionChangedEvent event) {
 				selected.add(event);
 			}

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/IFigureProviderTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/IFigureProviderTests.java
@@ -86,12 +86,15 @@ public class IFigureProviderTests extends Assert {
 
 	private class DestinationContentProvider implements IGraphContentProvider {
 
+		@Override
 		public void dispose() {
 		}
 
+		@Override
 		public void inputChanged(Viewer arg0, Object arg1, Object arg2) {
 		}
 
+		@Override
 		public Object getDestination(Object r) {
 			if (r.equals("1to2"))
 				return "2";
@@ -102,10 +105,12 @@ public class IFigureProviderTests extends Assert {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object arg0) {
 			return new String[] { "1to2", "2to3", "3to1" };
 		}
 
+		@Override
 		public Object getSource(Object r) {
 			return null;
 		}
@@ -114,20 +119,25 @@ public class IFigureProviderTests extends Assert {
 
 	private class SourceContentProvider implements IGraphContentProvider {
 
+		@Override
 		public void dispose() {
 		}
 
+		@Override
 		public void inputChanged(Viewer arg0, Object arg1, Object arg2) {
 		}
 
+		@Override
 		public Object getDestination(Object r) {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object arg0) {
 			return new String[] { "1to2", "2to3", "3to1" };
 		}
 
+		@Override
 		public Object getSource(Object r) {
 			if (r.equals("1to2"))
 				return "1";
@@ -142,12 +152,15 @@ public class IFigureProviderTests extends Assert {
 
 	private class FullContentProvider implements IGraphContentProvider {
 
+		@Override
 		public void dispose() {
 		}
 
+		@Override
 		public void inputChanged(Viewer arg0, Object arg1, Object arg2) {
 		}
 
+		@Override
 		public Object getDestination(Object r) {
 			if (r.equals("1to2"))
 				return "2";
@@ -158,10 +171,12 @@ public class IFigureProviderTests extends Assert {
 			return null;
 		}
 
+		@Override
 		public Object[] getElements(Object arg0) {
 			return new String[] { "1to2", "2to3", "3to1" };
 		}
 
+		@Override
 		public Object getSource(Object r) {
 			if (r.equals("1to2"))
 				return "1";
@@ -175,10 +190,12 @@ public class IFigureProviderTests extends Assert {
 	}
 
 	private class CustomLabelProvider extends LabelProvider implements IFigureProvider {
+		@Override
 		public String getText(Object node) {
 			return node.toString();
 		}
 
+		@Override
 		public IFigure getFigure(Object node) {
 			Ellipse e = new Ellipse();
 			e.setSize(40, 40);


### PR DESCRIPTION
Using Eclipse IDE's quickfix all missing @Override annotations where added.

This reduced the warnings to < 3.5k.