### PR TITLE
Update links to p2 repositories in ReadMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The code base of the GEF components implemented in JavaFX is located in the [ecl
 
 Update Sites (p2 repositories) are available at:
 
- - Latest release of GEF Classic: [https://download.eclipse.org/tools/gef/classic/releases/latest](https://download.eclipse.org/tools/gef/classic/releases/latest) 
- - Latest version build from master: [https://download.eclipse.org/tools/gef/classic/latest](https://download.eclipse.org/tools/gef/classic/latest)
+ - Latest release of GEF Classic: [https://download.eclipse.org/tools/gef/classic/release/latest]( https://download.eclipse.org/tools/gef/classic/release/latest) 
+ - Latest version build from master: [https://download.eclipse.org/tools/gef/classic/nightly/latest](https://download.eclipse.org/tools/gef/classic/nightly/latest)
 
 Other update sites are:
 
-- 3.14 release: [https://download.eclipse.org/tools/gef/classic/releases/3.14.0 ](https://download.eclipse.org/tools/gef/classic/releases/3.14.0)
+- 3.x.y release: `https://download.eclipse.org/tools/gef/classic/release/3.x.y`
 
 ## Getting started with the framework components ([adopters](https://www.eclipse.org/projects/dev_process/#2_3_3_Adopters))
 In order to develop graphical applications with GEF Classic, you should first set up a proper development environment. The following sections shortly lay out how to set up an Eclipse IDE for this purpose. They conclude with running our deployed and undeployed examples to confirm everything is set up properly. 


### PR DESCRIPTION
I've generalized the URL to a specific release, so that we don't have to update the ReadMe for every release.

Primarily because we've forgotten about it since 3.14 :P