### PR TITLE
Rework Rectangle.intersects so that it does not need to create a rect

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -739,7 +739,12 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @since 2.0
 	 */
 	public boolean intersects(Rectangle rect) {
-		return !getIntersection(rect).isEmpty();
+		int x1 = Math.max(x, rect.x());
+		int x2 = Math.min(x + width, rect.x() + rect.width());
+		int y1 = Math.max(y, rect.y());
+		int y2 = Math.min(y + height, rect.y() + rect.height());
+
+		return (((x2 - x1) > 0) && ((y2 - y1) > 0));
 	}
 
 	/**


### PR DESCRIPTION
The intersects checking method of Rectangle used intersect with a copy of an rectangle. This generated a lot of garbage during drawing as intersect is used to check if a children should be drawn or not.

Addresses #282 