### PR TITLE
Handle implicit ClassCastException in Zest Core due to raw types

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStructuredGraphViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2011 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -37,6 +37,7 @@ import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.IContainer;
 import org.eclipse.zest.core.widgets.ZestStyles;
 import org.eclipse.zest.layouts.LayoutAlgorithm;
+import org.eclipse.zest.layouts.LayoutRelationship;
 
 import org.eclipse.draw2d.IFigure;
 
@@ -442,9 +443,9 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * util.List, boolean)
 	 */
 	@Override
-	protected void setSelectionToWidget(List l, boolean reveal) {
+	protected void setSelectionToWidget(@SuppressWarnings("rawtypes") List l, boolean reveal) {
 		Graph control = (Graph) getControl();
-		List selection = new LinkedList();
+		List<GraphItem> selection = new LinkedList<>();
 		for (Object obj : l) {
 			GraphNode node = (GraphNode) nodesMap.get(obj);
 			GraphConnection conn = (GraphConnection) connectionsMap.get(obj);
@@ -455,7 +456,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 				selection.add(conn);
 			}
 		}
-		control.setSelection((GraphNode[]) selection.toArray(new GraphNode[selection.size()]));
+		control.setSelection(selection.toArray(new GraphItem[selection.size()]));
 	}
 
 	/**
@@ -702,8 +703,14 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 			// remove the node from the layout algorithm and all the connections
 			if (getLayoutAlgorithm() != null) {
 				getLayoutAlgorithm().removeEntity(node.getLayoutEntity());
-				getLayoutAlgorithm().removeRelationships(node.getSourceConnections());
-				getLayoutAlgorithm().removeRelationships(node.getTargetConnections());
+				List<LayoutRelationship> relationships = new ArrayList<>();
+				for (GraphConnection connection : node.getSourceConnections()) {
+					relationships.add(connection.getLayoutRelationship());
+				}
+				for (GraphConnection connection : node.getTargetConnections()) {
+					relationships.add(connection.getLayoutRelationship());
+				}
+				getLayoutAlgorithm().removeRelationships(relationships);
 			}
 			// remove the node and it's connections from the model
 			node.dispose();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2023, CHISEL Group, University of Victoria, Victoria, BC, Canada.
+ * Copyright 2005, 2024, CHISEL Group, University of Victoria, Victoria, BC, Canada.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -55,8 +55,8 @@ public class GraphNode extends GraphItem {
 
 	private int nodeStyle;
 
-	private List /* IGraphModelConnection */ sourceConnections;
-	private List /* IGraphModelConnection */ targetConnections;
+	private List<GraphConnection> sourceConnections;
+	private List<GraphConnection> targetConnections;
 
 	private Color foreColor;
 	private Color backColor;
@@ -151,8 +151,8 @@ public class GraphNode extends GraphItem {
 	protected void initModel(IContainer parent, String text, Image image) {
 		this.nodeStyle |= parent.getGraph().getNodeStyle();
 		this.parent = parent;
-		this.sourceConnections = new ArrayList();
-		this.targetConnections = new ArrayList();
+		this.sourceConnections = new ArrayList<>();
+		this.targetConnections = new ArrayList<>();
 		this.foreColor = parent.getGraph().DARK_BLUE;
 		this.backColor = parent.getGraph().LIGHT_BLUE;
 		this.highlightColor = parent.getGraph().HIGHLIGHT_COLOR;
@@ -204,7 +204,7 @@ public class GraphNode extends GraphItem {
 		super.dispose();
 		this.isDisposed = true;
 		while (!getSourceConnections().isEmpty()) {
-			GraphConnection connection = (GraphConnection) getSourceConnections().get(0);
+			GraphConnection connection = getSourceConnections().get(0);
 			if (!connection.isDisposed()) {
 				connection.dispose();
 			} else {
@@ -212,7 +212,7 @@ public class GraphNode extends GraphItem {
 			}
 		}
 		while (!getTargetConnections().isEmpty()) {
-			GraphConnection connection = (GraphConnection) getTargetConnections().get(0);
+			GraphConnection connection = getTargetConnections().get(0);
 			if (!connection.isDisposed()) {
 				connection.dispose();
 			} else {
@@ -247,8 +247,8 @@ public class GraphNode extends GraphItem {
 	 *
 	 * @return List a new list of GraphModelConnect objects
 	 */
-	public List getSourceConnections() {
-		return new ArrayList(sourceConnections);
+	public List<? extends GraphConnection> getSourceConnections() {
+		return new ArrayList<>(sourceConnections);
 	}
 
 	/**
@@ -256,8 +256,8 @@ public class GraphNode extends GraphItem {
 	 *
 	 * @return List a new list of GraphModelConnect objects
 	 */
-	public List getTargetConnections() {
-		return new ArrayList(targetConnections);
+	public List<? extends GraphConnection> getTargetConnections() {
+		return new ArrayList<>(targetConnections);
 	}
 
 	/**
@@ -672,15 +672,11 @@ public class GraphNode extends GraphItem {
 		// graph.addRemoveFigure(this, visible);
 		this.visible = visible;
 		this.getNodeFigure().setVisible(visible);
-		List sConnections = (this).getSourceConnections();
-		List tConnections = (this).getTargetConnections();
-		for (Object sConnection : sConnections) {
-			GraphConnection connection = (GraphConnection) sConnection;
+		for (GraphConnection connection : getSourceConnections()) {
 			connection.setVisible(visible);
 		}
 
-		for (Object tConnection : tConnections) {
-			GraphConnection connection = (GraphConnection) tConnection;
+		for (GraphConnection connection : getTargetConnections()) {
 			connection.setVisible(visible);
 		}
 	}


### PR DESCRIPTION
The selection of an abstract viewer can either be of type GraphNode or GraphConnection. However, this list of items is explicitly casted to an array of GraphNodes. Use the common base class GraphItem instead.

Furthermore, the viewer attempts to remove the objects of type GraphConnection from the layout manager, whenever a node is removed. But the layout manager only accepts objects of type LayoutRelationship which is a member of the GraphConnection.