### PR TITLE
[Modernize Code] Type the return value of GraphicalEditPolicy getHost

### DIFF
--- a/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/policies/ActivityContainerHighlightEditPolicy.java
+++ b/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/policies/ActivityContainerHighlightEditPolicy.java
@@ -12,13 +12,14 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.flow.policies;
 
+import org.eclipse.swt.graphics.Color;
+
 import org.eclipse.draw2d.IFigure;
+
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.editpolicies.GraphicalEditPolicy;
-import org.eclipse.swt.graphics.Color;
 
 /**
  * @author Daniel Lee
@@ -44,7 +45,7 @@ public class ActivityContainerHighlightEditPolicy extends GraphicalEditPolicy {
 	}
 
 	private IFigure getContainerFigure() {
-		return ((GraphicalEditPart) getHost()).getFigure();
+		return getHost().getFigure();
 	}
 
 	/**
@@ -74,8 +75,10 @@ public class ActivityContainerHighlightEditPolicy extends GraphicalEditPolicy {
 	 */
 	@Override
 	public void showTargetFeedback(Request request) {
-		if (request.getType().equals(RequestConstants.REQ_CREATE) || request.getType().equals(RequestConstants.REQ_ADD))
+		if (request.getType().equals(RequestConstants.REQ_CREATE)
+				|| request.getType().equals(RequestConstants.REQ_ADD)) {
 			showHighlight();
+		}
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/ContainerHighlightEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/ContainerHighlightEditPolicy.java
@@ -17,7 +17,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.draw2d.IFigure;
 
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 
@@ -42,7 +41,7 @@ public class ContainerHighlightEditPolicy extends org.eclipse.gef.editpolicies.G
 	}
 
 	private IFigure getContainerFigure() {
-		return ((GraphicalEditPart) getHost()).getFigure();
+		return getHost().getFigure();
 	}
 
 	@Override
@@ -67,8 +66,9 @@ public class ContainerHighlightEditPolicy extends org.eclipse.gef.editpolicies.G
 				|| request.getType().equals(RequestConstants.REQ_CLONE)
 				|| request.getType().equals(RequestConstants.REQ_CONNECTION_START)
 				|| request.getType().equals(RequestConstants.REQ_CONNECTION_END)
