### PR TITLE
Make sure to check for disposal in asyncExec

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2000, 2010 IBM Corporation and others.
  *
- * This program and the accompanying materials are made available under the 
+ * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
  *
@@ -38,14 +38,14 @@ public abstract class PopUpHelper {
 
 	/**
 	 * These style bits should be used when creating the Shell.
-	 * 
+	 *
 	 * @see #createShell()
 	 */
 	protected final int shellStyle;
 
 	/**
 	 * Constructs a PopUpHelper to assist with popups on Control c.
-	 * 
+	 *
 	 * @param c the Control
 	 * @since 2.0
 	 */
@@ -55,7 +55,7 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Constructs a PopUpHelper to display the given shell style popup.
-	 * 
+	 *
 	 * @param c          the control on which the popup is active.
 	 * @param shellStyle the SWT style bits for the shell
 	 * @since 3.1
@@ -68,7 +68,7 @@ public abstract class PopUpHelper {
 	/**
 	 * Creates and returns the LightweightSystem object used by PopUpHelper to draw
 	 * upon.
-	 * 
+	 *
 	 * @return the newly created LightweightSystem
 	 * @since 2.0
 	 */
@@ -78,7 +78,7 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Creates a new Shell object with the style specified for this helper.
-	 * 
+	 *
 	 * @return the newly created Shell
 	 * @since 2.0
 	 */
@@ -88,20 +88,22 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Dispose of this PopUpHelper object.
-	 * 
+	 *
 	 * @since 2.0
 	 */
 	public void dispose() {
-		if (isShowing())
+		if (isShowing()) {
 			hide();
-		if (shell != null && !shell.isDisposed())
+		}
+		if (shell != null && !shell.isDisposed()) {
 			shell.dispose();
+		}
 	}
 
 	/**
 	 * Returns this PopUpHelper's shell. If no shell exists for this PopUpHelper, a
 	 * new shell is created and hookShellListeners() is called.
-	 * 
+	 *
 	 * @return the Shell
 	 * @since 2.0
 	 */
@@ -116,7 +118,7 @@ public abstract class PopUpHelper {
 	/**
 	 * Returns the size needed to display the shell's trim. This method should not
 	 * be called until the shell has been created.
-	 * 
+	 *
 	 * @return the size of the shells trim.
 	 * @since 3.1
 	 */
@@ -129,7 +131,7 @@ public abstract class PopUpHelper {
 	 * Returns this PopUpHelper's LightweightSystem. If no LightweightSystem exists
 	 * for this PopUpHelper, a new LightweightSystem is created with this
 	 * PopUpHelper's Shell as its Control.
-	 * 
+	 *
 	 * @return the LightweightSystem
 	 * @since 2.0
 	 */
@@ -143,12 +145,13 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Hides this PopUpHelper's Shell.
-	 * 
+	 *
 	 * @since 2.0
 	 */
 	protected void hide() {
-		if (shell != null && !shell.isDisposed())
+		if (shell != null && !shell.isDisposed()) {
 			shell.setVisible(false);
+		}
 		tipShowing = false;
 	}
 
@@ -156,7 +159,7 @@ public abstract class PopUpHelper {
 	 * Desired popup helper behavior is achieved by writing listeners that
 	 * manipulate the behavior of the PopUpHelper's Shell. Override this method and
 	 * add these listeners here.
-	 * 
+	 *
 	 * @since 2.0
 	 */
 	protected abstract void hookShellListeners();
@@ -164,7 +167,7 @@ public abstract class PopUpHelper {
 	/**
 	 * Returns <code>true</code> if this PopUpHelper's Shell is visible,
 	 * <code>false</code> otherwise.
-	 * 
+	 *
 	 * @return <code>true</code> if this PopUpHelper's Shell is visible
 	 * @since 2.0
 	 */
@@ -174,7 +177,7 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Sets the background color of this PopUpHelper's Shell.
-	 * 
+	 *
 	 * @param c the new background color
 	 * @since 2.0
 	 */
@@ -184,7 +187,7 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Sets the foreground color of this PopUpHelper's Shell.
-	 * 
+	 *
 	 * @param c the new foreground color
 	 * @since 2.0
 	 */
@@ -194,7 +197,7 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Sets the bounds on this PopUpHelper's Shell.
-	 * 
+	 *
 	 * @param x      the x coordinate
 	 * @param y      the y coordinate
 	 * @param width  the width
@@ -207,7 +210,7 @@ public abstract class PopUpHelper {
 
 	/**
 	 * Displays this PopUpHelper's Shell.
-	 * 
+	 *
 	 * @since 2.0
 	 */
 	protected void show() {

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2000, 2010 IBM Corporation and others.
  *
- * This program and the accompanying materials are made available under the 
+ * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
  *
@@ -14,10 +14,7 @@ package org.eclipse.gef.internal.ui.palette.editparts;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.events.MouseMoveListener;
 import org.eclipse.swt.events.MouseTrackAdapter;
-import org.eclipse.swt.events.PaintEvent;
-import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.events.ShellListener;
@@ -35,8 +32,9 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 	private ShellListener shellListener;
 
 	private static void setHelper(EditPartTipHelper helper) {
-		if (currentHelper != null && currentHelper != helper && currentHelper.isShowing())
+		if (currentHelper != null && currentHelper != helper && currentHelper.isShowing()) {
 			currentHelper.hide();
+		}
 		currentHelper = helper;
 	}
 
@@ -49,7 +47,7 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 	 * displays the tip at the coordianates specified by tipPosX and tipPosY. The
 	 * given coordinates will be adjusted if the tip cannot be completely visible on
 	 * the screen.
-	 * 
+	 *
 	 * @param tip     The tool tip to be displayed.
 	 * @param tipPosX X coordiante of tooltip to be displayed
 	 * @param tipPosY Y coordinate of tooltip to be displayed
@@ -121,15 +119,13 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 		 * cursor is no longer in the tooltip. This occurs in the rare case that a
 		 * mouseEnter is not received on the tooltip when it appears.
 		 */
-		getShell().addMouseMoveListener(new MouseMoveListener() {
-			@Override
-			public void mouseMove(MouseEvent e) {
-				Point eventPoint = getShell().toDisplay(new Point(e.x, e.y));
-				if (!getShell().getBounds().contains(eventPoint)) {
-					if (isShowing())
-						getShell().setCapture(false);
-					dispose();
+		getShell().addMouseMoveListener(e -> {
+			Point eventPoint = getShell().toDisplay(new Point(e.x, e.y));
+			if (!getShell().getBounds().contains(eventPoint)) {
+				if (isShowing()) {
+					getShell().setCapture(false);
 				}
+				dispose();
 			}
 		});
 
@@ -139,17 +135,16 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 			shellListener = new ShellAdapter() {
 				@Override
 				public void shellDeactivated(ShellEvent event) {
-					Display.getCurrent().asyncExec(new Runnable() {
-						@Override
-						public void run() {
-							Shell active = Display.getCurrent().getActiveShell();
-							if (getShell() == active || control.isDisposed() || control.getShell() == active
-									|| getShell().isDisposed())
-								return;
-							if (isShowing())
-								getShell().setCapture(false);
-							dispose();
+					Display.getCurrent().asyncExec(() -> {
+						Shell active = Display.getCurrent().getActiveShell();
+						if (getShell() == active || control.isDisposed() || control.getShell() == active
+								|| getShell().isDisposed()) {
+							return;
 						}
+						if (isShowing()) {
+							getShell().setCapture(false);
+						}
+						dispose();
 					});
 				}
 			};
@@ -163,22 +158,17 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 		 * dispose of the shell.
 		 */
 		if (SWT.getPlatform().equals("gtk")) { //$NON-NLS-1$
-			getShell().addPaintListener(new PaintListener() {
-				@Override
-				public void paintControl(PaintEvent event) {
-					Point cursorLoc = Display.getCurrent().getCursorLocation();
-					if (!getShell().getBounds().contains(cursorLoc)) {
-						// This must be run asynchronously. If not, other paint
-						// listeners may attempt to paint on a disposed control.
-						Display.getCurrent().asyncExec(new Runnable() {
-							@Override
-							public void run() {
-								if (isShowing())
-									getShell().setCapture(false);
-								dispose();
-							}
-						});
-					}
+			getShell().addPaintListener(event -> {
+				Point cursorLoc = Display.getCurrent().getCursorLocation();
+				if (!getShell().getBounds().contains(cursorLoc)) {
+					// This must be run asynchronously. If not, other paint
+					// listeners may attempt to paint on a disposed control.
+					Display.getCurrent().asyncExec(() -> {
+						if (isShowing()) {
+							getShell().setCapture(false);
+						}
+						dispose();
+					});
 				}
 			});
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
@@ -143,7 +143,8 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 						@Override
 						public void run() {
 							Shell active = Display.getCurrent().getActiveShell();
-							if (getShell() == active || control.getShell() == active || getShell().isDisposed())
+							if (getShell() == active || control.isDisposed() || control.getShell() == active
+									|| getShell().isDisposed())
 								return;
 							if (isShowing())
 								getShell().setCapture(false);


### PR DESCRIPTION
In EditPartTipHelper, there is a listener to check for shell deactivation. This runs in asyncExec, but disposal was never checked, so you would get errors like:

```
org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4918)
	at org.eclipse.swt.SWT.error(SWT.java:4833)
	at org.eclipse.swt.SWT.error(SWT.java:4804)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:811)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:597)
	at org.eclipse.swt.widgets.Control.getShell(Control.java:1965)
	at org.eclipse.gef.internal.ui.palette.editparts.EditPartTipHelper$3$1.run(EditPartTipHelper.java:144)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4368)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3991)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1155)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:342)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:645)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:342)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:552)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:171)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:402)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:651)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:588)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1459)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1432)
```

This patch checks for `control.isDisposed()` before checking `control.getShell()` to prevent this error.

Also some auto code cleanup.