### PR TITLE
Allow more customizable Zest Graph implementations

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -169,7 +169,7 @@ public class Graph extends FigureCanvas implements IContainer {
 		});
 
 		this.setContents(createLayers());
-		DragSupport dragSupport = new DragSupport(this);
+		GraphDragSupport dragSupport = createGraphDragSupport();
 		this.getLightweightSystem().getRootFigure().addMouseListener(dragSupport);
 		this.getLightweightSystem().getRootFigure().addMouseMotionListener(dragSupport);
 
@@ -456,11 +456,20 @@ public class Graph extends FigureCanvas implements IContainer {
 	public boolean getHideNodesEnabled() {
 		return enableHideNodes;
 	}
+	
+	/**
+	 * Creator method for DragSupport
+	 * @return class that implemented GraphDragSupport
+	 * @since 3.2
+	 */
+	protected GraphDragSupport createGraphDragSupport() {
+		return new DragSupport(this);
+	}
 
 	// /////////////////////////////////////////////////////////////////////////////////
 	// PRIVATE METHODS. These are NON API
 	// /////////////////////////////////////////////////////////////////////////////////
-	class DragSupport implements MouseMotionListener, org.eclipse.draw2d.MouseListener {
+	class DragSupport implements GraphDragSupport {
 		/**
 		 *
 		 */
@@ -1134,10 +1143,15 @@ public class Graph extends FigureCanvas implements IContainer {
 		}
 	}
 
-	private ScalableFigure createLayers() {
+	/**
+	 * Layer creation
+	 * @return IFigure the rootlayer
+	 * @since 3.2
+	 */
+	protected IFigure createLayers() {
 		rootlayer = new ScalableFreeformLayeredPane();
 		rootlayer.setLayoutManager(new FreeformLayout());
-		zestRootLayer = new ZestRootLayer();
+		zestRootLayer = createZestRootLayer();
 
 		zestRootLayer.setLayoutManager(new FreeformLayout());
 
@@ -1150,6 +1164,16 @@ public class Graph extends FigureCanvas implements IContainer {
 		zestRootLayer.addLayoutListener(LayoutAnimator.getDefault());
 		fishEyeLayer.addLayoutListener(LayoutAnimator.getDefault());
 		return rootlayer;
+	}
+	
+	/**
+	 * Creator method for ZestRootLayer
+	 * @return new ZestRootLayer instance
+	 * @since 3.2
+	 */
+	@SuppressWarnings("static-method")
+	protected ZestRootLayer createZestRootLayer() {
+		return new ZestRootLayer();
 	}
 
 	/**

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphDragSupport.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphDragSupport.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Philipp Bauer - initial implementation
+ */
+
+package org.eclipse.zest.core.widgets;
+
+import org.eclipse.draw2d.MouseListener;
+import org.eclipse.draw2d.MouseMotionListener;
+
+/** Super Interface for drag support for zest graphs @see{Graph}
+ *
+ * @since 3.2 */
+public interface GraphDragSupport extends MouseMotionListener, MouseListener {
+
+}


### PR DESCRIPTION
Allow the Zest Graph to be more flexible and customizable
- exposed createLayers() method
- added creator method for ZestRootLayer (e.g. to change highlighting behavior)
- created super-interface and creator method for drag support.