-				|| request.getType().equals(RequestConstants.REQ_CREATE))
+				|| request.getType().equals(RequestConstants.REQ_CREATE)) {
 			showHighlight();
+		}
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LabelDirectEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LabelDirectEditPolicy.java
@@ -29,8 +29,7 @@ public class LabelDirectEditPolicy extends DirectEditPolicy {
 	protected Command getDirectEditCommand(DirectEditRequest edit) {
 		String labelText = (String) edit.getCellEditor().getValue();
 		LogicLabelEditPart label = (LogicLabelEditPart) getHost();
-		LogicLabelCommand command = new LogicLabelCommand((LogicLabel) label.getModel(), labelText);
-		return command;
+		return new LogicLabelCommand((LogicLabel) label.getModel(), labelText);
 	}
 
 	/**

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicNodeEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicNodeEditPolicy.java
@@ -16,7 +16,6 @@ import org.eclipse.draw2d.Connection;
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
 
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
@@ -43,8 +42,9 @@ public class LogicNodeEditPolicy extends org.eclipse.gef.editpolicies.GraphicalN
 		ConnectionCommand command = (ConnectionCommand) request.getStartCommand();
 		command.setTarget(getLogicSubpart());
 		ConnectionAnchor ctor = getLogicEditPart().getTargetConnectionAnchor(request);
-		if (ctor == null)
+		if (ctor == null) {
 			return null;
+		}
 		command.setTargetTerminal(getLogicEditPart().mapConnectionAnchorToTerminal(ctor));
 		return command;
 	}
@@ -83,8 +83,9 @@ public class LogicNodeEditPolicy extends org.eclipse.gef.editpolicies.GraphicalN
 
 	@Override
 	protected Command getReconnectTargetCommand(ReconnectRequest request) {
-		if (getLogicSubpart() instanceof LiveOutput || getLogicSubpart() instanceof GroundOutput)
+		if (getLogicSubpart() instanceof LiveOutput || getLogicSubpart() instanceof GroundOutput) {
 			return null;
+		}
 
 		ConnectionCommand cmd = new ConnectionCommand();
 		cmd.setWire((Wire) request.getConnectionEditPart().getModel());
@@ -107,7 +108,7 @@ public class LogicNodeEditPolicy extends org.eclipse.gef.editpolicies.GraphicalN
 	}
 
 	protected NodeFigure getNodeFigure() {
-		return (NodeFigure) ((GraphicalEditPart) getHost()).getFigure();
+		return (NodeFigure) getHost().getFigure();
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
@@ -55,7 +55,7 @@ public class LogicResizableEditPolicy extends ResizableEditPolicy {
 	 */
 	@Override
 	protected IFigure createDragSourceFeedbackFigure() {
-		IFigure figure = createFigure((GraphicalEditPart) getHost(), null);
+		IFigure figure = createFigure(getHost(), null);
 
 		figure.setBounds(getInitialFeedbackBounds());
 		figure.validate();
@@ -66,8 +66,9 @@ public class LogicResizableEditPolicy extends ResizableEditPolicy {
 	protected IFigure createFigure(GraphicalEditPart part, IFigure parent) {
 		IFigure child = getCustomFeedbackFigure(part.getModel());
 
-		if (parent != null)
+		if (parent != null) {
 			parent.add(child);
+		}
 
 		Rectangle childBounds = part.getFigure().getBounds().getCopy();
 
@@ -86,25 +87,25 @@ public class LogicResizableEditPolicy extends ResizableEditPolicy {
 	protected IFigure getCustomFeedbackFigure(Object modelPart) {
 		IFigure figure;
 
-		if (modelPart instanceof Circuit)
+		if (modelPart instanceof Circuit) {
 			figure = new CircuitFeedbackFigure();
-		else if (modelPart instanceof LogicFlowContainer)
+		} else if (modelPart instanceof LogicFlowContainer) {
 			figure = new LogicFlowFeedbackFigure();
-		else if (modelPart instanceof LogicLabel)
+		} else if (modelPart instanceof LogicLabel) {
 			figure = new LabelFeedbackFigure();
-		else if (modelPart instanceof LED)
+		} else if (modelPart instanceof LED) {
 			figure = new LEDFeedbackFigure();
-		else if (modelPart instanceof OrGate)
+		} else if (modelPart instanceof OrGate) {
 			figure = new OrGateFeedbackFigure();
-		else if (modelPart instanceof XORGate)
+		} else if (modelPart instanceof XORGate) {
 			figure = new XOrGateFeedbackFigure();
-		else if (modelPart instanceof GroundOutput)
+		} else if (modelPart instanceof GroundOutput) {
 			figure = new GroundFeedbackFigure();
-		else if (modelPart instanceof LiveOutput)
+		} else if (modelPart instanceof LiveOutput) {
 			figure = new LiveOutputFeedbackFigure();
-		else if (modelPart instanceof AndGate)
+		} else if (modelPart instanceof AndGate) {
 			figure = new AndGateFeedbackFigure();
-		else {
+		} else {
 			figure = new RectangleFigure();
 			((RectangleFigure) figure).setXOR(true);
 			((RectangleFigure) figure).setFill(true);
@@ -138,6 +139,6 @@ public class LogicResizableEditPolicy extends ResizableEditPolicy {
 	 */
 	@Override
 	protected ResizeTracker getResizeTracker(int direction) {
-		return new LogicResizeTracker((GraphicalEditPart) getHost(), direction);
+		return new LogicResizeTracker(getHost(), direction);
 	}
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEndpointEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/WireEndpointEditPolicy.java
@@ -14,8 +14,6 @@ package org.eclipse.gef.examples.logicdesigner.edit;
 
 import org.eclipse.draw2d.PolylineConnection;
 
-import org.eclipse.gef.GraphicalEditPart;
-
 public class WireEndpointEditPolicy extends org.eclipse.gef.editpolicies.ConnectionEndpointEditPolicy {
 
 	@Override
@@ -25,7 +23,7 @@ public class WireEndpointEditPolicy extends org.eclipse.gef.editpolicies.Connect
 	}
 
 	protected PolylineConnection getConnectionFigure() {
-		return (PolylineConnection) ((GraphicalEditPart) getHost()).getFigure();
+		return (PolylineConnection) getHost().getFigure();
 	}
 
 	@Override

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.16.0.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/BendpointEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/BendpointEditPolicy.java
@@ -30,6 +30,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.handles.BendpointCreationHandle;
+import org.eclipse.gef.handles.BendpointHandle;
 import org.eclipse.gef.handles.BendpointMoveHandle;
 import org.eclipse.gef.requests.BendpointRequest;
 
@@ -66,24 +67,26 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 		List list = new ArrayList();
 		ConnectionEditPart connEP = (ConnectionEditPart) getHost();
 		PointList points = getConnection().getPoints();
-		for (int i = 0; i < points.size() - 1; i++)
+		for (int i = 0; i < points.size() - 1; i++) {
 			list.add(new BendpointCreationHandle(connEP, 0, i));
+		}
 
 		return list;
 	}
 
 	private List createHandlesForUserBendpoints() {
-		List list = new ArrayList();
+		List<BendpointHandle> list = new ArrayList<>();
 		ConnectionEditPart connEP = (ConnectionEditPart) getHost();
 		PointList points = getConnection().getPoints();
 		List bendPoints = (List) getConnection().getRoutingConstraint();
 		int bendPointIndex = 0;
 		Point currBendPoint = null;
 
-		if (bendPoints == null)
+		if (bendPoints == null) {
 			bendPoints = NULL_CONSTRAINT;
-		else if (!bendPoints.isEmpty())
+		} else if (!bendPoints.isEmpty()) {
 			currBendPoint = ((Bendpoint) bendPoints.get(0)).getLocation();
+		}
 
 		for (int i = 0; i < points.size() - 1; i++) {
 			// Put a create handle on the middle of every segment
@@ -97,8 +100,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 
 				// Go to the next user bendpoint
 				bendPointIndex++;
-				if (bendPointIndex < bendPoints.size())
+				if (bendPointIndex < bendPoints.size()) {
 					currBendPoint = ((Bendpoint) bendPoints.get(bendPointIndex)).getLocation();
+				}
 			}
 		}
 
@@ -117,12 +121,10 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 */
 	@Override
 	protected List createSelectionHandles() {
-		List list = new ArrayList();
-		if (isAutomaticallyBending())
-			list = createHandlesForAutomaticBendpoints();
-		else
-			list = createHandlesForUserBendpoints();
-		return list;
+		if (isAutomaticallyBending()) {
+			return createHandlesForAutomaticBendpoints();
+		}
+		return createHandlesForUserBendpoints();
 	}
 
 	/**
@@ -154,8 +156,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 */
 	@Override
 	public void eraseSourceFeedback(Request request) {
-		if (REQ_MOVE_BENDPOINT.equals(request.getType()) || REQ_CREATE_BENDPOINT.equals(request.getType()))
+		if (REQ_MOVE_BENDPOINT.equals(request.getType()) || REQ_CREATE_BENDPOINT.equals(request.getType())) {
 			eraseConnectionFeedback((BendpointRequest) request);
+		}
 	}
 
 	/**
@@ -166,12 +169,14 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	@Override
 	public Command getCommand(Request request) {
 		if (REQ_MOVE_BENDPOINT.equals(request.getType())) {
-			if (isDeleting)
+			if (isDeleting) {
 				return getDeleteBendpointCommand((BendpointRequest) request);
+			}
 			return getMoveBendpointCommand((BendpointRequest) request);
 		}
-		if (REQ_CREATE_BENDPOINT.equals(request.getType()))
+		if (REQ_CREATE_BENDPOINT.equals(request.getType())) {
 			return getCreateBendpointCommand((BendpointRequest) request);
+		}
 		return null;
 	}
 
@@ -221,8 +226,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 		rect.setLocation(p1.x, p1.y);
 		rect.union(p2.x, p2.y);
 		rect.expand(tolerance, tolerance);
-		if (!rect.contains(p.x, p.y))
+		if (!rect.contains(p.x, p.y)) {
 			return false;
+		}
 
 		int v1x, v1y, v2x, v2y;
 		int numerator, denominator;
@@ -254,8 +260,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	@Override
 	public void propertyChange(PropertyChangeEvent evt) {
 		// $TODO optimize so that handles aren't added constantly.
-		if (getHost().getSelected() != EditPart.SELECTED_NONE)
+		if (getHost().getSelected() != EditPart.SELECTED_NONE) {
 			addSelectionHandles();
+		}
 	}
 
 	/**
@@ -264,10 +271,11 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 */
 	protected void restoreOriginalConstraint() {
 		if (originalConstraint != null) {
-			if (originalConstraint == NULL_CONSTRAINT)
+			if (originalConstraint == NULL_CONSTRAINT) {
 				getConnection().setRoutingConstraint(null);
-			else
+			} else {
 				getConnection().setRoutingConstraint(originalConstraint);
+			}
 		}
 	}
 
@@ -277,8 +285,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 */
 	protected void saveOriginalConstraint() {
 		originalConstraint = (List) getConnection().getRoutingConstraint();
-		if (originalConstraint == null)
+		if (originalConstraint == null) {
 			originalConstraint = NULL_CONSTRAINT;
+		}
 		getConnection().setRoutingConstraint(new ArrayList(originalConstraint));
 	}
 
@@ -296,8 +305,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 			if (smallestDistance == -1 || points.getPoint(i).getDistance2(bp) < smallestDistance) {
 				bpIndex = i;
 				smallestDistance = points.getPoint(i).getDistance2(bp);
-				if (smallestDistance == 0)
+				if (smallestDistance == 0) {
 					break;
+				}
 			}
 		}
 
@@ -358,8 +368,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 */
 	protected void showMoveBendpointFeedback(BendpointRequest request) {
 		Point p = new Point(request.getLocation());
-		if (!isDeleting)
+		if (!isDeleting) {
 			setReferencePoints(request);
+		}
 
 		if (lineContainsPoint(ref1, ref2, p)) {
 			if (!isDeleting) {
@@ -373,8 +384,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 			isDeleting = false;
 			eraseSourceFeedback(request);
 		}
-		if (originalConstraint == null)
+		if (originalConstraint == null) {
 			saveOriginalConstraint();
+		}
 		List constraint = (List) getConnection().getRoutingConstraint();
 		getConnection().translateToRelative(p);
 		Bendpoint bp = new AbsoluteBendpoint(p);
@@ -392,10 +404,11 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 	 */
 	@Override
 	public void showSourceFeedback(Request request) {
-		if (REQ_MOVE_BENDPOINT.equals(request.getType()))
+		if (REQ_MOVE_BENDPOINT.equals(request.getType())) {
 			showMoveBendpointFeedback((BendpointRequest) request);
-		else if (REQ_CREATE_BENDPOINT.equals(request.getType()))
+		} else if (REQ_CREATE_BENDPOINT.equals(request.getType())) {
 			showCreateBendpointFeedback((BendpointRequest) request);
+		}
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConnectionEndpointEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ConnectionEndpointEditPolicy.java
@@ -28,7 +28,6 @@ import org.eclipse.draw2d.Polygon;
 import org.eclipse.draw2d.geometry.PointList;
 
 import org.eclipse.gef.ConnectionEditPart;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.NodeEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
@@ -94,8 +93,9 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 
 		@Override
 		public void validate() {
-			if (isValid())
+			if (isValid()) {
 				return;
+			}
 			PointList points = getConnection().getPoints().getCopy();
 			getConnection().translateToAbsolute(points);
 			points = StrokePointList.strokeList(points, 5);
@@ -109,7 +109,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 */
 	@Override
 	protected List createSelectionHandles() {
-		List list = new ArrayList();
+		List<ConnectionEndpointHandle> list = new ArrayList<>();
 		list.add(new ConnectionEndpointHandle((ConnectionEditPart) getHost(), ConnectionLocator.SOURCE));
 		list.add(new ConnectionEndpointHandle((ConnectionEditPart) getHost(), ConnectionLocator.TARGET));
 		return list;
@@ -122,12 +122,14 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 * @param request the reconnect request.
 	 */
 	protected void eraseConnectionMoveFeedback(ReconnectRequest request) {
-		if (originalAnchor == null)
+		if (originalAnchor == null) {
 			return;
-		if (request.isMovingStartAnchor())
+		}
+		if (request.isMovingStartAnchor()) {
 			getConnection().setSourceAnchor(originalAnchor);
-		else
+		} else {
 			getConnection().setTargetAnchor(originalAnchor);
+		}
 		originalAnchor = null;
 		feedbackHelper = null;
 	}
@@ -137,8 +139,9 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 */
 	@Override
 	public void eraseSourceFeedback(Request request) {
-		if (REQ_RECONNECT_TARGET.equals(request.getType()) || REQ_RECONNECT_SOURCE.equals(request.getType()))
+		if (REQ_RECONNECT_TARGET.equals(request.getType()) || REQ_RECONNECT_SOURCE.equals(request.getType())) {
 			eraseConnectionMoveFeedback((ReconnectRequest) request);
+		}
 	}
 
 	/**
@@ -155,7 +158,7 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 * @return the Connection figure
 	 */
 	protected Connection getConnection() {
-		return (Connection) ((GraphicalEditPart) getHost()).getFigure();
+		return (Connection) getHost().getFigure();
 	}
 
 	/**
@@ -198,20 +201,23 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 */
 	protected void showConnectionMoveFeedback(ReconnectRequest request) {
 		NodeEditPart node = null;
-		if (request.getTarget() instanceof NodeEditPart)
-			node = (NodeEditPart) request.getTarget();
+		if (request.getTarget() instanceof NodeEditPart nodeEP) {
+			node = nodeEP;
+		}
 		if (originalAnchor == null) {
-			if (request.isMovingStartAnchor())
+			if (request.isMovingStartAnchor()) {
 				originalAnchor = getConnection().getSourceAnchor();
-			else
+			} else {
 				originalAnchor = getConnection().getTargetAnchor();
+			}
 		}
 		ConnectionAnchor anchor = null;
 		if (node != null) {
-			if (request.isMovingStartAnchor())
+			if (request.isMovingStartAnchor()) {
 				anchor = node.getSourceConnectionAnchor(request);
-			else
+			} else {
 				anchor = node.getTargetConnectionAnchor(request);
+			}
 		}
 		FeedbackHelper helper = getFeedbackHelper(request);
 		helper.update(anchor, request.getLocation());
@@ -235,8 +241,9 @@ public class ConnectionEndpointEditPolicy extends SelectionHandlesEditPolicy {
 	 */
 	@Override
 	public void showSourceFeedback(Request request) {
-		if (REQ_RECONNECT_SOURCE.equals(request.getType()) || REQ_RECONNECT_TARGET.equals(request.getType()))
+		if (REQ_RECONNECT_SOURCE.equals(request.getType()) || REQ_RECONNECT_TARGET.equals(request.getType())) {
 			showConnectionMoveFeedback((ReconnectRequest) request);
+		}
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/FlowLayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/FlowLayoutEditPolicy.java
@@ -48,7 +48,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 		}
 	}
 
-	private Rectangle getAbsoluteBounds(GraphicalEditPart ep) {
+	private static Rectangle getAbsoluteBounds(GraphicalEditPart ep) {
 		Rectangle bounds = ep.getFigure().getBounds().getCopy();
 		ep.getFigure().translateToAbsolute(bounds);
 		return bounds;
@@ -60,8 +60,9 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	 */
 	protected int getFeedbackIndexFor(Request request) {
 		List<? extends EditPart> children = getHost().getChildren();
-		if (children.isEmpty())
+		if (children.isEmpty()) {
 			return -1;
+		}
 
 		Transposer transposer = new Transposer();
 		transposer.setEnabled(!isLayoutHorizontal());
@@ -82,12 +83,13 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 				 * row, so this Figure (which is at the start of a new row) is the candidate.
 				 */
 				if (p.y <= rowBottom) {
-					if (candidate == -1)
+					if (candidate == -1) {
 						candidate = i;
+					}
 					break;
-				} else
-					candidate = -1; // Mouse's Y is outside the row, so reset
-									// the candidate
+				}
+				candidate = -1; // Mouse's Y is outside the row, so reset
+								// the candidate
 			}
 			rowBottom = Math.max(rowBottom, rect.bottom());
 			if (candidate == -1) {
@@ -95,8 +97,9 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 				 * See if we have a possible candidate. It is a candidate if the cursor is left
 				 * of the center of this candidate.
 				 */
-				if (p.x <= rect.x + (rect.width / 2))
+				if (p.x <= rect.x + (rect.width / 2)) {
 					candidate = i;
+				}
 			}
 			if (candidate != -1) {
 				// We have a candidate, see if the rowBottom has grown to
@@ -122,8 +125,9 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 
 		if (request.getType().equals(RequestConstants.REQ_CREATE)) {
 			int i = getFeedbackIndexFor(request);
-			if (i == -1)
+			if (i == -1) {
 				return null;
+			}
 			return children.get(i);
 		}
 
@@ -132,8 +136,9 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 			List selection = getHost().getViewer().getSelectedEditParts();
 			do {
 				EditPart editpart = children.get(index);
-				if (!selection.contains(editpart))
+				if (!selection.contains(editpart)) {
 					return editpart;
+				}
 			} while (++index < children.size());
 		}
 		return null; // Not found, add at the end.
@@ -165,6 +170,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	 *         orientation
 	 * @deprecated Use {@link #isLayoutHorizontal()} instead.
 	 */
+	@Deprecated
 	protected boolean isHorizontal() {
 		return isLayoutHorizontal();
 	}
@@ -176,8 +182,9 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 	 */
 	@Override
 	protected void showLayoutTargetFeedback(Request request) {
-		if (getHost().getChildren().isEmpty())
+		if (getHost().getChildren().isEmpty()) {
 			return;
+		}
 		Polyline fb = getLineFeedback();
 		Transposer transposer = new Transposer();
 		transposer.setEnabled(!isLayoutHorizontal());
@@ -194,9 +201,9 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 			EditPart editPart = getHost().getChildren().get(epIndex);
 			r = transposer.t(getAbsoluteBounds((GraphicalEditPart) editPart));
 			Point p = transposer.t(getLocationFromRequest(request));
-			if (p.x <= r.x + (r.width / 2))
+			if (p.x <= r.x + (r.width / 2)) {
 				before = true;
-			else {
+			} else {
 				/*
 				 * We are not to the left of this Figure, so the emphasis line needs to be to
 				 * the right of the previous Figure, which must be on the previous row.
@@ -217,8 +224,7 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 			 */
 			if (epIndex > 0) {
 				// Need to determine if a line break.
-				Rectangle boxPrev = transposer
-						.t(getAbsoluteBounds((GraphicalEditPart) getHost().getChildren().get(epIndex - 1)));
+				Rectangle boxPrev = transposer.t(getAbsoluteBounds(getHost().getChildren().get(epIndex - 1)));
 				int prevRight = boxPrev.right();
 				if (prevRight < r.x) {
 					// Not a line break
@@ -229,10 +235,11 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 			}
 			if (x == Integer.MIN_VALUE) {
 				// It is a line break.
-				Rectangle parentBox = transposer.t(getAbsoluteBounds((GraphicalEditPart) getHost()));
+				Rectangle parentBox = transposer.t(getAbsoluteBounds(getHost()));
 				x = r.x - 5;
-				if (x < parentBox.x)
+				if (x < parentBox.x) {
 					x = parentBox.x + (r.x - parentBox.x) / 2;
+				}
 			}
 		} else {
 			/*
@@ -240,12 +247,13 @@ public abstract class FlowLayoutEditPolicy extends OrderedLayoutEditPolicy {
 			 * between the right edge and the right edge of the parent, but no more than 5
 			 * pixels.
 			 */
-			Rectangle parentBox = transposer.t(getAbsoluteBounds((GraphicalEditPart) getHost()));
+			Rectangle parentBox = transposer.t(getAbsoluteBounds(getHost()));
 			int rRight = r.x + r.width;
 			int pRight = parentBox.x + parentBox.width;
 			x = rRight + 5;
-			if (x > pRight)
+			if (x > pRight) {
 				x = rRight + (pRight - rRight) / 2;
+			}
 		}
 		Point p1 = new Point(x, r.y - 4);
 		p1 = transposer.t(p1);

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/GraphicalEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/GraphicalEditPolicy.java
@@ -50,12 +50,25 @@ public abstract class GraphicalEditPolicy extends AbstractEditPolicy {
 	}
 
 	/**
+	 * Cast the parent getHost to GraphicalEditPart
+	 *
+	 * This reduces the necessary cast operations in this and all child classes as
+	 * well as in any users of a GraphicalEditPolicy.
+	 *
+	 * @since 3.16
+	 */
+	@Override
+	public GraphicalEditPart getHost() {
+		return (GraphicalEditPart) super.getHost();
+	}
+
+	/**
 	 * Convenience method to return the host's Figure.
 	 *
 	 * @return The host GraphicalEditPart's Figure
 	 */
 	protected IFigure getHostFigure() {
-		return ((GraphicalEditPart) getHost()).getFigure();
+		return getHost().getFigure();
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/LayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/LayoutEditPolicy.java
@@ -167,11 +167,13 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	public void eraseTargetFeedback(Request request) {
 		if (REQ_ADD.equals(request.getType()) || REQ_MOVE.equals(request.getType())
 				|| REQ_RESIZE_CHILDREN.equals(request.getType()) || REQ_CREATE.equals(request.getType())
-				|| REQ_CLONE.equals(request.getType()))
+				|| REQ_CLONE.equals(request.getType())) {
 			eraseLayoutTargetFeedback(request);
+		}
 
-		if (REQ_CREATE.equals(request.getType()))
+		if (REQ_CREATE.equals(request.getType())) {
 			eraseSizeOnDropFeedback(request);
+		}
 	}
 
 	/**
@@ -203,23 +205,29 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	 */
 	@Override
 	public Command getCommand(Request request) {
-		if (REQ_DELETE_DEPENDANT.equals(request.getType()))
+		if (REQ_DELETE_DEPENDANT.equals(request.getType())) {
 			return getDeleteDependantCommand(request);
+		}
 
-		if (REQ_ADD.equals(request.getType()))
+		if (REQ_ADD.equals(request.getType())) {
 			return getAddCommand(request);
+		}
 
-		if (REQ_ORPHAN_CHILDREN.equals(request.getType()))
+		if (REQ_ORPHAN_CHILDREN.equals(request.getType())) {
 			return getOrphanChildrenCommand(request);
+		}
 
-		if (REQ_MOVE_CHILDREN.equals(request.getType()))
+		if (REQ_MOVE_CHILDREN.equals(request.getType())) {
 			return getMoveChildrenCommand(request);
+		}
 
-		if (REQ_CLONE.equals(request.getType()))
+		if (REQ_CLONE.equals(request.getType())) {
 			return getCloneCommand((ChangeBoundsRequest) request);
+		}
 
-		if (REQ_CREATE.equals(request.getType()))
+		if (REQ_CREATE.equals(request.getType())) {
 			return getCreateCommand((CreateRequest) request);
+		}
 
 		return null;
 	}
@@ -263,7 +271,7 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	 * @return the Figure that owns the corresponding <code>LayoutManager</code>
 	 */
 	protected IFigure getLayoutContainer() {
-		return ((GraphicalEditPart) getHost()).getContentPane();
+		return getHost().getContentPane();
 	}
 
 	/**
@@ -297,8 +305,9 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	 * @return the size-on-drop feedback figure
 	 */
 	protected IFigure getSizeOnDropFeedback(CreateRequest createRequest) {
-		if (sizeOnDropFeedback == null)
+		if (sizeOnDropFeedback == null) {
 			sizeOnDropFeedback = createSizeOnDropFeedback(createRequest);
+		}
 
 		return getSizeOnDropFeedback();
 	}
@@ -327,8 +336,9 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	@Override
 	public EditPart getTargetEditPart(Request request) {
 		if (REQ_ADD.equals(request.getType()) || REQ_MOVE.equals(request.getType())
-				|| REQ_CREATE.equals(request.getType()) || REQ_CLONE.equals(request.getType()))
+				|| REQ_CREATE.equals(request.getType()) || REQ_CLONE.equals(request.getType())) {
 			return getHost();
+		}
 		return null;
 	}
 
@@ -343,11 +353,13 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	 * @param listener <code>null</code> or the listener.
 	 */
 	protected void setListener(EditPartListener listener) {
-		if (this.listener != null)
+		if (this.listener != null) {
 			getHost().removeEditPartListener(this.listener);
+		}
 		this.listener = listener;
-		if (this.listener != null)
+		if (this.listener != null) {
 			getHost().addEditPartListener(this.listener);
+		}
 	}
 
 	/**
@@ -381,8 +393,9 @@ public abstract class LayoutEditPolicy extends GraphicalEditPolicy {
 	public void showTargetFeedback(Request request) {
 		if (REQ_ADD.equals(request.getType()) || REQ_CLONE.equals(request.getType())
 				|| REQ_MOVE.equals(request.getType()) || REQ_RESIZE_CHILDREN.equals(request.getType())
-				|| REQ_CREATE.equals(request.getType()))
+				|| REQ_CREATE.equals(request.getType())) {
 			showLayoutTargetFeedback(request);
+		}
 
 		if (REQ_CREATE.equals(request.getType())) {
 			CreateRequest createReq = (CreateRequest) request;

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
@@ -21,14 +21,12 @@ import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.FocusBorder;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
-import org.eclipse.draw2d.Locator;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.RectangleFigure;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.DragTracker;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.SharedCursors;
@@ -106,13 +104,11 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	protected void createDragHandle(List handles, int direction) {
 		if (isDragAllowed()) {
 			// display 'resize' handles to allow dragging (drag tracker)
-			NonResizableHandleKit.addHandle((GraphicalEditPart) getHost(), handles, direction, getDragTracker(),
-					SharedCursors.SIZEALL);
+			NonResizableHandleKit.addHandle(getHost(), handles, direction, getDragTracker(), SharedCursors.SIZEALL);
 		} else {
 			// display 'resize' handles to indicate selection only (selection
 			// tracker)
-			NonResizableHandleKit.addHandle((GraphicalEditPart) getHost(), handles, direction, getSelectTracker(),
-					SharedCursors.ARROW);
+			NonResizableHandleKit.addHandle(getHost(), handles, direction, getSelectTracker(), SharedCursors.ARROW);
 		}
 	}
 
@@ -147,11 +143,10 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	protected void createMoveHandle(List handles) {
 		if (isDragAllowed()) {
 			// display 'move' handle to allow dragging
-			ResizableHandleKit.addMoveHandle((GraphicalEditPart) getHost(), handles, getDragTracker(), Cursors.SIZEALL);
+			ResizableHandleKit.addMoveHandle(getHost(), handles, getDragTracker(), Cursors.SIZEALL);
 		} else {
 			// display 'move' handle only to indicate selection
-			ResizableHandleKit.addMoveHandle((GraphicalEditPart) getHost(), handles, getSelectTracker(),
-					SharedCursors.ARROW);
+			ResizableHandleKit.addMoveHandle(getHost(), handles, getSelectTracker(), SharedCursors.ARROW);
 		}
 	}
 
@@ -187,8 +182,9 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	@Override
 	public void eraseSourceFeedback(Request request) {
 		if ((REQ_MOVE.equals(request.getType()) && isDragAllowed()) || REQ_CLONE.equals(request.getType())
-				|| REQ_ADD.equals(request.getType()))
+				|| REQ_ADD.equals(request.getType())) {
 			eraseChangeBoundsFeedback((ChangeBoundsRequest) request);
+		}
 	}
 
 	/**
@@ -198,12 +194,15 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	public Command getCommand(Request request) {
 		Object type = request.getType();
 
-		if (REQ_MOVE.equals(type) && isDragAllowed())
+		if (REQ_MOVE.equals(type) && isDragAllowed()) {
 			return getMoveCommand((ChangeBoundsRequest) request);
-		if (REQ_ORPHAN.equals(type))
+		}
+		if (REQ_ORPHAN.equals(type)) {
 			return getOrphanCommand(request);
-		if (REQ_ALIGN.equals(type))
+		}
+		if (REQ_ALIGN.equals(type)) {
 			return getAlignCommand((AlignmentRequest) request);
+		}
 
 		return null;
 	}
@@ -214,8 +213,9 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 * @return the feedback figure
 	 */
 	protected IFigure getDragSourceFeedbackFigure() {
-		if (feedback == null)
+		if (feedback == null) {
 			feedback = createDragSourceFeedbackFigure();
+		}
 		return feedback;
 	}
 
@@ -241,9 +241,10 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 * @return the host figure's bounding Rectangle
 	 */
 	protected Rectangle getInitialFeedbackBounds() {
-		if (((GraphicalEditPart) getHost()).getFigure() instanceof HandleBounds)
-			return ((HandleBounds) ((GraphicalEditPart) getHost()).getFigure()).getHandleBounds();
-		return ((GraphicalEditPart) getHost()).getFigure().getBounds();
+		if (getHost().getFigure() instanceof HandleBounds handleBounds) {
+			return handleBounds.getHandleBounds();
+		}
+		return getHost().getFigure().getBounds();
 	}
 
 	/**
@@ -288,8 +289,9 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 */
 	@Override
 	protected void hideFocus() {
-		if (focusRect != null)
+		if (focusRect != null) {
 			removeFeedback(focusRect);
+		}
 		focusRect = null;
 	}
 
@@ -309,8 +311,9 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 * @param isDragAllowed whether or not the EditPolicy can be dragged.
 	 */
 	public void setDragAllowed(boolean isDragAllowed) {
-		if (isDragAllowed == this.isDragAllowed)
+		if (isDragAllowed == this.isDragAllowed) {
 			return;
+		}
 		this.isDragAllowed = isDragAllowed;
 	}
 
@@ -340,19 +343,17 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 */
 	@Override
 	protected void showFocus() {
-		focusRect = new AbstractHandle((GraphicalEditPart) getHost(), new Locator() {
-			@Override
-			public void relocate(IFigure target) {
-				IFigure figure = getHostFigure();
-				Rectangle r;
-				if (figure instanceof HandleBounds)
-					r = ((HandleBounds) figure).getHandleBounds().getCopy();
-				else
-					r = getHostFigure().getBounds().getResized(-1, -1);
-				getHostFigure().translateToAbsolute(r);
-				target.translateToRelative(r);
-				target.setBounds(r.expand(5, 5).resize(1, 1));
+		focusRect = new AbstractHandle(getHost(), target -> {
+			IFigure figure = getHostFigure();
+			Rectangle r;
+			if (figure instanceof HandleBounds handleBounds) {
+				r = handleBounds.getHandleBounds().getCopy();
+			} else {
+				r = getHostFigure().getBounds().getResized(-1, -1);
 			}
+			getHostFigure().translateToAbsolute(r);
+			target.translateToRelative(r);
+			target.setBounds(r.expand(5, 5).resize(1, 1));
 		}) {
 			{
 				setBorder(new FocusBorder());
@@ -374,8 +375,9 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	@Override
 	public void showSourceFeedback(Request request) {
 		if ((REQ_MOVE.equals(request.getType()) && isDragAllowed()) || REQ_ADD.equals(request.getType())
-				|| REQ_CLONE.equals(request.getType()))
+				|| REQ_CLONE.equals(request.getType())) {
 			showChangeBoundsFeedback((ChangeBoundsRequest) request);
+		}
 	}
 
 	/**
@@ -387,11 +389,13 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	 */
 	@Override
 	public boolean understandsRequest(Request request) {
-		if (REQ_MOVE.equals(request.getType()))
+		if (REQ_MOVE.equals(request.getType())) {
 			return isDragAllowed();
-		else if (REQ_CLONE.equals(request.getType()) || REQ_ADD.equals(request.getType())
-				|| REQ_ORPHAN.equals(request.getType()) || REQ_ALIGN.equals(request.getType()))
+		}
+		if (REQ_CLONE.equals(request.getType()) || REQ_ADD.equals(request.getType())
+				|| REQ_ORPHAN.equals(request.getType()) || REQ_ALIGN.equals(request.getType())) {
 			return true;
+		}
 		return super.understandsRequest(request);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ResizableEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ResizableEditPolicy.java
@@ -18,7 +18,6 @@ import java.util.List;
 import org.eclipse.draw2d.Cursors;
 import org.eclipse.draw2d.PositionConstants;
 
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.handles.ResizableHandleKit;
@@ -89,7 +88,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	 */
 	protected void createResizeHandle(List handles, int direction) {
 		if ((resizeDirections & direction) == direction) {
-			ResizableHandleKit.addHandle((GraphicalEditPart) getHost(), handles, direction, getResizeTracker(direction),
+			ResizableHandleKit.addHandle(getHost(), handles, direction, getResizeTracker(direction),
 					Cursors.getDirectionalCursor(direction, getHostFigure().isMirrored()));
 		} else {
 			// display 'resize' handle to allow dragging or indicate selection
@@ -107,7 +106,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	 * @since 3.7
 	 */
 	protected ResizeTracker getResizeTracker(int direction) {
-		return new ResizeTracker((GraphicalEditPart) getHost(), direction);
+		return new ResizeTracker(getHost(), direction);
 	}
 
 	/**
@@ -117,10 +116,11 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	 */
 	@Override
 	public void eraseSourceFeedback(Request request) {
-		if (REQ_RESIZE.equals(request.getType()))
+		if (REQ_RESIZE.equals(request.getType())) {
 			eraseChangeBoundsFeedback((ChangeBoundsRequest) request);
-		else
+		} else {
 			super.eraseSourceFeedback(request);
+		}
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ScrollableSelectionFeedbackEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ScrollableSelectionFeedbackEditPolicy.java
@@ -55,7 +55,7 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 
 	private int feedbackAlpha = 100;
 
-	private final List feedbackFigures = new ArrayList();
+	private final List<IFigure> feedbackFigures = new ArrayList<>();
 
 	private final FigureListener figureListener = source -> {
 		// react on host figure move
@@ -96,15 +96,12 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	@Override
 	public void activate() {
 		super.activate();
-		// register listeners to all viewports in the host figure's path;
-		// listeners
-		// to the host figure itself will be registered within showFeedback()
-		// and
-		// unregistered within hideFeedback()
-		for (Iterator iterator = ViewportUtilities
-				.getViewportsPath(getHostFigureViewport(), ViewportUtilities.getRootViewport(getHostFigure()))
-				.iterator(); iterator.hasNext();) {
-			Viewport viewport = (Viewport) iterator.next();
+		// register listeners to all viewports in the host figure's path:
+		// listeners the host figure itself will be registered within showFeedback()
+		// and unregistered within hideFeedback()
+		for (Object element : ViewportUtilities.getViewportsPath(getHostFigureViewport(),
+				ViewportUtilities.getRootViewport(getHostFigure()))) {
+			Viewport viewport = (Viewport) element;
 			viewport.addPropertyChangeListener(viewportViewLocationChangeListener);
 		}
 	}
@@ -144,11 +141,9 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	 * Creates the connection layer feedback figures.
 	 */
 	protected void createConnectionFeedbackFigures() {
-		HashSet transitiveNestedConnections = EditPartUtilities
-				.getAllNestedConnectionEditParts((GraphicalEditPart) getHost());
+		HashSet transitiveNestedConnections = EditPartUtilities.getAllNestedConnectionEditParts(getHost());
 
-		for (Iterator iterator = transitiveNestedConnections.iterator(); iterator.hasNext();) {
-			Object connection = iterator.next();
+		for (Object connection : transitiveNestedConnections) {
 			if (connection instanceof ConnectionEditPart) {
 				createConnectionFeedbackFigure((ConnectionEditPart) connection);
 			}
@@ -172,11 +167,7 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	 */
 	protected void createNodeFeedbackFigures() {
 		// create ghost feedback for node children
-		getHost().getChildren().forEach(child -> {
-			if (child instanceof GraphicalEditPart gEP) {
-				createNodeFeedbackFigure(gEP);
-			}
-		});
+		getHost().getChildren().forEach(this::createNodeFeedbackFigure);
 	}
 
 	/**
@@ -187,10 +178,9 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 		// remove viewport listeners; listener to host figure, which were
 		// registered during showSelection() will be unregistered during
 		// hideSelection(), so they do not have to be unregistered here
-		for (Iterator iterator = ViewportUtilities
-				.getViewportsPath(getHostFigureViewport(), ViewportUtilities.getRootViewport(getHostFigure()))
-				.iterator(); iterator.hasNext();) {
-			Viewport viewport = (Viewport) iterator.next();
+		for (Object element : ViewportUtilities.getViewportsPath(getHostFigureViewport(),
+				ViewportUtilities.getRootViewport(getHostFigure()))) {
+			Viewport viewport = (Viewport) element;
 			viewport.removePropertyChangeListener(viewportViewLocationChangeListener);
 
 		}
@@ -229,9 +219,7 @@ public class ScrollableSelectionFeedbackEditPolicy extends SelectionEditPolicy {
 	 * {@link #feedbackFigures} list.
 	 */
 	protected void hideFeedback() {
-		for (Iterator iterator = feedbackFigures.iterator(); iterator.hasNext();) {
-			removeFeedback((IFigure) iterator.next());
-		}
+		feedbackFigures.forEach(this::removeFeedback);
 		feedbackFigures.clear();
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SnapFeedbackPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/SnapFeedbackPolicy.java
@@ -26,7 +26,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.PrecisionPoint;
 import org.eclipse.draw2d.geometry.Rectangle;
 
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.SnapToGeometry;
 import org.eclipse.gef.SnapToGuides;
@@ -41,8 +40,8 @@ import org.eclipse.gef.SnapToGuides;
  */
 public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 
-	IFigure guide[] = new IFigure[6];
-	Integer location[] = new Integer[6];
+	IFigure[] guide = new IFigure[6];
+	Integer[] location = new Integer[6];
 
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseTargetFeedback(org.eclipse.gef.Request)
@@ -50,8 +49,9 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 	@Override
 	public void eraseTargetFeedback(Request request) {
 		for (int i = 0; i < guide.length; i++) {
-			if (guide[i] != null)
+			if (guide[i] != null) {
 				removeFeedback(guide[i]);
+			}
 			guide[i] = null;
 			location[i] = null;
 		}
@@ -96,19 +96,17 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 					image = new Image(display, iData);
 					count++;
 				}
-				Display.getCurrent().timerExec(100, new Runnable() {
-					@Override
-					public void run() {
-						opacity = Math.min(FRAMES, opacity + 1);
-						repaint();
-					}
+				Display.getCurrent().timerExec(100, () -> {
+					opacity = Math.min(FRAMES, opacity + 1);
+					repaint();
 				});
 			}
 			Rectangle r = getBounds();
-			if (image != null)
+			if (image != null) {
 				graphics.drawImage(image, 0, 0, 1, 1, r.x, r.y, r.width, r.height);
-			else
+			} else {
 				super.paintFigure(graphics);
+			}
 		}
 
 		/**
@@ -139,7 +137,7 @@ public class SnapFeedbackPolicy extends GraphicalEditPolicy {
 		// translate pos to absolute, and then make it relative to fig.
 		int position = pos.intValue();
 		PrecisionPoint loc = new PrecisionPoint(position, position);
-		IFigure contentPane = ((GraphicalEditPart) getHost()).getContentPane();
+		IFigure contentPane = getHost().getContentPane();
 		contentPane.translateToParent(loc);
 		contentPane.translateToAbsolute(loc);
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/XYLayoutEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/XYLayoutEditPolicy.java
@@ -51,9 +51,8 @@ public abstract class XYLayoutEditPolicy extends ConstrainedLayoutEditPolicy {
 	 */
 	@Override
 	protected Object getConstraintFor(Request request, GraphicalEditPart child, Rectangle rect) {
-		if (request instanceof ChangeBoundsRequest) {
-			if (((ChangeBoundsRequest) request).getSizeDelta().width == 0
-					&& ((ChangeBoundsRequest) request).getSizeDelta().height == 0) {
+		if (request instanceof ChangeBoundsRequest cbRequest) {
+			if (cbRequest.getSizeDelta().width == 0 && cbRequest.getSizeDelta().height == 0) {
 				if (getCurrentConstraintFor(child) != null) {
 					// Bug 86473 allows for unintended use of this method
 					rect.setSize(getCurrentConstraintFor(child).getSize());
@@ -157,6 +156,7 @@ public abstract class XYLayoutEditPolicy extends ConstrainedLayoutEditPolicy {
 	 *             tracker, constructed by the 'satellite' primary drag edit policy
 	 *             should be parameterized with max and min size constraints.
 	 */
+	@Deprecated
 	protected Dimension getMinimumSizeFor(GraphicalEditPart child) {
 		return new Dimension(8, 8);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/DragGuidePolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/DragGuidePolicy.java
@@ -67,8 +67,9 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 
 			Iterator i = attachedEditParts.iterator();
 
-			while (i.hasNext())
+			while (i.hasNext()) {
 				((EditPart) i.next()).eraseSourceFeedback(req);
+			}
 			attachedEditParts = null;
 		}
 	}
@@ -86,9 +87,10 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 	}
 
 	private List getAttachedEditParts() {
-		if (attachedEditParts == null)
+		if (attachedEditParts == null) {
 			attachedEditParts = getGuideEditPart().getRulerProvider().getAttachedEditParts(getHost().getModel(),
 					((RulerEditPart) getHost().getParent()).getDiagramViewer());
+		}
 		return attachedEditParts;
 	}
 
@@ -187,15 +189,17 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 		ChangeBoundsRequest req = new ChangeBoundsRequest(request.getType());
 		req.setEditParts(getAttachedEditParts());
 
-		if (getGuideEditPart().isHorizontal())
+		if (getGuideEditPart().isHorizontal()) {
 			req.setMoveDelta(new Point(0, request.getMoveDelta().y));
-		else
+		} else {
 			req.setMoveDelta(new Point(request.getMoveDelta().x, 0));
+		}
 
 		Iterator i = getAttachedEditParts().iterator();
 
-		while (i.hasNext())
+		while (i.hasNext()) {
 			((EditPart) i.next()).showSourceFeedback(req);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Java now allows overriding return values. Using this for GraphicalEditPolicy.getHost() reduces cast requirements and makes code clearer.