### PR TITLE
Add flag to enable double-buffering when doing paint operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# GEF Classic 3.20.0 
+# GEF Classic 3.20.0 (Eclipse 2024-03)
+
+## Draw2d
+ - _Experimental:_ Clients can set the  `org.eclipse.draw2d.LightweightSystem.useDoubleBuffering` system property to enable double buffering while performing paint operations.
 
 ## GEF
 - Clients can now configure the accessible steps of tools through methods `accGetStep()`, `accStepIncrement` and `accStepReset` from `org.eclipse.gef.tools.AbstractTool`.

--- a/org.eclipse.draw2d/.settings/.api_filters
+++ b/org.eclipse.draw2d/.settings/.api_filters
@@ -40,6 +40,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/draw2d/LightweightSystem.java" type="org.eclipse.draw2d.LightweightSystem">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.draw2d.LightweightSystem"/>
+                <message_argument value="KEY_USE_DOUBLE_BUFFERING"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/draw2d/Orientable.java" type="org.eclipse.draw2d.Orientable">
         <filter id="576720909">
             <message_arguments>


### PR DESCRIPTION
By using the `org.eclipse.draw2d.LightweightSystem.useDoubleBuffering`, clients can enable a special functionality, that first paints all UI updates to an internal buffer, before it is painted to the screen.

The hope of behavior is to increase the perceived performance of an application by detaching rendering from the display.

https://github.com/eclipse/gef-classic/issues/430