### PR TITLE
Typify internal list in DirectGraphLayout and convert to Deque

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LocalOptimizerTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LocalOptimizerTest.java
@@ -12,7 +12,8 @@
 package org.eclipse.draw2d.test;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 import org.eclipse.draw2d.graph.DirectedGraph;
 import org.eclipse.draw2d.graph.DirectedGraphLayout;
@@ -146,10 +147,9 @@ public class LocalOptimizerTest extends Assert {
 			DirectedGraphLayout layout = new DirectedGraphLayout();
 			Field stepsField = DirectedGraphLayout.class.getDeclaredField("steps"); //$NON-NLS-1$
 			stepsField.setAccessible(true);
-			ArrayList steps = (ArrayList) stepsField.get(layout);
-			ArrayList filteredSteps = new ArrayList();
-			for (int i = 0; i < steps.size(); i++) {
-				Object graphVisitor = steps.get(i);
+			Deque<?> steps = (Deque<?>) stepsField.get(layout);
+			Deque<Object> filteredSteps = new ArrayDeque<>();
+			for (Object graphVisitor : steps) {
 				for (String graphVisitorClassName : graphVisitorClassNames) {
 					if (graphVisitorClassName.equals(graphVisitor.getClass().getName())) {
 						filteredSteps.add(graphVisitor);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/DirectedGraphLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/DirectedGraphLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.graph;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * Performs a graph layout of a <code>DirectedGraph</code>. The directed graph
@@ -70,7 +70,7 @@ import java.util.List;
  */
 public class DirectedGraphLayout {
 
-	List steps = new ArrayList();
+	Deque<GraphVisitor> steps = new ArrayDeque<>();
 
 	/**
 	 * @since 3.1
@@ -101,14 +101,8 @@ public class DirectedGraphLayout {
 	public void visit(DirectedGraph graph) {
 		if (graph.nodes.isEmpty())
 			return;
-		for (int i = 0; i < steps.size(); i++) {
-			GraphVisitor visitor = (GraphVisitor) steps.get(i);
-			visitor.visit(graph);
-		}
-		for (int i = steps.size() - 1; i >= 0; i--) {
-			GraphVisitor visitor = (GraphVisitor) steps.get(i);
-			visitor.revisit(graph);
-		}
+		steps.iterator().forEachRemaining(visitor -> visitor.visit(graph));
+		steps.descendingIterator().forEachRemaining(visitor -> visitor.revisit(graph));
 	}
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ * Copyright 2005, 2023 CHISEL Group, University of Victoria, Victoria, BC, Canada.
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which
  * accompanies this distribution, and is available at
@@ -10,9 +10,9 @@
 package org.eclipse.zest.layouts.algorithms;
 
 import java.lang.reflect.Field;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.graph.DirectedGraph;
@@ -34,20 +34,14 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 				field = DirectedGraphLayout.class.getDeclaredField("steps");
 				field.setAccessible(true);
 				Object object = field.get(this);
-				List steps = (List) object;
+				Deque<?> steps = (Deque<?>) object;
 				steps.remove(10);
 				steps.remove(9);
 				steps.remove(8);
 				steps.remove(2);
 				field.setAccessible(false);
 				super.visit(graph);
-			} catch (SecurityException e) {
-				e.printStackTrace();
-			} catch (NoSuchFieldException e) {
-				e.printStackTrace();
-			} catch (IllegalArgumentException e) {
-				e.printStackTrace();
-			} catch (IllegalAccessException e) {
+			} catch (SecurityException | ReflectiveOperationException | IllegalArgumentException e) {
 				e.printStackTrace();
 			}
 		}


### PR DESCRIPTION
By using a deque, we have access to both an iterator() and an descendingIterator() method. This allows us to iterate over the collection in both directions.