### PR TITLE
Fix wrong line width on Windows hi-dpi

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
@@ -306,7 +306,7 @@ public class SWTGraphics extends Graphics {
 		LineAttributes lineAttributes = currentState.lineAttributes;
 		if (!appliedState.lineAttributes.equals(lineAttributes)) {
 			if (getAdvanced()) {
-				gc.setLineAttributes(lineAttributes);
+				gc.setLineAttributes(clone(lineAttributes)); // Clone lineAttributes because on Windows hi-dpi the line width may be increased
 			} else {
 				gc.setLineWidth((int) lineAttributes.width);
 				gc.setLineCap(lineAttributes.cap);


### PR DESCRIPTION
- On Windows hi-dpi calling GC#setLineAttributes will mean that lineattributes.width is increased by calling DPIUtil.autoScaleUp so we clone lineAttributes

- See https://github.com/eclipse/gef-classic/issues/248