### PR TITLE
added label initialization for graphconnection

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -583,7 +583,10 @@ public class GraphConnection extends GraphItem {
 		connectionShape.setLineStyle(getLineStyle());
 
 		if (this.getText() != null || this.getImage() != null) {
-			// Label l = new Label(this.getText(), this.getImage());
+			// label can be null if createFigure has been overridden
+			if (this.connectionLabel == null) {
+				this.connectionLabel = new Label();
+			}
 			if (this.getImage() != null) {
 				this.connectionLabel.setIcon(this.getImage());
 			}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -581,12 +581,9 @@ public class GraphConnection extends GraphItem {
 		Shape connectionShape = (Shape) connection;
 
 		connectionShape.setLineStyle(getLineStyle());
-
-		if (this.getText() != null || this.getImage() != null) {
-			// label can be null if createFigure has been overridden
-			if (this.connectionLabel == null) {
-				this.connectionLabel = new Label();
-			}
+		
+		// label can be null if createFigure has been overridden
+		if (this.connectionLabel != null && (this.getText() != null || this.getImage() != null)) {
 			if (this.getImage() != null) {
 				this.connectionLabel.setIcon(this.getImage());
 			}


### PR DESCRIPTION
if the already exposed createFigure method in GraphConnection is overridden, the connectionLabel will never be initialized and thus lead to a null pointer in the doUpdateFigure method.