### PR TITLE
Cleanup Zest Core Viewer component and resolve compiler warnings

### DIFF
--- a/org.eclipse.zest.core/.settings/.api_filters
+++ b/org.eclipse.zest.core/.settings/.api_filters
@@ -31,14 +31,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="src/org/eclipse/zest/core/viewers/ZoomContributionViewItem.java" type="org.eclipse.zest.core.viewers.ZoomContributionViewItem">
-        <filter id="576725006">
-            <message_arguments>
-                <message_argument value="ZoomListener"/>
-                <message_argument value="ZoomContributionViewItem"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/zest/core/widgets/GraphContainer.java" type="org.eclipse.zest.core.widgets.GraphContainer">
         <filter id="627060751">
             <message_arguments>

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -13,12 +13,11 @@
 package org.eclipse.zest.core.viewers;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Composite;
@@ -52,7 +51,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 
 	protected Graph graph = null;
 	private IStylingGraphModelFactory modelFactory = null;
-	private List selectionChangedListeners = null;
+	private List<ISelectionChangedListener> selectionChangedListeners = null;
 	ZoomManager zoomManager = null;
 
 	/**
@@ -78,18 +77,15 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	protected void hookControl(Control control) {
 		super.hookControl(control);
 
-		selectionChangedListeners = new ArrayList();
+		selectionChangedListeners = new ArrayList<>();
 		getGraphControl().addSelectionListener(new SelectionAdapter() {
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				Iterator iterator = selectionChangedListeners.iterator();
-
 				ISelection structuredSelection = getSelection();
 				SelectionChangedEvent event = new SelectionChangedEvent(GraphViewer.this, structuredSelection);
 
-				while (iterator.hasNext()) {
-					ISelectionChangedListener listener = (ISelectionChangedListener) iterator.next();
+				for (ISelectionChangedListener listener : selectionChangedListeners) {
 					listener.selectionChanged(event);
 				}
 				firePostSelectionChanged(event);
@@ -97,7 +93,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 
 		});
 
-		control.addMouseListener(new MouseListener() {
+		control.addMouseListener(new MouseAdapter() {
 
 			@Override
 			public void mouseDoubleClick(MouseEvent e) {
@@ -105,23 +101,11 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 				fireDoubleClick(doubleClickEvent);
 			}
 
-			@Override
-			public void mouseDown(MouseEvent e) {
-
-			}
-
-			@Override
-			public void mouseUp(MouseEvent e) {
-
-			}
-
 		});
 	}
 
 	/**
 	 * Gets the styles for this structuredViewer
-	 *
-	 * @return
 	 */
 	public int getStyle() {
 		return this.graph.getStyle();
@@ -136,7 +120,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	@Override
 	public Graph getGraphControl() {
 		return super.getGraphControl();
-	};
+	}
 
 	/**
 	 * Sets the layout algorithm to use for this viewer.
@@ -198,7 +182,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	 * this method (to access internal nodes and edges), your code may not compile
 	 * between versions.
 	 *
-	 * @param The user model node.
+	 * @param element The user model node.
 	 * @return An IGraphItem. This should be either a IGraphModelNode or
 	 *         IGraphModelConnection
 	 */
@@ -216,7 +200,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 	}
 
 	@Override
