### PR TITLE
Relax demands on PaletteContainer getChildren() method

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteContainer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/PaletteContainer.java
@@ -81,12 +81,12 @@ public class PaletteContainer extends PaletteEntry {
 					+ entry.getType());
 		}
 
-		List<PaletteEntry> oldChildren = new ArrayList<>(getChildren());
+		List<PaletteEntry> oldChildren = new ArrayList<>(children);
 
-		int actualIndex = index < 0 ? getChildren().size() : index;
-		getChildren().add(actualIndex, entry);
+		int actualIndex = index < 0 ? children.size() : index;
+		children.add(actualIndex, entry);
 		entry.setParent(this);
-		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, getChildren());
+		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, children);
 	}
 
 	/**
@@ -95,16 +95,16 @@ public class PaletteContainer extends PaletteEntry {
 	 * @param list a list of PaletteEntry objects to add to this PaletteContainer
 	 */
 	public void addAll(List<? extends PaletteEntry> list) {
-		List<PaletteEntry> oldChildren = new ArrayList<>(getChildren());
+		List<PaletteEntry> oldChildren = new ArrayList<>(children);
 		for (PaletteEntry child : list) {
 			if (!acceptsType(child.getType())) {
 				throw new IllegalArgumentException("This container can not contain this type of child: " //$NON-NLS-1$
 						+ child.getType());
 			}
-			getChildren().add(child);
+			children.add(child);
 			child.setParent(this);
 		}
-		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, getChildren());
+		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, children);
 	}
 
 	/**
@@ -117,8 +117,8 @@ public class PaletteContainer extends PaletteEntry {
 	public void appendToSection(String id, PaletteEntry entry) {
 		// find the entry with the given id
 		boolean found = false;
-		for (int i = 0; i < getChildren().size(); i++) {
-			PaletteEntry currEntry = getChildren().get(i);
+		for (int i = 0; i < children.size(); i++) {
+			PaletteEntry currEntry = children.get(i);
 			if (currEntry.getId().equals(id)) {
 				found = true;
 			} else if (found && currEntry instanceof PaletteSeparator) {
@@ -135,23 +135,23 @@ public class PaletteContainer extends PaletteEntry {
 	/**
 	 * @return the children of this container
 	 */
