### PR TITLE
Code Cleanup - Use pattern matching for instanceof operator

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ChopboxAnchor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ChopboxAnchor.java
@@ -107,8 +107,7 @@ public class ChopboxAnchor extends AbstractConnectionAnchor {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof ChopboxAnchor) {
-			ChopboxAnchor other = (ChopboxAnchor) obj;
+		if (obj instanceof ChopboxAnchor other) {
 			return other.getOwner() == getOwner() && other.getBox().equals(getBox());
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/EllipseAnchor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/EllipseAnchor.java
@@ -76,8 +76,7 @@ public class EllipseAnchor extends AbstractConnectionAnchor {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof EllipseAnchor) {
-			EllipseAnchor other = (EllipseAnchor) o;
+		if (o instanceof EllipseAnchor other) {
 			return other.getOwner() == getOwner();
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -239,8 +239,7 @@ public class Figure implements IFigure {
 	 */
 	@Override
 	public void addLayoutListener(LayoutListener listener) {
-		if (layoutManager instanceof LayoutNotifier) {
-			LayoutNotifier notifier = (LayoutNotifier) layoutManager;
+		if (layoutManager instanceof LayoutNotifier notifier) {
 			notifier.listeners.add(listener);
 		} else
 			layoutManager = new LayoutNotifier(layoutManager, listener);
@@ -1391,8 +1390,7 @@ public class Figure implements IFigure {
 	 */
 	@Override
 	public void removeLayoutListener(LayoutListener listener) {
-		if (layoutManager instanceof LayoutNotifier) {
-			LayoutNotifier notifier = (LayoutNotifier) layoutManager;
+		if (layoutManager instanceof LayoutNotifier notifier) {
 			notifier.listeners.remove(listener);
 			if (notifier.listeners.isEmpty())
 				layoutManager = notifier.realLayout;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LabeledContainer.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LabeledContainer.java
@@ -41,8 +41,7 @@ public class LabeledContainer extends Figure {
 	private static LabeledBorder findLabeledBorder(Border border) {
 		if (border instanceof LabeledBorder)
 			return (LabeledBorder) border;
-		if (border instanceof CompoundBorder) {
-			CompoundBorder cb = (CompoundBorder) border;
+		if (border instanceof CompoundBorder cb) {
 			LabeledBorder labeled = findLabeledBorder(cb.getInnerBorder());
 			if (labeled == null)
 				labeled = findLabeledBorder(cb.getOuterBorder());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineConnection.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PolylineConnection.java
@@ -61,8 +61,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * @since 3.2
 	 */
 	public void addRoutingListener(RoutingListener listener) {
-		if (connectionRouter instanceof RoutingNotifier) {
-			RoutingNotifier notifier = (RoutingNotifier) connectionRouter;
+		if (connectionRouter instanceof RoutingNotifier notifier) {
 			notifier.listeners.add(listener);
 		} else
 			connectionRouter = new RoutingNotifier(connectionRouter, listener);
@@ -208,8 +207,7 @@ public class PolylineConnection extends Polyline implements Connection, AnchorLi
 	 * @since 3.2
 	 */
 	public void removeRoutingListener(RoutingListener listener) {
-		if (connectionRouter instanceof RoutingNotifier) {
-			RoutingNotifier notifier = (RoutingNotifier) connectionRouter;
+		if (connectionRouter instanceof RoutingNotifier notifier) {
 			notifier.listeners.remove(listener);
 			if (notifier.listeners.isEmpty())
 				connectionRouter = notifier.realRouter;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
@@ -164,8 +164,7 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof Dimension) {
-			Dimension d = (Dimension) o;
+		if (o instanceof Dimension d) {
 			return (d.width() == width && d.height() == height);
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Insets.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Insets.java
@@ -95,8 +95,7 @@ public class Insets implements Cloneable, java.io.Serializable {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof Insets) {
-			Insets i = (Insets) o;
+		if (o instanceof Insets i) {
 			return i.top == top && i.bottom == bottom && i.left == left && i.right == right;
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
@@ -147,8 +147,7 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof Point) {
-			Point p = (Point) o;
+		if (o instanceof Point p) {
 			return p.x() == x && p.y() == y;
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
@@ -81,8 +81,7 @@ public class PrecisionDimension extends Dimension {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof PrecisionDimension) {
-			PrecisionDimension d = (PrecisionDimension) o;
+		if (o instanceof PrecisionDimension d) {
 			return d.preciseWidth() == preciseWidth() && d.preciseHeight() == preciseHeight();
 		}
 		return super.equals(o);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
@@ -76,8 +76,7 @@ public class PrecisionPoint extends Point {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof PrecisionPoint) {
-			PrecisionPoint p = (PrecisionPoint) o;
+		if (o instanceof PrecisionPoint p) {
 			return p.preciseX() == preciseX() && p.preciseY() == preciseY();
 		}
 		return super.equals(o);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -152,8 +152,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof PrecisionRectangle) {
-			PrecisionRectangle rect = (PrecisionRectangle) o;
+		if (o instanceof PrecisionRectangle rect) {
 			return super.equals(o) && Math.abs(rect.preciseX() - preciseX()) < 0.000000001
 					&& Math.abs(rect.preciseY() - preciseY()) < 0.000000001
 					&& Math.abs(rect.preciseWidth() - preciseWidth()) < 0.000000001

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
@@ -122,8 +122,7 @@ public final class Ray {
 	public boolean equals(Object obj) {
 		if (obj == this)
 			return true;
-		if (obj instanceof Ray) {
-			Ray r = (Ray) obj;
+		if (obj instanceof Ray r) {
 			return x == r.x && y == r.y;
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -221,8 +221,7 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	public boolean equals(Object o) {
 		if (this == o)
 			return true;
-		if (o instanceof Rectangle) {
-			Rectangle r = (Rectangle) o;
+		if (o instanceof Rectangle r) {
 			return (x == r.x()) && (y == r.y()) && (width == r.width()) && (height == r.height());
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Straight.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Straight.java
@@ -221,10 +221,9 @@ public class Straight {
 	 */
 	@Override
 	public boolean equals(Object other) {
-		if (!(other instanceof Straight)) {
+		if (!(other instanceof Straight otherStraight)) {
 			return false;
 		} else {
-			Straight otherStraight = (Straight) other;
 			return contains(otherStraight.position) && isParallelTo(otherStraight);
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Vector.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Vector.java
@@ -285,8 +285,7 @@ public class Vector {
 	public boolean equals(Object obj) {
 		if (obj == this)
 			return true;
-		if (obj instanceof Vector) {
-			Vector r = (Vector) obj;
+		if (obj instanceof Vector r) {
 			return x == r.x && y == r.y;
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodePair.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodePair.java
@@ -29,8 +29,7 @@ class NodePair {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof NodePair) {
-			NodePair np = (NodePair) obj;
+		if (obj instanceof NodePair np) {
 			return np.n1 == n1 && np.n2 == n2;
 		}
 		return false;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/MultiValueMap.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/MultiValueMap.java
@@ -36,8 +36,7 @@ public class MultiValueMap {
 			map.put(key, value);
 			return;
 		}
-		if (existingValues instanceof ArrayList) {
-			ArrayList v = (ArrayList) existingValues;
+		if (existingValues instanceof ArrayList v) {
 			if (!v.contains(value))
 				v.add(value);
 			return;
@@ -53,8 +52,7 @@ public class MultiValueMap {
 	public int remove(Object key, Object value) {
 		Object existingValues = map.get(key);
 		if (existingValues != null) {
-			if (existingValues instanceof ArrayList) {
-				ArrayList v = (ArrayList) existingValues;
+			if (existingValues instanceof ArrayList v) {
 				int result = v.indexOf(value);
 				if (result == -1)
 					return -1;

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/actions/IncrementDecrementAction.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/actions/IncrementDecrementAction.java
@@ -63,9 +63,8 @@ public class IncrementDecrementAction extends org.eclipse.gef.ui.actions.Selecti
 		List parts = getSelectedObjects();
 		for (int i = 0; i < parts.size(); i++) {
 			Object o = parts.get(i);
-			if (!(o instanceof EditPart))
+			if (!(o instanceof EditPart part))
 				return false;
-			EditPart part = (EditPart) o;
 			if (!(part.getModel() instanceof LED))
 				return false;
 		}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/actions/LogicPrintAction.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/actions/LogicPrintAction.java
@@ -92,9 +92,8 @@ public class LogicPrintAction extends Action implements IObjectActionDelegate {
 	 */
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
-		if (!(selection instanceof IStructuredSelection))
+		if (!(selection instanceof IStructuredSelection sel))
 			return;
-		IStructuredSelection sel = (IStructuredSelection) selection;
 		if (sel.size() != 1)
 			return;
 		selectedFile = (IFile) sel.getFirstElement();

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FixedConnectionAnchor.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FixedConnectionAnchor.java
@@ -85,9 +85,7 @@ public class FixedConnectionAnchor extends AbstractConnectionAnchor {
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof FixedConnectionAnchor) {
-			FixedConnectionAnchor fa = (FixedConnectionAnchor) o;
-
+		if (o instanceof FixedConnectionAnchor fa) {
 			if (fa.leftToRight == this.leftToRight && fa.topDown == this.topDown && fa.offsetH == this.offsetH
 					&& fa.offsetV == this.offsetV && fa.getOwner() == this.getOwner()) {
 				return true;

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/model/LogicFlowContainer.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/model/LogicFlowContainer.java
@@ -25,8 +25,7 @@ public class LogicFlowContainer extends LogicDiagram {
 
 		@Override
 		public String getText(Object element) {
-			if (element instanceof Integer) {
-				Integer integer = (Integer) element;
+			if (element instanceof Integer integer) {
 				if (LAYOUT_SINGLE_ROW.intValue() == integer.intValue())
 					return LogicMessages.PropertyDescriptor_LogicFlowContainer_SingleColumnLayout;
 				if (LAYOUT_MULTI_ROW.intValue() == integer.intValue())

--- a/org.eclipse.gef/src/org/eclipse/gef/KeyStroke.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/KeyStroke.java
@@ -139,8 +139,7 @@ public class KeyStroke {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof KeyStroke) {
-			KeyStroke stroke = (KeyStroke) obj;
+		if (obj instanceof KeyStroke stroke) {
 			return stroke.character == character && stroke.keyCode == keyCode && stroke.onPressed == onPressed
 					&& stroke.stateMask == stateMask;
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/ToolbarDropdownContributionItem.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/ToolbarDropdownContributionItem.java
@@ -528,8 +528,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 			boolean checkChanged = (action.getStyle() == IAction.AS_CHECK_BOX)
 					&& (propertyName == null || propertyName.equals(Action.CHECKED));
 
-			if (widget instanceof ToolItem) {
-				ToolItem ti = (ToolItem) widget;
+			if (widget instanceof ToolItem ti) {
 				if (imageChanged) {
 					updateImages(true);
 				}
@@ -550,8 +549,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 				return;
 			}
 
-			if (widget instanceof MenuItem) {
-				MenuItem mi = (MenuItem) widget;
+			if (widget instanceof MenuItem mi) {
 				boolean isContextMenu = belongsToContextMenu(mi);
 
 				// We only install an accelerator if the menu item doesn't
@@ -610,8 +608,7 @@ public class ToolbarDropdownContributionItem extends ContributionItem {
 				return;
 			}
 
-			if (widget instanceof Button) {
-				Button button = (Button) widget;
+			if (widget instanceof Button button) {
 				if (imageChanged) {
 					if (updateImages(false)) {
 						// don't update text if it has an image

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
@@ -628,11 +628,9 @@ public class MarqueeSelectionTool extends AbstractTool {
 	 */
 	private boolean isSecondaryMarqueeSelectedEditPart(Collection directlyMarqueeSelectedEditParts, EditPart editPart) {
 		boolean included = false;
-		if (editPart instanceof ConnectionEditPart
+		if (editPart instanceof ConnectionEditPart connection
 				&& (marqueeBehavior == BEHAVIOR_NODES_CONTAINED_AND_RELATED_CONNECTIONS
 						|| marqueeBehavior == BEHAVIOR_NODES_TOUCHED_AND_RELATED_CONNECTIONS)) {
-			// connections are included, if related nodes are included
-			ConnectionEditPart connection = (ConnectionEditPart) editPart;
 			GraphicalEditPart source = (GraphicalEditPart) connection.getSource();
 			GraphicalEditPart target = (GraphicalEditPart) connection.getTarget();
 			boolean sourceIncludedInMarqueeSelection = directlyMarqueeSelectedEditParts.contains(source);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyTemplateAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyTemplateAction.java
@@ -81,9 +81,8 @@ public class CopyTemplateAction extends WorkbenchPartAction implements ISelectio
 	@Override
 	public void selectionChanged(SelectionChangedEvent event) {
 		ISelection s = event.getSelection();
-		if (!(s instanceof IStructuredSelection))
+		if (!(s instanceof IStructuredSelection selection))
 			return;
-		IStructuredSelection selection = (IStructuredSelection) s;
 		template = null;
 		if (selection != null && selection.size() == 1) {
 			Object obj = selection.getFirstElement();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteTemplateAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteTemplateAction.java
@@ -67,8 +67,7 @@ public class PasteTemplateAction extends SelectionAction {
 		List selection = getSelectedObjects();
 		if (selection != null && selection.size() == 1) {
 			Object obj = selection.get(0);
-			if (obj instanceof GraphicalEditPart) {
-				GraphicalEditPart gep = (GraphicalEditPart) obj;
+			if (obj instanceof GraphicalEditPart gep) {
 				Object template = getClipboardContents();
 				if (template != null) {
 					CreationFactory factory = getFactory(template);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteAnimator.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteAnimator.java
@@ -122,8 +122,7 @@ public class PaletteAnimator extends LayoutAnimator {
 	 */
 	@Override
 	public void init(IFigure figure) {
-		if (figure instanceof DrawerFigure) {
-			DrawerFigure drawer = (DrawerFigure) figure;
+		if (figure instanceof DrawerFigure drawer) {
 			if (drawer.isExpanded())
 				autoCollapse(drawer);
 			return;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
@@ -394,9 +394,8 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 	}
 
 	private void traverseChildren(PaletteEntry parent, boolean add) {
-		if (!(parent instanceof PaletteContainer))
+		if (!(parent instanceof PaletteContainer container))
 			return;
-		PaletteContainer container = (PaletteContainer) parent;
 		traverseChildren(container.getChildren(), add);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
@@ -221,9 +221,8 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 */
 	@Override
 	public void reveal(EditPart part) {
-		if (!(part instanceof TreeEditPart))
+		if (!(part instanceof TreeEditPart treePart))
 			return;
-		TreeEditPart treePart = (TreeEditPart) part;
 		Tree tree = (Tree) getControl();
 		Widget widget = treePart.getWidget();
 		if (widget instanceof TreeItem)

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackInspector.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/CommandStackInspector.java
@@ -64,8 +64,7 @@ public class CommandStackInspector extends PageBookView {
 	protected PageRec doCreatePage(IWorkbenchPart part) {
 		// Try to get a custom command stack page.
 		Object obj = part.getAdapter(CommandStackInspectorPage.class);
-		if (obj instanceof IPage) {
-			IPage page = (IPage) obj;
+		if (obj instanceof IPage page) {
 			page.createControl(getPageBook());
 			return new PageRec(part, page);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/TreeLabelProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/stackview/TreeLabelProvider.java
@@ -65,8 +65,7 @@ public class TreeLabelProvider implements org.eclipse.jface.viewers.ILabelProvid
 	 */
 	@Override
 	public Image getImage(Object o) {
-		if (o instanceof Command) {
-			Command command = (Command) o;
+		if (o instanceof Command command) {
 			// if(((DefaultCommandStack)stack).canUndoCommand(command))
 			// return yesIcon;
 			// if(((DefaultCommandStack)stack).canRedoCommand(command))

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/EntityConnectionData.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/EntityConnectionData.java
@@ -42,10 +42,9 @@ public final class EntityConnectionData {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof EntityConnectionData)) {
+		if (!(obj instanceof EntityConnectionData that)) {
 			return false;
 		}
-		EntityConnectionData that = (EntityConnectionData) obj;
 		return (this.source.equals(that.source) && this.dest.equals(that.dest));
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
@@ -628,11 +628,9 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 		Widget[] items = this.findItems(element);
 		for (int i = 0; i < items.length; i++) {
 			Widget item = items[i];
-			if (item instanceof GraphNode) {
-				GraphNode graphModelNode = (GraphNode) item;
+			if (item instanceof GraphNode graphModelNode) {
 				graphModelNode.highlight();
-			} else if (item instanceof GraphConnection) {
-				GraphConnection graphModelConnection = (GraphConnection) item;
+			} else if (item instanceof GraphConnection graphModelConnection) {
 				graphModelConnection.highlight();
 			}
 		}
@@ -642,11 +640,9 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 		Widget[] items = this.findItems(element);
 		for (int i = 0; i < items.length; i++) {
 			Widget item = items[i];
-			if (item instanceof GraphNode) {
-				GraphNode graphModelNode = (GraphNode) item;
+			if (item instanceof GraphNode graphModelNode) {
 				graphModelNode.unhighlight();
-			} else if (item instanceof GraphConnection) {
-				GraphConnection graphModelConnection = (GraphConnection) item;
+			} else if (item instanceof GraphConnection graphModelConnection) {
 				graphModelConnection.unhighlight();
 			}
 		}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
@@ -35,8 +35,7 @@ import org.eclipse.zest.core.widgets.ZestStyles;
 public class GraphItemStyler {
 	public static void styleItem(GraphItem item, final IBaseLabelProvider labelProvider) {
 
-		if (item instanceof GraphNode) {
-			GraphNode node = (GraphNode) item;
+		if (item instanceof GraphNode node) {
 			// set defaults.
 			if (node.getGraphModel().getNodeStyle() != ZestStyles.NONE) {
 				node.setNodeStyle(node.getGraphModel().getNodeStyle());
@@ -47,13 +46,11 @@ public class GraphItemStyler {
 			if (labelProvider instanceof IEntityStyleProvider) {
 				styleNode(node, (IEntityStyleProvider) labelProvider);
 			}
-			if (labelProvider instanceof IColorProvider) {
-				IColorProvider colorProvider = (IColorProvider) labelProvider;
+			if (labelProvider instanceof IColorProvider colorProvider) {
 				node.setForegroundColor(colorProvider.getForeground(entity));
 				node.setBackgroundColor(colorProvider.getBackground(entity));
 			}
-			if (labelProvider instanceof IFontProvider) {
-				IFontProvider fontProvider = (IFontProvider) labelProvider;
+			if (labelProvider instanceof IFontProvider fontProvider) {
 				node.setFont(fontProvider.getFont(entity));
 			}
 			if (labelProvider instanceof ILabelProvider) {
@@ -64,9 +61,7 @@ public class GraphItemStyler {
 			if (labelProvider instanceof ISelfStyleProvider) {
 				((ISelfStyleProvider) labelProvider).selfStyleNode(entity, node);
 			}
-		} else if (item instanceof GraphConnection) {
-			GraphConnection conn = (GraphConnection) item;
-
+		} else if (item instanceof GraphConnection conn) {
 			// set defaults
 			if (conn.getGraphModel().getConnectionStyle() != ZestStyles.NONE) {
 				int s = conn.getGraphModel().getConnectionStyle();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -599,8 +599,7 @@ public class GraphConnection extends GraphItem {
 			connectionShape.setLineWidth(getLineWidth());
 		}
 
-		if (connection instanceof PolylineArcConnection) {
-			PolylineArcConnection arcConnection = (PolylineArcConnection) connection;
+		if (connection instanceof PolylineArcConnection arcConnection) {
 			arcConnection.setDepth(curveDepth);
 		}
 		if ((connectionStyle & ZestStyles.CONNECTIONS_DIRECTED) > 0) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -803,10 +803,9 @@ public class GraphNode extends GraphItem {
 			return;
 		}
 
-		if (!(currentFigure instanceof GraphLabel)) {
+		if (!(currentFigure instanceof GraphLabel figure)) {
 			return;
 		}
-		GraphLabel figure = (GraphLabel) currentFigure;
 		IFigure toolTip;
 
 		if (!checkStyle(ZestStyles.NODES_HIDE_TEXT)) {
@@ -1001,8 +1000,7 @@ public class GraphNode extends GraphItem {
 		@Override
 		public int compareTo(Object otherNode) {
 			int rv = 0;
-			if (otherNode instanceof GraphNode) {
-				GraphNode node = (GraphNode) otherNode;
+			if (otherNode instanceof GraphNode node) {
 				if (getText() != null) {
 					rv = getText().compareTo(node.getText());
 				}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AspectRatioFreeformLayer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AspectRatioFreeformLayer.java
@@ -112,31 +112,24 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		super.translateFromParent(t);
 		// t.performScale(1/widthScale);
 
-		if (t instanceof PrecisionRectangle) {
-			PrecisionRectangle r = (PrecisionRectangle) t;
+		if (t instanceof PrecisionRectangle r) {
 			r.setPreciseX(r.preciseX() * (1 / widthScale));
 			r.setPreciseY(r.preciseY() * (1 / heigthScale));
 			r.setPreciseWidth(r.preciseWidth() * (1 / widthScale));
 			r.setPreciseHeight(r.preciseHeight() * (1 / heigthScale));
-		} else if (t instanceof Rectangle) {
-			Rectangle r = (Rectangle) t;
+		} else if (t instanceof Rectangle r) {
 			r.scale(1 / widthScale, 1 / heigthScale);
-		} else if (t instanceof CaretInfo) {
-			CaretInfo c = (CaretInfo) t;
+		} else if (t instanceof CaretInfo c) {
 			c.performScale(1 / heigthScale);
-		} else if (t instanceof PrecisionDimension) {
-			PrecisionDimension d = (PrecisionDimension) t;
+		} else if (t instanceof PrecisionDimension d) {
 			d.setPreciseWidth(d.preciseWidth() * (1 / widthScale));
 			d.setPreciseHeight(d.preciseHeight() * (1 / heigthScale));
-		} else if (t instanceof Dimension) {
-			Dimension d = (Dimension) t;
+		} else if (t instanceof Dimension d) {
 			d.scale(1 / widthScale, 1 / heigthScale);
-		} else if (t instanceof PrecisionPoint) {
-			PrecisionPoint p = (PrecisionPoint) t;
+		} else if (t instanceof PrecisionPoint p) {
 			p.setPreciseX(p.preciseX() * (1 / widthScale));
 			p.setPreciseY(p.preciseY() * (1 / heigthScale));
-		} else if (t instanceof Point) {
-			Point p = (Point) t;
+		} else if (t instanceof Point p) {
 			p.scale(1 / widthScale, 1 / heigthScale);
 		} else if (t instanceof PointList) {
 			throw new RuntimeException("PointList not supported in AspectRatioScale");
@@ -151,32 +144,25 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 	public void translateToParent(Translatable t) {
 		// t.performScale(widthScale);
 
-		if (t instanceof PrecisionRectangle) {
-			PrecisionRectangle r = (PrecisionRectangle) t;
+		if (t instanceof PrecisionRectangle r) {
 			r.setPreciseX(r.preciseX() * widthScale);
 			r.setPreciseY(r.preciseY() * heigthScale);
 			r.setPreciseWidth(r.preciseWidth() * widthScale);
 			r.setPreciseHeight(r.preciseHeight() * heigthScale);
-		} else if (t instanceof Rectangle) {
-			Rectangle r = (Rectangle) t;
+		} else if (t instanceof Rectangle r) {
 			// r.performScale(widthScale);
 			r.scale(widthScale, heigthScale);
-		} else if (t instanceof CaretInfo) {
-			CaretInfo c = (CaretInfo) t;
+		} else if (t instanceof CaretInfo c) {
 			c.performScale(heigthScale);
-		} else if (t instanceof PrecisionDimension) {
-			PrecisionDimension d = (PrecisionDimension) t;
+		} else if (t instanceof PrecisionDimension d) {
 			d.setPreciseWidth(d.preciseWidth() * widthScale);
 			d.setPreciseHeight(d.preciseHeight() * heigthScale);
-		} else if (t instanceof Dimension) {
-			Dimension d = (Dimension) t;
+		} else if (t instanceof Dimension d) {
 			d.scale(widthScale, heigthScale);
-		} else if (t instanceof PrecisionPoint) {
-			PrecisionPoint p = (PrecisionPoint) t;
+		} else if (t instanceof PrecisionPoint p) {
 			p.setPreciseX(p.preciseX() * widthScale);
 			p.setPreciseY(p.preciseY() * heigthScale);
-		} else if (t instanceof Point) {
-			Point p = (Point) t;
+		} else if (t instanceof Point p) {
 			p.scale(widthScale, heigthScale);
 		} else if (t instanceof PointList) {
 			throw new RuntimeException("PointList not supported in AspectRatioScale");

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
@@ -94,8 +94,7 @@ public class GraphSnippet8 {
 				// Get the "Connection" from the Layout Item
 				// and use this connection to get the "Graph Data"
 				Object object = item.getGraphData();
-				if (object instanceof GraphConnection) {
-					GraphConnection connection = (GraphConnection) object;
+				if (object instanceof GraphConnection connection) {
 					if (connection.getData() != null && connection.getData() instanceof Boolean) {
 						// If the data is false, don't filter, otherwise, filter.
 						return ((Boolean) connection.getData()).booleanValue();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
@@ -59,8 +59,7 @@ public class LayoutExample {
 
 			@Override
 			public void populateConstraint(Object object, LayoutConstraint constraint) {
-				if (constraint instanceof BasicEdgeConstraints) {
-					BasicEdgeConstraints basicEdgeConstraints = (BasicEdgeConstraints) constraint;
+				if (constraint instanceof BasicEdgeConstraints basicEdgeConstraints) {
 					GraphConnection connection = (GraphConnection) object;
 					if (connection.getSource().getText().equals("Root")) {
 						basicEdgeConstraints.weight = 1;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleNode.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleNode.java
@@ -213,8 +213,7 @@ public class SimpleNode implements LayoutEntity {
 	@Override
 	public boolean equals(Object object) {
 		boolean result = false;
-		if (object instanceof SimpleNode) {
-			SimpleNode node = (SimpleNode) object;
+		if (object instanceof SimpleNode node) {
 			result = realObject.equals(node.getRealObject());
 		}
 		return result;
@@ -292,14 +291,12 @@ public class SimpleNode implements LayoutEntity {
 	 */
 	@Override
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
-		if (constraint instanceof LabelLayoutConstraint) {
-			LabelLayoutConstraint labelConstraint = (LabelLayoutConstraint) constraint;
+		if (constraint instanceof LabelLayoutConstraint labelConstraint) {
 			labelConstraint.label = realObject.toString();
 			labelConstraint.pointSize = 18;
 		} else if (constraint instanceof BasicEntityConstraint) {
 			// noop
-		} else if (constraint instanceof EntityPriorityConstraint) {
-			EntityPriorityConstraint priorityConstraint = (EntityPriorityConstraint) constraint;
+		} else if (constraint instanceof EntityPriorityConstraint priorityConstraint) {
 			priorityConstraint.priority = Math.random() * 10 + 1;
 		}
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/exampleStructures/SimpleRelationship.java
@@ -272,8 +272,7 @@ public class SimpleRelationship implements LayoutRelationship {
 	 */
 	@Override
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
-		if (constraint instanceof LabelLayoutConstraint) {
-			LabelLayoutConstraint labelConstraint = (LabelLayoutConstraint) constraint;
+		if (constraint instanceof LabelLayoutConstraint labelConstraint) {
 			labelConstraint.label = this.label;
 			labelConstraint.pointSize = 18;
 		} else if (constraint instanceof BasicEdgeConstraints) {


### PR DESCRIPTION
This replaces code of the form:
```
if (o instanceof <type>) {
  <type> t = (<type>) o;
  ...
}
```

with:
```
if (o instanceof <type> t) {
  ...
}
```