### PR TITLE
Make default hide delay for tooltip configurable

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
@@ -32,9 +32,11 @@ import org.eclipse.draw2d.geometry.Dimension;
  */
 public class ToolTipHelper extends PopUpHelper {
 
+	private static int defaultHideDelay = 5000;
+
 	private Timer timer;
 	private IFigure currentTipSource;
-	private int hideDelay = 5000;
+	private int hideDelay;
 
 	/**
 	 * Constructs a ToolTipHelper to be associated with Control <i>c</i>.
@@ -46,6 +48,7 @@ public class ToolTipHelper extends PopUpHelper {
 		super(c, SWT.TOOL | SWT.ON_TOP);
 		getShell().setBackground(ColorConstants.tooltipBackground);
 		getShell().setForeground(ColorConstants.tooltipForeground);
+		hideDelay = defaultHideDelay;
 	}
 
 	/*
@@ -80,6 +83,18 @@ public class ToolTipHelper extends PopUpHelper {
 	 */
 	public void setHideDelay(int hideDelay) {
 		this.hideDelay = hideDelay;
+	}
+
+	/**
+	 * Sets the default tooltip hide delay, which is the number in ms after which
+	 * the tooltip will disappear again if not overwritten using
+	 * {@link #setHideDelay(int)}.
+	 *
+	 * @param defaultHideDelay the delay in ms after which the tooltip is hidden
+	 * @since 3.15
+	 */
+	public static void setDefaultHideDelay(int defaultHideDelay) {
+		ToolTipHelper.defaultHideDelay = defaultHideDelay;
 	}
 
 	/**


### PR DESCRIPTION
The hide delay for tooltips in Draw2d is currently fixed to 5 seconds. The value can only be changed for a speific `ToolTipHelper`, which in turn is tied to a specific control. There is option to configure this delay globally.

With this change, the default value for the hide delay can globally be changed on the `ToolTipHelper` class, such that subsequent tooltip creations will use this value as default.

One could also think about more general configuration options, such as providing a system property, to make this delay configurable without a dependency to Draw2d. But since the demand for this configuration options does not seem to be high, I would expect the proposed lightweight realization to be sufficient (at least for us).