### PR TITLE
Fix: Regressions caused by cleaning up BreakCycle & PopulateRanks

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/graph/test/DirectedGraphLayoutTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/graph/test/DirectedGraphLayoutTest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.graph.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.eclipse.draw2d.graph.DirectedGraph;
+import org.eclipse.draw2d.graph.DirectedGraphLayout;
+import org.eclipse.draw2d.graph.Edge;
+import org.eclipse.draw2d.graph.EdgeList;
+import org.eclipse.draw2d.graph.Node;
+import org.eclipse.draw2d.graph.NodeList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+@SuppressWarnings("nls")
+public class DirectedGraphLayoutTest {
+	DirectedGraphLayout layout;
+	DirectedGraph g;
+
+	Node n1;
+	Node n2;
+	Node n3;
+
+	Edge e1;
+	Edge e2;
+	Edge e3;
+
+	@Before
+	public void setUp() {
+		n1 = new Node("n1");
+		n2 = new Node("n2");
+		n3 = new Node("n3");
+
+		e1 = new Edge(n1, n2);
+		e2 = new Edge(n2, n3);
+		e3 = new Edge(n3, n1);
+
+		NodeList nodes = new NodeList();
+		nodes.addAll(List.of(n1, n2, n3));
+
+		EdgeList edges = new EdgeList();
+		edges.addAll(List.of(e1, e2, e3));
+
+		g = new DirectedGraph();
+		g.nodes = nodes;
+		g.edges = edges;
+
+		layout = new DirectedGraphLayout();
+	}
+
+	@Test
+	public void test_detectCycles() {
+		assertFalse(e1.isFeedback());
+		assertFalse(e2.isFeedback());
+		assertFalse(e3.isFeedback());
+
+		layout.visit(g);
+
+		assertFalse(e1.isFeedback());
+		assertTrue(e2.isFeedback());
+		assertFalse(e3.isFeedback());
+	}
+
+	@Test
+	public void test_populateRanks() {
+		assertEquals(getRank(n1), 0);
+		assertEquals(getRank(n2), 0);
+		assertEquals(getRank(n3), 0);
+
+		layout.visit(g);
+
+		assertEquals(getRank(n1), 1);
+		assertEquals(getRank(n2), 2);
+		assertEquals(getRank(n3), 0);
+	}
+
+	private static final int getRank(Node n) {
+		try {
+			Field f = Node.class.getDeclaredField("rank");
+			f.setAccessible(true);
+			return f.getInt(n);
+		} catch (ReflectiveOperationException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
+import org.eclipse.draw2d.graph.test.DirectedGraphLayoutTest;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -52,7 +54,8 @@ import org.junit.runners.Suite;
 	ScalablePolygonShapeTest.class,
 	LayerTest.class,
 	ShapeTest.class,
-	InsetsTest.class
+	InsetsTest.class,
+	DirectedGraphLayoutTest.class
 })
 public class Draw2dTestSuite {
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/BreakCycles.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/BreakCycles.java
@@ -249,7 +249,7 @@ class BreakCycles extends GraphVisitor {
 	public void visit(DirectedGraph g) {
 		// put all nodes in list, initialize index
 		graphNodes.resetFlags();
-		for (Node n : graphNodes) {
+		for (Node n : g.nodes) {
 			setIncomingCount(n, n.incoming.size());
 			graphNodes.add(n);
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/PopulateRanks.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/PopulateRanks.java
@@ -12,6 +12,7 @@ package org.eclipse.draw2d.graph;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
 
 /**
  * This class takes a DirectedGraph with an optimal rank assignment and a
@@ -44,7 +45,11 @@ class PopulateRanks extends GraphVisitor {
 		for (Node node : g.nodes) {
 			g.ranks.getRank(node.rank).add(node);
 		}
-		for (Node node : g.nodes) {
+		// The constructor of VirtualNodeCreation may add additional nodes to the graph.
+		// If we work on the same list of nodes, this will cause a
+		// ConcurrentModificationException. Work on a copy of the node list so that we
+		// don't create virtual nodes of virtual nodes.
+		for (Node node : List.copyOf(g.nodes)) {
 			for (int j = 0; j < node.outgoing.size();) {
 				Edge e = node.outgoing.get(j);
 				if (e.getLength() > 1) {


### PR DESCRIPTION
The for-each loop inside the BreakCycle method used to iterate over all graph nodes. This was wrongfully changed to a local variable which is initialized as an empty list.

The for-each loop inside PopulateRanks iterates over all graph nodes and calls VirtualNodeCreation internally. The constructor of this class, however, may add nodes to the graph, leading to a
ConcurrentModifcationException. To avoid this problem, we iterate of a local copy of the graph nodes instead.

Amends 31a70127f763d40fd1f6eb6a56de9158cf9538ce