### PR TITLE
fix wrong color for grid line foreground

### DIFF
--- a/org.eclipse.gef/plugin.xml
+++ b/org.eclipse.gef/plugin.xml
@@ -104,7 +104,7 @@
 				label="%colorDefinition.org.eclipse.gef.color.line.foreground.label"
 				categoryId="org.eclipse.gef"
 				id="org.eclipse.gef.color.line.foreground"
-				value="COLOR_LIST_FOREGROUND">
+				value="COLOR_GRAY">
 			<description>%colorDefinition.org.eclipse.gef.color.line.foreground.description</description>
 		</colorDefinition>
 		<colorDefinition


### PR DESCRIPTION
We found out that the wrong color was used for line foreground when grid is shown