### PR TITLE
Use PrecisionPoint instead of Point to handle deprecation warning

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,6 +25,7 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+	FanRouterTest.class,
 	ShortestPathRoutingTest.class,
 	XYLayoutTest.class,
 	TextFlowWrapTest.class,

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FanRouterTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FanRouterTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.draw2d.Connection;
+import org.eclipse.draw2d.ConnectionAnchor;
+import org.eclipse.draw2d.FanRouter;
+import org.eclipse.draw2d.PolylineConnection;
+import org.eclipse.draw2d.XYAnchor;
+import org.eclipse.draw2d.geometry.Point;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class FanRouterTest {
+	FanRouter router;
+	Connection connection;
+	ConnectionAnchor sourceAnchor;
+	ConnectionAnchor targetAnchor;
+
+	@Before
+	public void setUp() {
+		sourceAnchor = new XYAnchor(new Point(0, 0));
+		targetAnchor = new XYAnchor(new Point(0, 50));
+
+		connection = new PolylineConnection();
+		connection.setSourceAnchor(sourceAnchor);
+		connection.setTargetAnchor(targetAnchor);
+
+		router = new FanRouter();
+	}
+
+	/**
+	 * When routing the "same" connection multiple times, no additional break point
+	 * needs to be created.
+	 */
+	@Test
+	public void testRouteSameConnection() {
+		router.route(connection);
+		assertEquals(connection.getPoints().size(), 2);
+
+		router.route(connection);
+		assertEquals(connection.getPoints().size(), 2);
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FanRouter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FanRouter.java
@@ -14,6 +14,7 @@ package org.eclipse.draw2d;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.draw2d.geometry.PrecisionPoint;
 import org.eclipse.draw2d.geometry.Ray;
 
 /**
@@ -61,17 +62,15 @@ public class FanRouter extends AutomaticRouter {
 		}
 		double length = ray.length();
 
-		double xSeparation = separation * ray.x / length;
-		double ySeparation = separation * ray.y / length;
+		double xSeparation = separation * ray.x / length * (index / 2);
+		double ySeparation = separation * ray.y / length * (index / 2);
 
 		Point bendPoint;
 
 		if (index % 2 == 0) {
-			bendPoint = new Point(midPoint.x + (int) ((index / 2.0) * -1.0 * ySeparation),
-					midPoint.y + (int) ((index / 2.0) * xSeparation));
+			bendPoint = new PrecisionPoint(midPoint.x + (-1 * ySeparation), midPoint.y + xSeparation);
 		} else {
-			bendPoint = new Point(midPoint.x + (int) ((index / 2.0) * ySeparation),
-					midPoint.y + (int) ((index / 2.0) * -1.0 * xSeparation));
+			bendPoint = new PrecisionPoint(midPoint.x + ySeparation, midPoint.y + (-1 * xSeparation));
 		}
 		if (!bendPoint.equals(midPoint)) {
 			points.insertPoint(bendPoint, 1);


### PR DESCRIPTION
This commit partially reverts fd75841fd7e0638c18827f203257e504536fb15e and uses PrecisionPoints instead of Points in the FanRouter class, to store the bend point.

Note that because the mid point is a plain point, the equality check is done using the integer coordinates.

Resolves #383