### PR TITLE
Pull getLocation() method from Figure to IFigure interface.

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -768,8 +768,9 @@ public class Figure implements IFigure {
 	 * @return The top-left corner of this Figure's bounds
 	 * @since 2.0
 	 */
+	@Override
 	public final Point getLocation() {
-		return getBounds().getLocation();
+		return IFigure.super.getLocation();
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -373,6 +373,16 @@ public interface IFigure {
 	 * @return The local foreground Color
 	 */
 	Color getLocalForegroundColor();
+
+	/**
+	 * Returns the top-left corner of this Figure's bounds.
+	 * 
+	 * @return The top-left corner of this Figure's bounds
+	 * @since 3.14
+	 */
+	default Point getLocation() {
+		return getBounds().getLocation();
+	}
 
 	/**
 	 * Returns a hint indicating the largest desireable size for the IFigure.


### PR DESCRIPTION
If a method only works on the IFigure interface, it currently has to either cast the object to a Figure, in order to be able to call getLocation() or instead go via getBounds().getLocation().

To avoid this issue, this method has been pulled to the implemented interface. A default implementation is used to for backwards compatibility. The implementation inside the Figure is not removed, in order to keep the 'final' modifier, but internally only calls the default implementation.

The interface already has a setter method for the location. Also providing a getter only seems natural.