### PR TITLE
Fix redraw performance issues in FigureCanvas when GTK overlay scrolling is enabled (eclipse#425)

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
@@ -300,9 +300,17 @@ public class FigureCanvas extends Canvas {
 
 	private void layoutViewport() {
 		ScrollPaneSolver.Result result;
+		int vBarWidth = 0;
+		int hBarHeight = 0;
+
+		if ((getScrollbarsMode() & SWT.SCROLLBAR_OVERLAY) != 0) {
+			org.eclipse.swt.graphics.Rectangle trim = computeTrim(0, 0, 0, 0);
+			vBarWidth = trim.width;
+			hBarHeight = trim.height;
+		}
+
 		result = ScrollPaneSolver.solve(new Rectangle(getBounds()).setLocation(0, 0), getViewport(),
-				getHorizontalScrollBarVisibility(), getVerticalScrollBarVisibility(), computeTrim(0, 0, 0, 0).width,
-				computeTrim(0, 0, 0, 0).height);
+				getHorizontalScrollBarVisibility(), getVerticalScrollBarVisibility(), vBarWidth, hBarHeight);
 		getLightweightSystem().setIgnoreResize(true);
 		try {
 			if (getHorizontalBar().getVisible() != result.showH) {


### PR DESCRIPTION
Fix for eclipse#425. Detect when overlay scrolling is enabled on GTK and it's the case then ignore scrollbar trims when calculating the viewport client area.

This fix tackles the immediate performance issue however it adds a platform dependency (which isn't the first in GEF), but also is not future proof because the upcoming GEF4 removes the GTK_OVERLAY_SCROLLING environment variable support which is being checked here. Since SWT doesn't provide a way to test for GTK version, a more complete fix would involve a better support for GTK_OVERLAY_SCROLLING in SWT's Scrollable.getScrollbarsMode() method.