### PR TITLE
Disable execution of tycho-packaging-plugin in Eclipse IDE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 			</plugin>
 			
 			<plugin>
+				<?m2e ignore?>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
 				<version>${tycho.version}</version>


### PR DESCRIPTION
The package-plugin mojo can't be executed within the Eclipse. Attempting to do only creates an error marker in the isv bundles.