### PR TITLE
Remove the repository containing GEF FX from the targlet in the setup

### DIFF
--- a/setup/GEF.setup
+++ b/setup/GEF.setup
@@ -201,8 +201,6 @@
           locateNestedProjects="true"/>
       <repositoryList>
         <repository
-            url="https://download.eclipse.org/releases/${eclipse.target.platform.latest}"/>
-        <repository
             url="https://download.eclipse.org/cbi/updates/license"/>
       </repositoryList>
     </targlet>


### PR DESCRIPTION
The set of IUs between GEF FX and GEF Classic are not unique, so more care must be taken to avoid resolving the GEF FX IUs with higher version into the target platform.  Furthermore, GEF Classic does not even require an Orbit repo to resolve the target platform; purely the Platform SDK is sufficient.

https://github.com/eclipse/gef-classic/issues/352