-	protected void setSelectionToWidget(List l, boolean reveal) {
+	protected void setSelectionToWidget(@SuppressWarnings("rawtypes") List l, boolean reveal) {
 		GraphItem[] listOfItems = findItems(l);
 		graph.setSelection(listOfItems);
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IConnectionStyleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -23,8 +23,8 @@ import org.eclipse.draw2d.IFigure;
  * relationships, rather than on connected nodes.
  *
  * @author Del Myers
- * @see #IGraphContentProvider
- * @see #IEntityStyleProvider
+ * @see IGraphContentProvider
+ * @see IEntityStyleProvider
  *
  */
 //@tag bug(151327-Styles) : created to solve this bug
@@ -73,7 +73,6 @@ public interface IConnectionStyleProvider extends IDisposable {
 	 * the default tooltip.
 	 *
 	 * @param entity
-	 * @return
 	 */
 	public IFigure getTooltip(Object entity);
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityConnectionStyleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -76,7 +76,6 @@ public interface IEntityConnectionStyleProvider extends IDisposable {
 	 * the default tooltip.
 	 *
 	 * @param entity
-	 * @return
 	 */
 	public IFigure getTooltip(Object entity);
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityStyleProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IEntityStyleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -119,7 +119,6 @@ public interface IEntityStyleProvider extends IDisposable {
 	 * the default tooltip.
 	 *
 	 * @param entity
-	 * @return
 	 */
 	public IFigure getTooltip(Object entity);
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IFigureProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IFigureProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2009 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,12 +12,14 @@
  *******************************************************************************/
 package org.eclipse.zest.core.viewers;
 
+import org.eclipse.jface.viewers.IBaseLabelProvider;
+
 import org.eclipse.draw2d.IFigure;
 
 /**
  * Allows a user to create a figure for an element in graph model. To use this
  * interface, it should be implemented and passed to
- * {@link GraphViewer#setLabelProvider()}
+ * {@link GraphViewer#setLabelProvider(IBaseLabelProvider)}
  */
 public interface IFigureProvider {
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IGraphEntityContentProvider.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/IGraphEntityContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -28,7 +28,6 @@ public interface IGraphEntityContentProvider extends IStructuredContentProvider 
 	 * Gets the elements this object is connected to
 	 *
 	 * @param entity
-	 * @return
 	 */
 	public Object[] getConnectedTo(Object entity);
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/ZoomContributionViewItem.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/ZoomContributionViewItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -74,7 +74,7 @@ public class ZoomContributionViewItem extends ContributionItem implements ZoomLi
 	 * values for initialZooms are percentage numbers (e.g., "100%"), or FIT_WIDTH,
 	 * FIT_HEIGHT, FIT_ALL.
 	 *
-	 * @param partService service used to see whether the view is zoomable.
+	 * @param part service used to see whether the view is zoomable.
 	 */
 	public ZoomContributionViewItem(IZoomableWorkbenchPart part) {
 		zoomManager = part.getZoomableViewer().getZoomManager();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -13,7 +13,6 @@
 package org.eclipse.zest.core.viewers.internal;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -80,7 +79,7 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 		}
 
 		// We may have other entities (such as children of containers)
-		Set keySet = ((AbstractStructuredGraphViewer) getViewer()).getNodesMap().keySet();
+		Set<Object> keySet = ((AbstractStructuredGraphViewer) getViewer()).getNodesMap().keySet();
 		entities = keySet.toArray();
 
 		for (Object data : entities) {
@@ -139,11 +138,11 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 
 		if (refreshLabels) {
 			update(node);
-			for (Iterator it = node.getSourceConnections().iterator(); it.hasNext();) {
-				update((GraphItem) it.next());
+			for (GraphItem item : node.getSourceConnections()) {
+				update(item);
 			}
-			for (Iterator it = node.getTargetConnections().iterator(); it.hasNext();) {
-				update((GraphItem) it.next());
+			for (GraphItem item : node.getTargetConnections()) {
+				update(item);
 			}
 		}
 	}
@@ -156,14 +155,14 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 	private void reconnect(Graph graph, Object element, boolean refreshLabels) {
 		GraphNode node = viewer.getGraphModelNode(element);
 		Object[] related = ((IGraphEntityContentProvider) getContentProvider()).getConnectedTo(element);
-		List connections = node.getSourceConnections();
-		LinkedList toAdd = new LinkedList();
-		LinkedList toDelete = new LinkedList();
-		LinkedList toKeep = new LinkedList();
-		HashSet oldExternalConnections = new HashSet();
-		HashSet newExternalConnections = new HashSet();
-		for (Iterator it = connections.iterator(); it.hasNext();) {
-			oldExternalConnections.add(((GraphConnection) it.next()).getExternalConnection());
+		List<? extends GraphConnection> connections = node.getSourceConnections();
+		List<Object> toAdd = new LinkedList<>();
+		List<Object> toDelete = new LinkedList<>();
+		List<Object> toKeep = new LinkedList<>();
+		Set<Object> oldExternalConnections = new HashSet<>();
+		Set<Object> newExternalConnections = new HashSet<>();
+		for (GraphConnection connection : connections) {
+			oldExternalConnections.add(connection.getExternalConnection());
 		}
 		for (Object element2 : related) {
 			newExternalConnections.add(new EntityConnectionData(element, element2));
@@ -180,13 +179,13 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 				toAdd.add(next);
 			}
 		}
-		for (Iterator it = toDelete.iterator(); it.hasNext();) {
-			viewer.removeGraphModelConnection(it.next());
+		for (Object element2 : toDelete) {
+			viewer.removeGraphModelConnection(element2);
 		}
 		toDelete.clear();
-		LinkedList newNodeList = new LinkedList();
-		for (Iterator it = toAdd.iterator(); it.hasNext();) {
-			EntityConnectionData data = (EntityConnectionData) it.next();
+		List<Object> newNodeList = new LinkedList<>();
+		for (Object element2 : toAdd) {
+			EntityConnectionData data = (EntityConnectionData) element2;
 			GraphNode dest = viewer.getGraphModelNode(data.dest);
 			if (dest == null) {
 				newNodeList.add(data.dest);
@@ -195,13 +194,13 @@ public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 		}
 		toAdd.clear();
 		if (refreshLabels) {
-			for (Iterator i = toKeep.iterator(); i.hasNext();) {
-				styleItem(viewer.getGraphModelConnection(i.next()));
+			for (Object element2 : toKeep) {
+				styleItem(viewer.getGraphModelConnection(element2));
 			}
 		}
-		for (Iterator it = newNodeList.iterator(); it.hasNext();) {
+		for (Object element2 : newNodeList) {
 			// refresh the new nodes so that we get a fully-up-to-date graph.
-			refresh(graph, it.next());
+			refresh(graph, element2);
 		}
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityRelationshipFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityRelationshipFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -13,6 +13,7 @@
 package org.eclipse.zest.core.viewers.internal;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.zest.core.viewers.IGraphEntityRelationshipContentProvider;
@@ -72,19 +73,17 @@ public class GraphModelEntityRelationshipFactory extends AbstractStylingModelFac
 	 */
 	private void createModelRelationships(Graph model) {
 		GraphNode[] modelNodes = getNodesArray(model);
-		List listOfNodes = new ArrayList();
-		for (GraphNode modelNode : modelNodes) {
-			listOfNodes.add(modelNode);
-		}
+		List<GraphNode> listOfNodes = new ArrayList<>();
+		Collections.addAll(listOfNodes, modelNodes);
 
 		for (int i = 0; i < listOfNodes.size(); i++) {
-			GraphNode node = (GraphNode) listOfNodes.get(i);
-			if (node instanceof GraphContainer) {
-				List childNodes = ((GraphContainer) node).getNodes();
+			GraphNode node = listOfNodes.get(i);
+			if (node instanceof GraphContainer container) {
+				List<GraphNode> childNodes = container.getNodes();
 				listOfNodes.addAll(childNodes);
 			}
 		}
-		modelNodes = (GraphNode[]) listOfNodes.toArray(new GraphNode[listOfNodes.size()]);
+		modelNodes = listOfNodes.toArray(new GraphNode[listOfNodes.size()]);
 
 		IGraphEntityRelationshipContentProvider content = getCastedContent();
 		for (GraphNode modelNode : modelNodes) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -11,9 +11,6 @@
  * Contributors: The Chisel Group, University of Victoria
  ******************************************************************************/
 package org.eclipse.zest.core.viewers.internal;
-
-import java.util.Iterator;
-import java.util.List;
 
 import org.eclipse.zest.core.viewers.IFigureProvider;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
@@ -138,14 +135,10 @@ public class GraphModelFactory extends AbstractStylingModelFactory {
 			// node.
 			GraphNode node = viewer.getGraphModelNode(element);
 			if (node != null) {
-				List connections = node.getSourceConnections();
-				for (Iterator it = connections.iterator(); it.hasNext();) {
-					GraphConnection c = (GraphConnection) it.next();
+				for (GraphConnection c : node.getSourceConnections()) {
 					refresh(graph, c.getExternalConnection(), updateLabels);
 				}
-				connections = node.getTargetConnections();
-				for (Iterator it = connections.iterator(); it.hasNext();) {
-					GraphConnection c = (GraphConnection) it.next();
+				for (GraphConnection c : node.getTargetConnections()) {
 					refresh(graph, c.getExternalConnection(), updateLabels);
 				}
 			}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/IStylingGraphModelFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/IStylingGraphModelFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -19,6 +19,7 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
+import org.eclipse.zest.core.widgets.ZestStyles;
 
 /**
  * A Graph model factory that supports the structural and visual refreshing of
@@ -31,7 +32,7 @@ import org.eclipse.zest.core.widgets.GraphNode;
  * particular implementation of IStylingGraphModelFactory. Unless otherwise
  * documented, clients should expect that the implementation of
  * IStylingGraphModelFactory adheres to the general defaults found in
- * {@link IZestGraphDefaults}.
+ * {@link ZestStyles}.
  *
  * @author Del Myers
  */

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/ZoomManager.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/ZoomManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -40,6 +40,7 @@ import org.eclipse.draw2d.Viewport;
  * @author Dan Lee
  * @author Eric Bordeau
  */
+@SuppressWarnings("javadoc") // GEF is not in classpath
 public class ZoomManager extends org.eclipse.draw2d.zoom.AbstractZoomManager {
 
 	/**


### PR DESCRIPTION
This change primarily focuses on getting rid of the raw-type warnings, as well as some general JavaDoc cleanup.

See https://github.com/eclipse/gef-classic/issues/155