### PR TITLE
Fix GEF.setup .project creation to happen after git clone task

### DIFF
--- a/setup/GEF.setup
+++ b/setup/GEF.setup
@@ -108,6 +108,7 @@
   </setupTask>
   <setupTask
       xsi:type="setup:ResourceCreationTask"
+      excludedTriggers="BOOTSTRAP"
       targetURL="${git.clone.gef.classic.location|uri}/.project"
       encoding="UTF-8">
     <content>


### PR DESCRIPTION
https://github.com/eclipse/gef-classic/issues/308