### PR TITLE
Removed usage of deprecated rectangle functions

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -646,7 +646,7 @@ public class Figure implements IFigure {
 	@Override
 	public Rectangle getClientArea(Rectangle rect) {
 		rect.setBounds(getBounds());
-		rect.crop(getInsets());
+		rect.shrink(getInsets());
 		if (useLocalCoordinates()) {
 			rect.setLocation(0, 0);
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
@@ -397,7 +397,7 @@ public class FigureCanvas extends Canvas {
 		}
 		int dx = -hOffset + hOffsetOld;
 
-		Rectangle clientArea = getViewport().getBounds().getCropped(getViewport().getInsets());
+		Rectangle clientArea = getViewport().getBounds().getShrinked(getViewport().getInsets());
 		Rectangle blit = clientArea.getResized(-Math.abs(dx), 0);
 		Rectangle expose = clientArea.getCopy();
 		Point dest = clientArea.getTopLeft();
@@ -449,7 +449,7 @@ public class FigureCanvas extends Canvas {
 		}
 		int dy = -vOffset + vOffsetOld;
 
-		Rectangle clientArea = getViewport().getBounds().getCropped(getViewport().getInsets());
+		Rectangle clientArea = getViewport().getBounds().getShrinked(getViewport().getInsets());
 		Rectangle blit = clientArea.getResized(0, -Math.abs(dy));
 		Rectangle expose = clientArea.getCopy();
 		Point dest = clientArea.getTopLeft();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintOperation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintOperation.java
@@ -117,8 +117,8 @@ public abstract class PrintOperation {
 		Insets userPreferred = new Insets((printMargin.top * printerDPI.x) / 72, (printMargin.left * printerDPI.x) / 72,
 				(printMargin.bottom * printerDPI.x) / 72, (printMargin.right * printerDPI.x) / 72);
 		Rectangle paperBounds = new Rectangle(printer.getBounds());
-		Rectangle printRegion = paperBounds.getCropped(notAvailable);
-		printRegion.intersect(paperBounds.getCropped(userPreferred));
+		Rectangle printRegion = paperBounds.getShrinked(notAvailable);
+		printRegion.intersect(paperBounds.getShrinked(userPreferred));
 		printRegion.translate(trim.x, trim.y);
 		return printRegion;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollBarLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollBarLayout.java
@@ -164,10 +164,8 @@ public class ScrollBarLayout extends AbstractLayout {
 			down.setBounds(transposer.t(r));
 		}
 
-		Rectangle trackBounds = bounds.getCropped(
+		return bounds.getShrinked(
 				new Insets((up == null) ? 0 : buttonSize.height, 0, (down == null) ? 0 : buttonSize.height, 0));
-
-		return trackBounds;
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPaneSolver.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPaneSolver.java
@@ -115,7 +115,7 @@ public class ScrollPaneSolver {
 		if (!result.showH) {
 			result.insets.bottom = 0;
 		}
-		result.viewportArea = clientArea.getCropped(result.insets);
+		result.viewportArea = clientArea.getShrinked(result.insets);
 		viewport.setBounds(result.viewportArea);
 		return result;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToggleButton.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToggleButton.java
@@ -84,7 +84,7 @@ public class ToggleButton extends Toggle {
 	protected void fillCheckeredRectangle(Graphics graphics) {
 		graphics.setBackgroundColor(ColorConstants.button);
 		graphics.setForegroundColor(ColorConstants.buttonLightest);
-		Rectangle rect = getClientArea(Rectangle.SINGLETON).crop(new Insets(1, 1, 0, 0));
+		Rectangle rect = getClientArea(Rectangle.SINGLETON).shrink(new Insets(1, 1, 0, 0));
 		graphics.fillRectangle(rect.x, rect.y, rect.width, rect.height);
 
 		graphics.clipRect(rect);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Triangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Triangle.java
@@ -105,46 +105,45 @@ public final class Triangle extends Shape implements Orientable {
 		super.validate();
 		Rectangle r = new Rectangle();
 		r.setBounds(getBounds());
-		r.crop(getInsets());
+		r.shrink(getInsets());
 		r.resize(-1, -1);
 		int size;
-		switch (direction & (NORTH | SOUTH)) {
-		case 0: // East or west.
-			size = Math.min(r.height / 2, r.width);
-			r.x += (r.width - size) / 2;
-			break;
-		default: // North or south
+		if ((direction & (NORTH | SOUTH)) != 0) {
+			// North or south
 			size = Math.min(r.height, r.width / 2);
 			r.y += (r.height - size) / 2;
-			break;
+		} else {
+			// East or west.
+			size = Math.min(r.height / 2, r.width);
+			r.x += (r.width - size) / 2;
 		}
 
 		size = Math.max(size, 1); // Size cannot be negative
 
 		Point head, p2, p3;
 
-		switch (direction) {
-		case NORTH:
+		p3 = switch (direction) {
+		case NORTH -> {
 			head = new Point(r.x + r.width / 2, r.y);
 			p2 = new Point(head.x - size, head.y + size);
-			p3 = new Point(head.x + size, head.y + size);
-			break;
-		case SOUTH:
+			yield new Point(head.x + size, head.y + size);
+		}
+		case SOUTH -> {
 			head = new Point(r.x + r.width / 2, r.y + size);
 			p2 = new Point(head.x - size, head.y - size);
-			p3 = new Point(head.x + size, head.y - size);
-			break;
-		case WEST:
+			yield new Point(head.x + size, head.y - size);
+		}
+		case WEST -> {
 			head = new Point(r.x, r.y + r.height / 2);
 			p2 = new Point(head.x + size, head.y - size);
-			p3 = new Point(head.x + size, head.y + size);
-			break;
-		default:
+			yield new Point(head.x + size, head.y + size);
+		}
+		default -> {
 			head = new Point(r.x + size, r.y + r.height / 2);
 			p2 = new Point(head.x - size, head.y - size);
-			p3 = new Point(head.x - size, head.y + size);
-
+			yield new Point(head.x - size, head.y + size);
 		}
+		};
 		triangle.removeAllPoints();
 		triangle.addPoint(head);
 		triangle.addPoint(p2);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlow.java
@@ -89,9 +89,8 @@ public class BlockFlow extends FlowFigure {
 
 	int getBottomMargin() {
 		int margin = 0;
-		if (getBorder() instanceof FlowBorder) {
-			FlowBorder border = (FlowBorder) getBorder();
-			return border.getBottomMargin();
+		if (getBorder() instanceof FlowBorder flowBorder) {
+			return flowBorder.getBottomMargin();
 		}
 		List<? extends IFigure> children = getChildren();
 		int childIndex = children.size() - 1;
@@ -124,8 +123,8 @@ public class BlockFlow extends FlowFigure {
 	}
 
 	int getLeftMargin() {
-		if (getBorder() instanceof FlowBorder) {
-			return ((FlowBorder) getBorder()).getLeftMargin();
+		if (getBorder() instanceof FlowBorder flowBorder) {
+			return flowBorder.getLeftMargin();
 		}
 		return 0;
 	}
@@ -177,17 +176,16 @@ public class BlockFlow extends FlowFigure {
 	}
 
 	int getRightMargin() {
-		if (getBorder() instanceof FlowBorder) {
-			return ((FlowBorder) getBorder()).getRightMargin();
+		if (getBorder() instanceof FlowBorder flowBorder) {
+			return flowBorder.getRightMargin();
 		}
 		return 0;
 	}
 
 	int getTopMargin() {
 		int margin = 0;
-		if (getBorder() instanceof FlowBorder) {
-			FlowBorder border = (FlowBorder) getBorder();
-			return border.getTopMargin();
+		if (getBorder() instanceof FlowBorder flowBorder) {
+			return flowBorder.getTopMargin();
 		}
 		List<? extends IFigure> children = getChildren();
 		if (!children.isEmpty() && children.get(0) instanceof BlockFlow) {
@@ -201,10 +199,10 @@ public class BlockFlow extends FlowFigure {
 	 */
 	@Override
 	public void paintBorder(Graphics graphics) {
-		if (getBorder() instanceof FlowBorder) {
+		if (getBorder() instanceof FlowBorder flowBorder) {
 			Rectangle where = getBlockBox().toRectangle();
-			where.crop(new Insets(getTopMargin(), getLeftMargin(), getBottomMargin(), getRightMargin()));
-			((FlowBorder) getBorder()).paint(this, graphics, where, SWT.LEAD | SWT.TRAIL);
+			where.shrink(new Insets(getTopMargin(), getLeftMargin(), getBottomMargin(), getRightMargin()));
+			flowBorder.paint(this, graphics, where, SWT.LEAD | SWT.TRAIL);
 		} else {
 			super.paintBorder(graphics);
 		}
@@ -222,7 +220,7 @@ public class BlockFlow extends FlowFigure {
 	@Override
 	public void postValidate() {
 		Rectangle newBounds = getBlockBox().toRectangle();
-		newBounds.crop(new Insets(getTopMargin(), getLeftMargin(), getBottomMargin(), getRightMargin()));
+		newBounds.shrink(new Insets(getTopMargin(), getLeftMargin(), getBottomMargin(), getRightMargin()));
 		setBounds(newBounds);
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportAutoexposeHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ViewportAutoexposeHelper.java
@@ -43,7 +43,7 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 	private long lastStepTime = 0;
 
 	/** The insets for this helper. */
-	private Insets threshold;
+	private final Insets threshold;
 
 	/**
 	 * Constructs a new helper on the given GraphicalEditPart. The editpart must
@@ -63,8 +63,8 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 	 * its <i>figure</i> inclusively.
 	 *
 	 * @param owner     the GraphicalEditPart that owns the Viewport
-	 * @param threshold the Expose Threshold to use when determing whether or not a
-	 *                  scroll should occur.
+	 * @param threshold the Expose Threshold to use when determining whether or not
+	 *                  a scroll should occur.
 	 */
 	public ViewportAutoexposeHelper(GraphicalEditPart owner, Insets threshold) {
 		super(owner);
@@ -85,7 +85,7 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 		port.getClientArea(rect);
 		port.translateToParent(rect);
 		port.translateToAbsolute(rect);
-		return rect.contains(where) && !rect.crop(threshold).contains(where);
+		return rect.contains(where) && !rect.shrink(threshold).contains(where);
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 		port.getClientArea(rect);
 		port.translateToParent(rect);
 		port.translateToAbsolute(rect);
-		if (!rect.contains(where) || rect.crop(threshold).contains(where)) {
+		if (!rect.contains(where) || rect.shrink(threshold).contains(where)) {
 			return false;
 		}
 
@@ -129,7 +129,7 @@ public class ViewportAutoexposeHelper extends ViewportHelper implements Autoexpo
 			return true;
 		}
 
-		rect.crop(threshold);
+		rect.shrink(threshold);
 
 		int region = rect.getPosition(where);
 		Point loc = port.getViewLocation();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteScrollBar.java
@@ -82,7 +82,6 @@ public final class PaletteScrollBar extends ScrollBar {
 	protected Label upLabel;
 
 	public PaletteScrollBar() {
-		super();
 	}
 
 	@Override
@@ -178,7 +177,7 @@ public final class PaletteScrollBar extends ScrollBar {
 				Rectangle r = new Rectangle(
 						bounds.getBottom().getTranslated(-(buttonSize.width / 2), -buttonSize.height), buttonSize);
 				getButtonDown().setBounds(transposer.t(r));
-				Rectangle trackBounds = bounds.getCropped(new Insets(buttonSize.height, 0, buttonSize.height, 0));
+				Rectangle trackBounds = bounds.getShrinked(new Insets(buttonSize.height, 0, buttonSize.height, 0));
 				RangeModel model = scrollBar.getRangeModel();
 				getButtonUp().setVisible(model.getValue() != model.getMinimum());
 				getButtonDown().setVisible(model.getValue() != model.getMaximum() - model.getExtent());


### PR DESCRIPTION
Rectangle's crop() and getCropped() methods are deprecated and shrinked and getShrinked should be used instead. All usages have been updated.

Addresses #21 