### PR TITLE
Added new Figure Container to serve as light weight drawing container

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Container.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Container.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d;
+
+/**
+ * Lightweight Container which just draws the children according to the given
+ * layout.
+ *
+ * This Container does not maintain any graphics state and delegates that to its
+ * children. This can save memory and increase drawing performance for larger
+ * graphs with deep nested figures.
+ *
+ * A Container can not have any border and does not draw any background.
+ *
+ * This class is currently in development its API may
+ * change: @noreference, @noextend and @noinstantiate
+ *
+ * @since 3.16
+ */
+public class Container extends Figure {
+
+	public Container(LayoutManager manager) {
+		setLayoutManager(manager);
+	}
+
+	@Override
+	public final void paint(Graphics graphics) {
+		getChildren().stream().filter(IFigure::isVisible).forEach(child -> child.paint(graphics));
+	}
+
+	@Override
+	public final void setLayoutManager(LayoutManager manager) {
+		super.setLayoutManager(manager);
+	}
+
+}

--- a/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/figures/SubgraphFigure.java
+++ b/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/figures/SubgraphFigure.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.flow.figures;
 
+import org.eclipse.draw2d.Container;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -30,8 +31,7 @@ public class SubgraphFigure extends Figure {
 	IFigure header;
 
 	public SubgraphFigure(IFigure header, IFigure footer) {
-		contents = new Figure();
-		contents.setLayoutManager(new DummyLayout());
+		contents = new Container(new DummyLayout());
 		add(contents);
 		add(this.header = header);
 		add(this.footer = footer);

--- a/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/parts/ActivityDiagramPart.java
+++ b/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/parts/ActivityDiagramPart.java
@@ -14,7 +14,7 @@ package org.eclipse.gef.examples.flow.parts;
 
 import java.util.Map;
 
-import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.Container;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.graph.CompoundDirectedGraph;
@@ -72,10 +72,11 @@ public class ActivityDiagramPart extends StructuredActivityPart {
 
 	@Override
 	protected IFigure createFigure() {
-		Figure f = new Figure() {
+		return new Container(new GraphLayoutManager(this)) {
 			@Override
 			public void setBounds(Rectangle rect) {
-				int x = bounds.x, y = bounds.y;
+				int x = bounds.x;
+				int y = bounds.y;
 
 				boolean resize = (rect.width != bounds.width) || (rect.height != bounds.height);
 				boolean translate = (rect.x != x) || (rect.y != y);
@@ -96,8 +97,6 @@ public class ActivityDiagramPart extends StructuredActivityPart {
 				}
 			}
 		};
-		f.setLayoutManager(new GraphLayoutManager(this));
-		return f;
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
@@ -30,6 +30,7 @@ import org.eclipse.draw2d.ButtonModel;
 import org.eclipse.draw2d.ChangeListener;
 import org.eclipse.draw2d.Clickable;
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Container;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
@@ -161,7 +162,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 	@Override
 	public IFigure createFigure() {
 
-		Figure figure = new Figure() {
+		Figure figure = new Container(new BorderLayout()) {
 			@Override
 			public Dimension getPreferredSize(int wHint, int hHint) {
 				if (PaletteStackEditPart.this.getChildren().isEmpty()) {
@@ -170,15 +171,13 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 				return super.getPreferredSize(wHint, hHint);
 			}
 		};
-		figure.setLayoutManager(new BorderLayout());
 
-		contentsFigure = new Figure();
 		StackLayout stackLayout = new StackLayout();
 		// make it so the stack layout does not allow the invisible figures to
 		// contribute
 		// to its bounds
 		stackLayout.setObserveVisibility(true);
-		contentsFigure.setLayoutManager(stackLayout);
+		contentsFigure = new Container(stackLayout);
 		figure.add(contentsFigure, BorderLayout.CENTER);
 
 		arrowFigure = new RolloverArrow();


### PR DESCRIPTION
Using pure Figure just as layout container for other figures is very heavy weight as the graphics state is saved and restored very often. For pure layout containers this would not be necessary. This new figure can help to reduce memory footprint and drawing performance for these cases.