### PR TITLE
Changed RulerLayout to directly inherit from AbstractLayout  #418

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/XYLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/XYLayout.java
@@ -136,7 +136,11 @@ public class XYLayout extends AbstractLayout {
 	@Override
 	public void setConstraint(IFigure figure, Object newConstraint) {
 		super.setConstraint(figure, newConstraint);
-		if (newConstraint instanceof Rectangle rect) {
+		if (newConstraint != null) {
+			if (!(newConstraint instanceof Rectangle rect)) {
+				throw new IllegalArgumentException("XYLayout was given " + newConstraint.getClass().getName() //$NON-NLS-1$
+						+ " as constraint for Figure. Rectangle expected!"); //$NON-NLS-1$
+			}
 			constraints.put(figure, rect);
 		}
 	}


### PR DESCRIPTION
`RulerLayout` inherited from `XYLayout`. The later assumed that children constraint are rectangles. As this is not valid for `RulerLayout`s the `RulerLayout` was changed to inherit from `AbstractLayout` and use its own constraint map with Integers.

Fixes #418