### PR TITLE
Relax demands on PaletteContainer addAll Methods.

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteContainer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteContainer.java
@@ -94,10 +94,9 @@ public class PaletteContainer extends PaletteEntry {
 	 *
 	 * @param list a list of PaletteEntry objects to add to this PaletteContainer
 	 */
-	public void addAll(List<PaletteEntry> list) {
+	public void addAll(List<? extends PaletteEntry> list) {
 		List<PaletteEntry> oldChildren = new ArrayList<>(getChildren());
-		for (PaletteEntry element : list) {
-			PaletteEntry child = element;
+		for (PaletteEntry child : list) {
 			if (!acceptsType(child.getType())) {
 				throw new IllegalArgumentException("This container can not contain this type of child: " //$NON-NLS-1$
 						+ child.getType());

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteGroup.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteGroup.java
@@ -43,7 +43,7 @@ public class PaletteGroup extends PaletteContainer {
 	 * @param label    the label
 	 * @param children the list of PaletteEntry children
 	 */
-	public PaletteGroup(String label, List<PaletteEntry> children) {
+	public PaletteGroup(String label, List<? extends PaletteEntry> children) {
 		this(label);
 		addAll(children);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteStack.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteStack.java
@@ -93,7 +93,7 @@ public class PaletteStack extends PaletteContainer {
 	 * @see org.eclipse.gef.palette.PaletteContainer#addAll(java.util.List)
 	 */
 	@Override
-	public void addAll(List<PaletteEntry> list) {
+	public void addAll(List<? extends PaletteEntry> list) {
 		super.addAll(list);
 		checkActiveEntry();
 		updateListeners(list, true);
@@ -181,7 +181,7 @@ public class PaletteStack extends PaletteContainer {
 	 * @param add     true if the lister should be added; false if it should be
 	 *                removed
 	 */
-	private void updateListeners(Collection<PaletteEntry> entries, boolean add) {
+	private void updateListeners(Collection<? extends PaletteEntry> entries, boolean add) {
 		for (PaletteEntry child : entries) {
 			if (add) {
 				child.addPropertyChangeListener(childListener);

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteToolbar.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteToolbar.java
@@ -51,7 +51,7 @@ public class PaletteToolbar extends PaletteContainer {
 	 * @param label    the label
 	 * @param children the list of PaletteEntry children
 	 */
-	public PaletteToolbar(String label, List<PaletteEntry> children) {
+	public PaletteToolbar(String label, List<? extends PaletteEntry> children) {
 		this(label);
 		addAll(children);
 	}


### PR DESCRIPTION
In the last clean-up a non back-wardscompaptible interface change was introduced. This commit fixes that.