### PR TITLE
 Specify different group id for features to avoid collisions with bundles 

### DIFF
--- a/org.eclipse.draw2d-feature/build.properties
+++ b/org.eclipse.draw2d-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2009 IBM Corporation and others.
+# Copyright (c) 2007, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -12,3 +12,4 @@
 ###############################################################################
 bin.includes = feature.xml,\
                feature.properties
+pom.model.groupId = org.eclipse.gef.feature

--- a/org.eclipse.draw2d.sdk-feature/build.properties
+++ b/org.eclipse.draw2d.sdk-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2009 IBM Corporation and others.
+# Copyright (c) 2007, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -12,4 +12,4 @@
 ###############################################################################
 bin.includes = feature.properties,\
                feature.xml
-               
+pom.model.groupId = org.eclipse.gef.feature

--- a/org.eclipse.gef-feature/build.properties
+++ b/org.eclipse.gef-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2009 IBM Corporation and others.
+# Copyright (c) 2007, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -12,3 +12,4 @@
 ###############################################################################
 bin.includes = feature.xml,\
                feature.properties
+pom.model.groupId = org.eclipse.gef.feature

--- a/org.eclipse.gef.examples-feature/build.properties
+++ b/org.eclipse.gef.examples-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2003, 2009 IBM Corporation and others.
+# Copyright (c) 2003, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -12,3 +12,4 @@
 ###############################################################################
 bin.includes =	feature.xml,\
 				feature.properties
+pom.model.groupId = org.eclipse.gef.feature

--- a/org.eclipse.gef.sdk-feature/build.properties
+++ b/org.eclipse.gef.sdk-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2009 IBM Corporation and others.
+# Copyright (c) 2007, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -12,3 +12,4 @@
 ###############################################################################
 bin.includes = feature.properties,\
                feature.xml
+pom.model.groupId = org.eclipse.gef.feature

--- a/org.eclipse.zest-feature/build.properties
+++ b/org.eclipse.zest-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2009 IBM Corporation and others.
+# Copyright (c) 2007, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -12,3 +12,4 @@
 ###############################################################################
 bin.includes = feature.xml,\
                feature.properties
+pom.model.groupId = org.eclipse.gef.feature

--- a/org.eclipse.zest.sdk-feature/build.properties
+++ b/org.eclipse.zest.sdk-feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2007, 2009 IBM Corporation and others.
+# Copyright (c) 2007, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the 
 # terms of the Eclipse Public License 2.0 which is available at
@@ -12,4 +12,4 @@
 ###############################################################################
 bin.includes = feature.properties,\
                feature.xml
-               
+pom.model.groupId = org.eclipse.gef.feature


### PR DESCRIPTION
Both the GEF feature and the GEF bundle have the artifact id "org.eclipse.gef".
If both artifact have the same group id, they are considered to be the "same" artifact, from a Maven perspective.

Overwrite the group id for features to be "org.eclipse.gef.features", to make sure the generated Maven coordinates are distinct.

See #290