### PR TITLE
Fix cursors double-size on Mac and Linux 11

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
@@ -70,7 +70,11 @@ public class SharedCursors extends Cursors {
 				}
 			}
 		}
-		return deviceZoom;
+		// On Mac and Linux X11 ImageData for cursors should always be created with 100% device zoom 
+		return Platform.getOS().equals(Platform.OS_MACOSX) ||
+				(Platform.getOS().equals(Platform.OS_LINUX) && "x11".equalsIgnoreCase(System.getenv("XDG_SESSION_TYPE"))) //$NON-NLS-1$ //$NON-NLS-2$
+				? 100 
+				: deviceZoom;
 	}
 
 }


### PR DESCRIPTION
See https://github.com/eclipse/gef-classic/issues/354

On Mac and Linux X11 device zoom should always be 100% when creating the ImageData for the cursor.