### PR TITLE
Compile and test GEF against both Java 17 and Java 21.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [ 17 ]
+        java: [ 17, 21 ]
     runs-on: ${{ matrix.os }} 
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     steps:


### PR DESCRIPTION
With Java 21 being the current LTS, we should ensure that GEF is forward compatible.