### PR TITLE
Update documentation regarding ICU removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Draw2d
  - Removal of dependency to ICU. If required, downstream projects may contribute
    their own BreakIterator and Bidi implementations using the
-   `BreakIteratorProvider` and `BidiProvider`. See the documentation for
-   examples.
-
+   `BreakIteratorProvider` and `BidiProvider`.
+ - The selection, stack and property `Actions` of the `GraphicalEditor` can only
+   hold Strings and no longer support objects of type IAction.
+ 
 # GEF Classic 3.15.0 (Eclipse 2022-12)
 
 ## General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,25 @@
+# GEF Classic 3.19.0 (Eclipse 2024-03)
+
+## Draw2d
+ - Removal of dependency to ICU. If required, downstream projects may contribute
+   their own BreakIterator and Bidi implementations using the
+   `BreakIteratorProvider` and `BidiProvider`. See the documentation for
+   examples.
+
 # GEF Classic 3.15.0 (Eclipse 2022-12)
 
-##General
+## General
  - Code clean-up and reduced deprecated code usage
- - Rreduced dependencies to com.ibm.icu.text package
+ - Reduced dependencies to com.ibm.icu.text package
 
-##Draw2d
+## Draw2d
  - Common ZoomManager code from GEF and ZEST was moved to Draw2d to reduce code duplication
  - Introduction of ZoomScrollPolicies allowing to configure how the ZoomManager will scroll after zooming
  - New MouseLocationZoomScrollPolicy which maintains the content under the mouse during zooming
  - Fixed thumbnailing for Mac OS
  - Fixed unwanted drawing artifacts that could occur during drag operations
 
-##GEF
+## GEF
  - Clients can now provide their own marquee selection figure 
  - Fixed resizing from left or top: When reaching minimum size it moved the element
  

--- a/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.doc.isv; singleton:=true
-Bundle-Version: 3.12.400.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Eclipse-LazyStart: true

--- a/org.eclipse.draw2d.doc.isv/guide-src/extensions.adoc
+++ b/org.eclipse.draw2d.doc.isv/guide-src/extensions.adoc
@@ -1,0 +1,91 @@
+= User-specific Extensions
+
+== BreakIterator
+
+The link:../reference/api/org/eclipse/draw2d/text/FlowUtilities.html[*`FlowUtilities`*]
+class uses the native _BreakIterator_ class to determine the boundaries between
+words. Clients may contribute their own implementation by contributing a custom
+_BreakIteratorProvider_ via SPI. If multiple services are contributed, the first
+one is chosen.
+
+=== Example: How to supply a custom BreakIterator
+
+____
+Users may want to use the break rules from e.g. ICU instead of the JDK rules.
+Because those classes don't share a common interface, the user has to extend
+the abstract _BreakIterator_ class and call the corresponding ICU method for
+abstract method that is overwritten.
+____
+
+=== Solution:
+
+____
+SPI uses the context-classloader to instantiate the custom implementation. In
+order to use this mechanism in OSGi with minimal complications, it is
+recommended to create this class within a Draw2D fragment. Also note that this
+class needs to be registered via _META-INF/services/java.text.spi.BreakIteratorProvider_
+
+[source,java]
+----
+public class CustomBreakIteratorProvider extends BreakIteratorProvider {
+	@Override
+	public BreakIterator getWordInstance(Locale locale) {
+		...
+	}
+
+	@Override
+	public BreakIterator getLineInstance(Locale locale) {
+		...
+	}
+
+	@Override
+	public BreakIterator getCharacterInstance(Locale locale) {
+		...
+	}
+
+	@Override
+	public BreakIterator getSentenceInstance(Locale locale) {
+		...
+	}
+
+	@Override
+	public Locale[] getAvailableLocales() {
+		...
+	}
+}
+----
+____
+
+== Bidi
+
+Similarly to the _BreakIterator_, the link:../reference/api/org/eclipse/draw2d/text/BidiProcessor.html[BidiProcessor]
+class uses the native _Bidi_ class to determine whether a text requires a Bidi
+analysis. Clients may contribute their own implementation by contributing a
+custom link:../reference/api/org/eclipse/draw2d/text/BidiProvider.html[BidiProvider]
+via SPI. If multiple services are contributed, the first one is chosen.
+
+=== Example: Custom BidiProvider Service
+
+____
+The Bidi algorithm provided by the JDK might not be sufficient to determine,
+whether a given text requires further analysis.
+____
+
+=== Solution:
+
+____
+SPI uses the context-classloader to instantiate the custom implementation. In
+order to use this mechanism in OSGi with minimal complications, it is
+recommended to create this class within a Draw2D fragment. Also note that this
+class needs to be registered via _META-INF/services/org.eclipse.draw2d.text.BidiProvider_.
+
+[source,java]
+----
+public class CustomBidiProvider implements BidiProvider {
+	@Override
+	public boolean requiresBidi(char[] text, int start, int limit) {
+		...
+	}
+}
+----
+____

