### PR TITLE
Add ability to contribute custom BreakIterator/Bidi via SPI

### DIFF
--- a/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.tests
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.draw2d.tests/META-INF/services/java.text.spi.BreakIteratorProvider
+++ b/org.eclipse.draw2d.tests/META-INF/services/java.text.spi.BreakIteratorProvider
@@ -1,0 +1,1 @@
+org.eclipse.draw2d.test.TextFlowWrapTest$BreakIteratorProviderMock

--- a/org.eclipse.draw2d.tests/META-INF/services/org.eclipse.draw2d.text.BidiProvider
+++ b/org.eclipse.draw2d.tests/META-INF/services/org.eclipse.draw2d.text.BidiProvider
@@ -1,0 +1,1 @@
+org.eclipse.draw2d.test.BidiProcessorTest$BidiProviderMock

--- a/org.eclipse.draw2d.tests/pom.xml
+++ b/org.eclipse.draw2d.tests/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.tests</artifactId>
-	<version>3.12.200-SNAPSHOT</version>
+	<version>3.13.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<profiles>
 		<profile>

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BaseTestCase.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 public abstract class BaseTestCase extends Assert {
 
 	protected static final Font TAHOMA = new Font(null, "Tahoma", 8, 0);//$NON-NLS-1$
+	protected static final Font SERIF = new Font(null, "Serif", 8, 0);//$NON-NLS-1$
 
 	public static void assertEquals(Image expected, Image actual) {
 		assertTrue("The given images did not match", //$NON-NLS-1$

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BidiProcessorTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/BidiProcessorTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test;
+
+import java.text.Bidi;
+import java.util.ServiceLoader;
+
+import org.eclipse.draw2d.text.BidiProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BidiProcessorTest extends BaseTestCase {
+	private ClassLoader classLoader;
+
+	@Before
+	public void setUp() {
+		classLoader = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+	}
+
+	@After
+	public void tearDown() {
+		Thread.currentThread().setContextClassLoader(classLoader);
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	public void testSpi() {
+		ServiceLoader<BidiProvider> serviceLoader = ServiceLoader.load(BidiProvider.class);
+		BidiProvider service = serviceLoader.findFirst().orElse(null);
+
+		assertNotNull(service);
+		assertTrue(service instanceof BidiProviderMock);
+	}
+
+	public static class BidiProviderMock implements BidiProvider {
+		@Override
+		public boolean requiresBidi(char[] text, int start, int limit) {
+			return Bidi.requiresBidi(text, start, limit);
+		}
+	}
+}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ColorConstantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2010 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,14 +15,13 @@ package org.eclipse.draw2d.test;
 import org.eclipse.swt.widgets.Display;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class ColorConstantTest extends Assert {
 
 	@Test
-	public static void testColorConstantInit() {
+	@SuppressWarnings("static-method")
+	public void testColorConstantInit() {
 		final Boolean[] result = new Boolean[2];
 		result[0] = Boolean.FALSE;
 		result[1] = Boolean.FALSE;

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,12 @@
  *******************************************************************************/
 package org.eclipse.draw2d.test;
 
+import java.text.BreakIterator;
+import java.text.spi.BreakIteratorProvider;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Locale;
+import java.util.ServiceLoader;
 
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.text.FlowPage;
@@ -22,11 +26,10 @@ import org.eclipse.draw2d.text.ParagraphTextLayout;
 import org.eclipse.draw2d.text.TextFlow;
 import org.eclipse.draw2d.text.TextFragmentBox;
 
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-// FIXME The text flow wrap test are currently unstable and therefore deactivated
-@Ignore
 public class TextFlowWrapTest extends BaseTestCase {
 
 	// @TODO:Pratik create similar test cases for bidi...where the fragments are
@@ -49,6 +52,18 @@ public class TextFlowWrapTest extends BaseTestCase {
 
 	FlowPage figure;
 	TextFlow textFlow, textFlow2;
+	ClassLoader classLoader;
+
+	@Before
+	public void setUp() {
+		classLoader = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+	}
+
+	@After
+	public void tearDown() {
+		Thread.currentThread().setContextClassLoader(classLoader);
+	}
 
 	protected void doTest(String stringToTest, String widthString, String[] answers) {
 		doTest2(stringToTest, "", widthString, answers); //$NON-NLS-1$
@@ -57,7 +72,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 	protected void doTest2(String string1, String string2, String widthString, String[] answers) {
 		int width = -1;
 		if (widthString != null) {
-			width = FigureUtilities.getStringExtents(widthString, TAHOMA).width;
+			width = FigureUtilities.getStringExtents(widthString, SERIF).width;
 		}
 		figure.setSize(width, 1000);
 		textFlow.setText(string1);
@@ -269,11 +284,11 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 
 		runGenericTests();
@@ -285,11 +300,11 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 
 		runGenericTests();
@@ -301,11 +316,11 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_TRUNCATE));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_TRUNCATE));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 
 		runGenericTests();
@@ -318,12 +333,12 @@ public class TextFlowWrapTest extends BaseTestCase {
 		InlineFlow inline = new InlineFlow();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		inline.add(textFlow);
 		figure.add(inline);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 		runGenericTests();
 		runSoftWrappingTests();
@@ -332,12 +347,12 @@ public class TextFlowWrapTest extends BaseTestCase {
 		inline = new InlineFlow();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		inline.add(textFlow);
 		figure.add(inline);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		figure.add(textFlow2);
 		runGenericTests();
 		runHardWrappingTests();
@@ -349,7 +364,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		InlineFlow inline = new InlineFlow();
 		figure.add(inline);
@@ -357,7 +372,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		inline.add(inline2);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_SOFT));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		inline2.add(textFlow2);
 		runGenericTests();
 		runSoftWrappingTests();
@@ -365,7 +380,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		figure = new FlowPage();
 		textFlow = new TextFlow();
 		textFlow.setLayoutManager(new ParagraphTextLayout(textFlow, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow.setFont(TAHOMA);
+		textFlow.setFont(SERIF);
 		figure.add(textFlow);
 		inline = new InlineFlow();
 		figure.add(inline);
@@ -373,11 +388,47 @@ public class TextFlowWrapTest extends BaseTestCase {
 		inline.add(inline2);
 		textFlow2 = new TextFlow();
 		textFlow2.setLayoutManager(new ParagraphTextLayout(textFlow2, ParagraphTextLayout.WORD_WRAP_HARD));
-		textFlow2.setFont(TAHOMA);
+		textFlow2.setFont(SERIF);
 		inline2.add(textFlow2);
 		runGenericTests();
 		runHardWrappingTests();
 		doTest2("def", "def", "defde", new String[] { "def", SAMELINE, "def", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 	}
 
+	@Test
+	@SuppressWarnings("static-method")
+	public void testSpi() {
+		ServiceLoader<BreakIteratorProvider> serviceLoader = ServiceLoader.load(BreakIteratorProvider.class);
+		BreakIteratorProvider service = serviceLoader.findFirst().orElse(null);
+
+		assertNotNull(service);
+		assertTrue(service instanceof BreakIteratorProviderMock);
+	}
+
+	public static class BreakIteratorProviderMock extends BreakIteratorProvider {
+		@Override
+		public BreakIterator getWordInstance(Locale locale) {
+			return BreakIterator.getWordInstance(locale);
+		}
+
+		@Override
+		public BreakIterator getLineInstance(Locale locale) {
+			return BreakIterator.getLineInstance(locale);
+		}
+
+		@Override
+		public BreakIterator getCharacterInstance(Locale locale) {
+			return BreakIterator.getCharacterInstance(locale);
+		}
+
+		@Override
+		public BreakIterator getSentenceInstance(Locale locale) {
+			return BreakIterator.getSentenceInstance(locale);
+		}
+
+		@Override
+		public Locale[] getAvailableLocales() {
+			return BreakIterator.getAvailableLocales();
+		}
+	}
 }

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Export-Package: org.eclipse.draw2d,
  org.eclipse.draw2d.text,
  org.eclipse.draw2d.widgets,
  org.eclipse.draw2d.zoom
-Import-Package: com.ibm.icu.text
 Require-Bundle: org.eclipse.swt;bundle-version="[3.4.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProcessor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,11 +14,12 @@ package org.eclipse.draw2d.text;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ServiceLoader;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.TextLayout;
 
-import com.ibm.icu.text.Bidi;
+import org.eclipse.draw2d.text.BidiProvider.DefaultBidiProvider;
 
 /**
  * A helper class for a BlockFlow that does Bidi evaluation of all the text in
@@ -53,6 +54,9 @@ public final class BidiProcessor {
 	 * A singleton instance.
 	 */
 	public static final BidiProcessor INSTANCE = new BidiProcessor();
+	private static final BidiProvider BIDI = ServiceLoader.load(BidiProvider.class) //
+			.findFirst() //
+			.orElseGet(DefaultBidiProvider::new);
 
 	private StringBuffer bidiText;
 	private List list = new ArrayList();
@@ -199,7 +203,7 @@ public final class BidiProcessor {
 			char[] chars = new char[bidiText.length()];
 			bidiText.getChars(0, bidiText.length(), chars, 0);
 
-			if (orientation != SWT.RIGHT_TO_LEFT && !Bidi.requiresBidi(chars, 0, chars.length - 1)) {
+			if (orientation != SWT.RIGHT_TO_LEFT && !BIDI.requiresBidi(chars, 0, chars.length - 1)) {
 				return;
 			}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProvider.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProvider.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.text;
+
+import java.text.Bidi;
+
+/**
+ * <p>
+ * An abstract class for service providers that provide concrete implementations
+ * of the {@link java.text.Bidi Bidi} class.
+ * </p>
+ *
+ * Example:
+ *
+ * <pre>
+ * import com.ibm.icu.text.Bidi;
+ *
+ * public class CustomBidiProvider implements BidiProvider {
+ * 	&#64;Override
+ * 	public boolean requiresBidi(char[] text, int start, int limit) {
+ * 		return Bidi.requiresBidi(text, start, limit);
+ * 	}
+ * }
+ * </pre>
+ *
+ * @since 3.15
+ */
+public interface BidiProvider {
+
+	/**
+	 * Return {@code true} if the specified text requires bidi analysis. If this
+	 * returns {@code false}, the text will display left-to-right. Clients can then
+	 * avoid constructing a Bidi object. Text in the Arabic Presentation Forms area
+	 * of Unicode is presumed to already be shaped and ordered for display, and so
+	 * will not cause this function to return {@code true}.
+	 *
+	 * @param text  the text containing the characters to test
+	 * @param start the start of the range of characters to test
+	 * @param limit the limit of the range of characters to test
+	 * @return true if the range of characters requires bidi analysis
+	 * @see Bidi#requiresBidi
+	 */
+	boolean requiresBidi(char[] text, int start, int limit);
+
+	/**
+	 * Default implementation of {@link BidiProvider}, backed by {@link Bidi}.
+	 *
+	 * @since 3.15
+	 */
+	static final class DefaultBidiProvider implements BidiProvider {
+		@Override
+		public boolean requiresBidi(char[] text, int start, int limit) {
+			return Bidi.requiresBidi(text, start, limit);
+		}
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,11 @@
  *******************************************************************************/
 package org.eclipse.draw2d.text;
 
+import java.text.BreakIterator;
+import java.text.spi.BreakIteratorProvider;
+import java.util.Locale;
+import java.util.ServiceLoader;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Rectangle;
@@ -20,8 +25,6 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.TextUtilities;
-
-import com.ibm.icu.text.BreakIterator;
 
 /**
  * Utility class for FlowFigures.
@@ -40,10 +43,25 @@ public class FlowUtilities {
 	 */
 	public static FlowUtilities INSTANCE = new FlowUtilities();
 
-	private static final BreakIterator INTERNAL_LINE_BREAK = BreakIterator.getLineInstance();
+	private static final BreakIterator INTERNAL_LINE_BREAK = getLineInstance();
 	private static TextLayout layout;
 
-	static final BreakIterator LINE_BREAK = BreakIterator.getLineInstance();
+	static final BreakIterator LINE_BREAK = getLineInstance();
+
+	/**
+	 * Creates a new {@link BreakIterator} instance for {@code line breaks} using
+	 * the {@link BreakIteratorProvider}. If multiple providers are registered, the
+	 * first available one is selected. If no providers are registered,
+	 * {@link BreakIterator#getLineInstance()} is called instead.
+	 *
+	 * @return A break iterator for line breaks
+	 */
+	private static BreakIterator getLineInstance() {
+		return ServiceLoader.load(BreakIteratorProvider.class) //
+				.findFirst() //
+				.map(provider -> provider.getLineInstance(Locale.getDefault())) //
+				.orElseGet(BreakIterator::getLineInstance);
+	}
 
 	static boolean canBreakAfter(char c) {
 		boolean result = Character.isWhitespace(c) || c == '-';

--- a/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples.text/META-INF/MANIFEST.MF
@@ -2,10 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef.examples.text; singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.15.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Import-Package: com.ibm.icu.text
 Export-Package: org.eclipse.gef.examples.text,
  org.eclipse.gef.examples.text.actions,
  org.eclipse.gef.examples.text.edit,

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/edit/TextFlowPart.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/edit/TextFlowPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@
 package org.eclipse.gef.examples.text.edit;
 
 import java.beans.PropertyChangeEvent;
+import java.text.BreakIterator;
 
 import org.eclipse.swt.graphics.Font;
 
@@ -31,8 +32,6 @@ import org.eclipse.gef.examples.text.model.Style;
 import org.eclipse.gef.examples.text.model.TextRun;
 import org.eclipse.gef.examples.text.requests.CaretRequest;
 import org.eclipse.gef.examples.text.requests.SearchResult;
-
-import com.ibm.icu.text.BreakIterator;
 
 /**
  * @since 3.1


### PR DESCRIPTION
With this change, the FlowUtilities class uses the BreakIteratorProvider
to create its BreakIterator instances. This way, downstream project can
contribute their own implementations, if they don't want to use the
native Java implementation.

Similarly, a BidiProvider class is created, to support a custom Bidi
implementation in the BidiProcessor class.

Resolves #289