-	public List<PaletteEntry> getChildren() {
+	public List<? extends PaletteEntry> getChildren() {
 		return children;
 	}
 
 	private boolean move(PaletteEntry entry, boolean up) {
-		int index = getChildren().indexOf(entry);
+		int index = children.indexOf(entry);
 		if (index < 0) {
 			// This container does not contain the given palette entry
 			return false;
 		}
 		index = up ? index - 1 : index + 1;
-		if (index < 0 || index >= getChildren().size()) {
+		if (index < 0 || index >= children.size()) {
 			// Performing the move operation will give the child an invalid
 			// index
 			return false;
 		}
-		if (getChildren().get(index) instanceof PaletteContainer container
+		if (children.get(index) instanceof PaletteContainer container
 				&& getUserModificationPermission() == PaletteEntry.PERMISSION_FULL_MODIFICATION) {
 			// move it into a container if we have full permission
 			if (container.acceptsType(entry.getType())
@@ -165,10 +165,10 @@ public class PaletteContainer extends PaletteEntry {
 				return true;
 			}
 		}
-		List<PaletteEntry> oldChildren = new ArrayList<>(getChildren());
-		getChildren().remove(entry);
-		getChildren().add(index, entry);
-		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, getChildren());
+		List<PaletteEntry> oldChildren = new ArrayList<>(children);
+		children.remove(entry);
+		children.add(index, entry);
+		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, children);
 		return true;
 	}
 
@@ -200,10 +200,10 @@ public class PaletteContainer extends PaletteEntry {
 	 * @param entry the PaletteEntry to remove
 	 */
 	public void remove(PaletteEntry entry) {
-		List<PaletteEntry> oldChildren = new ArrayList<>(getChildren());
-		if (getChildren().remove(entry)) {
+		List<PaletteEntry> oldChildren = new ArrayList<>(children);
+		if (children.remove(entry)) {
 			entry.setParent(null);
-			listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, getChildren());
+			listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, children);
 		}
 	}
 
@@ -218,7 +218,7 @@ public class PaletteContainer extends PaletteEntry {
 		oldChildren.forEach(entry -> entry.setParent(null));
 		children = list;
 		children.forEach(entry -> entry.setParent(this));
-		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, getChildren());
+		listeners.firePropertyChange(PROPERTY_CHILDREN, oldChildren, children);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteCustomizer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteCustomizer.java
@@ -105,7 +105,7 @@ public abstract class PaletteCustomizer {
 		}
 
 		// walk parent siblings till we find one it can go into.
-		List<PaletteEntry> children = parent.getParent().getChildren();
+		List<? extends PaletteEntry> children = parent.getParent().getChildren();
 		int parentIndex = children.indexOf(parent);
 
 		for (int i = parentIndex + 1; i < children.size(); i++) {
@@ -152,7 +152,7 @@ public abstract class PaletteCustomizer {
 		}
 
 		// walk parent siblings till we find one it can go into.
-		List<PaletteEntry> children = parent.getParent().getChildren();
+		List<? extends PaletteEntry> children = parent.getParent().getChildren();
 		int parentIndex = children.indexOf(parent);
 
 		for (int i = parentIndex - 1; i >= 0; i--) {
@@ -230,7 +230,7 @@ public abstract class PaletteCustomizer {
 			if (canAdd(newParent, entry)) {
 				insertionIndex = newParent.getChildren().indexOf(parent) + 1;
 			} else {
-				List<PaletteEntry> parents = newParent.getChildren();
+				List<? extends PaletteEntry> parents = newParent.getChildren();
 				for (int i = parents.indexOf(parent) + 1; i < parents.size(); i++) {
 					if (parents.get(i) instanceof PaletteContainer pc) {
 						newParent = pc;
@@ -266,7 +266,7 @@ public abstract class PaletteCustomizer {
 			if (canAdd(newParent, entry)) {
 				insertionIndex = newParent.getChildren().indexOf(parent);
 			} else {
-				List<PaletteEntry> parents = newParent.getChildren();
+				List<? extends PaletteEntry> parents = newParent.getChildren();
 
 				for (int i = parents.indexOf(parent) - 1; i >= 0; i--) {
 					if (parents.get(i) instanceof PaletteContainer pc) {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteContainerFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteContainerFactory.java
@@ -56,7 +56,7 @@ public abstract class PaletteContainerFactory extends PaletteEntryFactory {
 			return 0;
 		}
 
-		List<PaletteEntry> children = parent.getChildren();
+		List<? extends PaletteEntry> children = parent.getChildren();
 		PaletteEntry current = selected;
 		while (!children.contains(current)) {
 			current = current.getParent();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizerDialog.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteCustomizerDialog.java
@@ -364,7 +364,7 @@ public class PaletteCustomizerDialog extends Dialog implements EntryPageContaine
 			// otherwise the
 			// will scroll to show the last item, and then will select the first
 			// visible item.
-			List<PaletteEntry> children = getPaletteRoot().getChildren();
+			List<? extends PaletteEntry> children = getPaletteRoot().getChildren();
 			if (!children.isEmpty()) {
 				initialSelection = children.get(0);
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteTreeProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/customize/PaletteTreeProvider.java
@@ -69,7 +69,7 @@ class PaletteTreeProvider implements ITreeContentProvider {
 	@Override
 	public Object[] getChildren(Object parentElement) {
 		if (parentElement instanceof PaletteContainer pc) {
-			List<PaletteEntry> children = pc.getChildren();
+			List<? extends PaletteEntry> children = pc.getChildren();
 			if (!children.isEmpty()) {
 				return children.toArray();
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
@@ -415,7 +415,7 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 		traverseChildren(container.getChildren(), add);
 	}
 
-	private void traverseChildren(List<PaletteEntry> children, boolean add) {
+	private void traverseChildren(List<? extends PaletteEntry> children, boolean add) {
 		for (PaletteEntry entry : children) {
 			if (add) {
 				entry.addPropertyChangeListener(childListener);


### PR DESCRIPTION
Downstream projects may declare their own custom palette entries. By returning a list of PaletteEntry's, it's no longer possible to cast this list of those custom entries.

Resolves https://github.com/eclipse/gef-classic/issues/401