--- a/org.eclipse.draw2d.doc.isv/guide-src/guide.adoc
+++ b/org.eclipse.draw2d.doc.isv/guide-src/guide.adoc
@@ -13,3 +13,5 @@ coordinates, modifying the space occupied by a figure
 decorations, and routing
 * link:coordinates.html[Coordinate Systems] - absolute and relative
 coordinates, working with absolute coordinates
+* link:extensions.html[User-specific Extensions] - customize runtime
+behavior

--- a/org.eclipse.draw2d.doc.isv/guide-src/guide.adoc
+++ b/org.eclipse.draw2d.doc.isv/guide-src/guide.adoc
@@ -15,3 +15,5 @@ decorations, and routing
 coordinates, working with absolute coordinates
 * link:extensions.html[User-specific Extensions] - customize runtime
 behavior
+* link:migration-guide.html[Plug-in Migration Guide] - changes between
+individual releases

--- a/org.eclipse.draw2d.doc.isv/guide-src/migration-guide.adoc
+++ b/org.eclipse.draw2d.doc.isv/guide-src/migration-guide.adoc
@@ -1,0 +1,15 @@
+= Plug-in Migration Guide
+
+== Contents
+
+* link:#3.15[Migrating from 3.14 to 3.15]
+
+=== [#3.15]#Migrating from 3.14 to 3.15#
+
+Draw2D has dropped ICU as the default Java implementation for *`Bidi`* and
+*`BreakIterator`*. If clients require a different behavior, they may contribute
+their own implementation as described in link:extensions.html[User-specific extensions].
+
+The selection, stack and property `Actions` of the `GraphicalEditor` can only
+hold Strings and no longer support objects of type IAction. Clients can convert
+their actions by explicitly calling *`IAction.getId()`*.

--- a/org.eclipse.draw2d.doc.isv/pom.xml
+++ b/org.eclipse.draw2d.doc.isv/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.doc.isv</artifactId>
-	<version>3.12.400-SNAPSHOT</version>
+	<version>3.13.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>[bundle] GEF Classic Draw2d Developer Documentation</name>
 	<build>

--- a/org.eclipse.draw2d.doc.isv/topics_Guide.xml
+++ b/org.eclipse.draw2d.doc.isv/topics_Guide.xml
@@ -12,5 +12,6 @@
 		<topic label="Hit Testing" href="guide/hittest.html"/>
 		<topic label="Connections and Routing" href="guide/connections.html"/>
 		<topic label="Coordinate Systems" href="guide/coordinates.html"/>
+		<topic label="Custom Extensions" href="guide/extensions.html" />
 	</topic>
 </toc>

--- a/org.eclipse.draw2d.doc.isv/topics_Guide.xml
+++ b/org.eclipse.draw2d.doc.isv/topics_Guide.xml
@@ -12,6 +12,8 @@
 		<topic label="Hit Testing" href="guide/hittest.html"/>
 		<topic label="Connections and Routing" href="guide/connections.html"/>
 		<topic label="Coordinate Systems" href="guide/coordinates.html"/>
-		<topic label="Custom Extensions" href="guide/extensions.html" />
+		<topic label="User-specific Extensions" href="guide/extensions.html" />
+  <topic href="guide/migration-guide.html" label="Plug-in Migration Guide">
+  </topic>
 	</topic>
 </toc>


### PR DESCRIPTION
We switched from the Bidi and BreakIterator implementation contributed by com.ibm.icu to the native Java implementation.

Because those implementations are not 100% compatible, we should note this in the changelog and also inform users about how they may be able to contribute their own implementation.