### PR TITLE
Typify GroupRequest and SimpleFactory classes

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/requests/GroupRequest.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/GroupRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.gef.requests;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.gef.EditPart;
@@ -22,7 +23,7 @@ import org.eclipse.gef.EditPart;
  */
 public class GroupRequest extends org.eclipse.gef.Request {
 
-	List parts;
+	List<? extends EditPart> parts;
 
 	/**
 	 * Creates a GroupRequest with the given type.
@@ -44,7 +45,7 @@ public class GroupRequest extends org.eclipse.gef.Request {
 	 * 
 	 * @return A List containing the EditParts making this Request.
 	 */
-	public List getEditParts() {
+	public List<? extends EditPart> getEditParts() {
 		return parts;
 	}
 
@@ -53,7 +54,7 @@ public class GroupRequest extends org.eclipse.gef.Request {
 	 * 
 	 * @param list The List of EditParts.
 	 */
-	public void setEditParts(List list) {
+	public void setEditParts(List<? extends EditPart> list) {
 		parts = list;
 	}
 
@@ -63,8 +64,7 @@ public class GroupRequest extends org.eclipse.gef.Request {
 	 * @param part The EditPart making the request.
 	 */
 	public void setEditParts(EditPart part) {
-		parts = new ArrayList(1);
-		parts.add(part);
+		parts = new ArrayList<>(Arrays.asList(part));
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/SimpleFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/SimpleFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,17 +18,18 @@ package org.eclipse.gef.requests;
  * 
  * @author hudsonr
  * @since 2.1
+ * @param <T> the type of object that is created by this factory.
  */
-public class SimpleFactory implements CreationFactory {
+public class SimpleFactory<T> implements CreationFactory {
 
-	private Class type;
+	private final Class<T> type;
 
 	/**
 	 * Creates a SimpleFactory.
 	 * 
 	 * @param aClass The class to be instantiated using this factory.
 	 */
-	public SimpleFactory(Class aClass) {
+	public SimpleFactory(Class<T> aClass) {
 		type = aClass;
 	}
 
@@ -38,9 +39,9 @@ public class SimpleFactory implements CreationFactory {
 	 * @return The newly created object.
 	 */
 	@Override
-	public Object getNewObject() {
+	public T getNewObject() {
 		try {
-			return type.newInstance();
+			return type.getDeclaredConstructor().newInstance();
 		} catch (Exception exc) {
 			return null;
 		}


### PR DESCRIPTION
For the GroupRequest class, we store the list of edit-parts as a List<? extends EditPart>, in order to support casting it to e.g. a List<CustomEditPart>.

For the SimpleFactory class, we replace the deprecated Class.newInstance() call with Constructor.newInstance(), to keep the compile-time exception checking (see JavaDoc for more details).