### PR TITLE
Fix ConcurrentModificationException in Zest SimpleSWTExample

### DIFF
--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2023 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
@@ -950,12 +950,20 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 
 	protected void fireProgressStarted(int totalNumberOfSteps) {
 		ProgressEvent event = new ProgressEvent(0, totalNumberOfSteps);
-		progressListeners.forEach(listener -> listener.progressStarted(event));
+		List.copyOf(progressListeners).forEach(listener -> listener.progressStarted(event));
 	}
 
 	protected void fireProgressEnded(int totalNumberOfSteps) {
 		ProgressEvent event = new ProgressEvent(totalNumberOfSteps, totalNumberOfSteps);
-		progressListeners.forEach(listener -> listener.progressEnded(event));
+		List.copyOf(progressListeners).forEach(listener -> listener.progressEnded(event));
+	}
+
+	/**
+	 * @since 1.5
+	 */
+	protected void fireProgressUpdated(int currentStep, int totalNumberOfSteps) {
+		ProgressEvent event = new ProgressEvent(currentStep, totalNumberOfSteps);
+		List.copyOf(progressListeners).forEach(listener -> listener.progressUpdated(event));
 	}
 
 	/**
@@ -971,8 +979,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm, Stoppa
 		now.add(Calendar.MILLISECOND, -MIN_TIME_DELAY_BETWEEN_PROGRESS_EVENTS);
 
 		if (now.after(lastProgressEventFired) || currentStep == totalNumberOfSteps) {
-			ProgressEvent event = new ProgressEvent(currentStep, totalNumberOfSteps);
-			progressListeners.forEach(listener -> listener.progressUpdated(event));
+			fireProgressUpdated(currentStep, totalNumberOfSteps);
 			lastProgressEventFired = Calendar.getInstance();
 		}
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -20,6 +20,24 @@ package org.eclipse.zest.layouts.progress;
  * @author Casey Best
  */
 public interface ProgressListener {
+	/**
+	 * An empty implementation of {@list ProgressListener} for convenience.
+	 *
+	 * @since 1.5
+	 */
+	public static class Stub implements ProgressListener {
+		@Override
+		public void progressStarted(ProgressEvent e) {
+		}
+
+		@Override
+		public void progressUpdated(ProgressEvent e) {
+		}
+
+		@Override
+		public void progressEnded(ProgressEvent e) {
+		}
+	}
 
 	/**
 	 *

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/LayoutAlgorithmTest.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/LayoutAlgorithmTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.zest.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.zest.layouts.InvalidLayoutConfiguration;
+import org.eclipse.zest.layouts.LayoutAlgorithm;
+import org.eclipse.zest.layouts.LayoutEntity;
+import org.eclipse.zest.layouts.LayoutRelationship;
+import org.eclipse.zest.layouts.algorithms.GridLayoutAlgorithm;
+import org.eclipse.zest.layouts.exampleStructures.SimpleNode;
+import org.eclipse.zest.layouts.progress.ProgressEvent;
+import org.eclipse.zest.layouts.progress.ProgressListener;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class LayoutAlgorithmTest {
+	private LayoutAlgorithm layoutAlgorithm;
+	private Set<String> logger;
+
+	@Before
+	public void setUp() {
+		logger = new HashSet<>();
+		layoutAlgorithm = new GridLayoutAlgorithm();
+	}
+
+	// Check for ConcurrentModificationException when the listeners are
+	// added/removed while an event is fired.
+	// See https://github.com/eclipse/gef-classic/issues/398
+
+	@Test
+	public void testWithConcurrentModification1() throws InvalidLayoutConfiguration {
+		testWith(new ProgressListener.Stub() {
+			@Override
+			public void progressStarted(ProgressEvent e) {
+				logger.add("progressStarted()"); //$NON-NLS-1$
+				layoutAlgorithm.removeProgressListener(this);
+			}
+		});
+	}
+
+	/**
+	 * Test with {@link ProgressListener}.
+	 */
+	@Test
+	public void testWithConcurrentModification2() throws InvalidLayoutConfiguration {
+		testWith(new ProgressListener.Stub() {
+			@Override
+			public void progressUpdated(ProgressEvent e) {
+				logger.add("progressUpdated()"); //$NON-NLS-1$
+				layoutAlgorithm.removeProgressListener(this);
+			}
+		});
+	}
+
+	/**
+	 * Test with {@link ProgressListener}.
+	 */
+	@Test
+	public void testWithConcurrentModification3() throws InvalidLayoutConfiguration {
+		testWith(new ProgressListener.Stub() {
+			@Override
+			public void progressEnded(ProgressEvent e) {
+				logger.add("progressEnded()"); //$NON-NLS-1$
+				layoutAlgorithm.removeProgressListener(this);
+			}
+		});
+	}
+
+	private void testWith(ProgressListener progressListener) throws InvalidLayoutConfiguration {
+		LayoutEntity[] nodes = { new SimpleNode(new Object()) };
+		layoutAlgorithm.addProgressListener(progressListener);
+		layoutAlgorithm.addProgressListener(new ProgressListener.Stub());
+
+		layoutAlgorithm.applyLayout(nodes, new LayoutRelationship[0], 0, 0, 0, 0, false, false);
+		assertEquals(logger.size(), 1); // $NON-NLS-1$
+	}
+}


### PR DESCRIPTION
An exception might be thrown if a listener is remove when e.g. a ProgressEnded event is fired. Perform the notification on a local copy of the internal list of listeners instead.

Resolves https://github.com/eclipse/gef-classic/issues/398