### PR TITLE
Add static method to configure overlay scrolling for FigureCanvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# GEF Classic 3.20.0 (Eclipse 2024-06)
+
+## Draw2d
+ - Clients can disable overlay scrolling by calling FigureCanvas.setScrollbarsMode()
+   prior to creating the object.
+
 # GEF Classic 3.19.0 (Eclipse 2024-03)
 
 ## Draw2d


### PR DESCRIPTION
This allows the user to specify whether new instances of FigureCanvas should use overlay scrolling on not. This is disabled by default, due to performance issues on Linux/GTK3.

As a result, the scrollbar is shown as a separate entity and no longer part of the client area. This setting only affects operating systems supporting overlay scrolling. This method requires SWT 3.126 or newer.

https://github.com/eclipse/gef-classic/issues/430