### PR TITLE
Fix [#436] "Error: SWT Resource was not properly disposed" in ScaledG…

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
@@ -986,9 +986,6 @@ public class ScaledGraphics extends Graphics {
 	}
 
 	private TextLayout zoomTextLayout(TextLayout layout) {
-		TextLayout zoomed = new TextLayout(Display.getCurrent());
-		zoomed.setText(layout.getText());
-
 		int zoomWidth = -1;
 
 		if (layout.getWidth() != -1) {
@@ -996,10 +993,11 @@ public class ScaledGraphics extends Graphics {
 		}
 
 		if (zoomWidth < -1 || zoomWidth == 0) {
-			zoomed.dispose();
 			return null;
-		}
+		} 
 
+		TextLayout zoomed = new TextLayout(Display.getCurrent());
+		zoomed.setText(layout.getText());
 		zoomed.setFont(zoomFont(layout.getFont()));
 		zoomed.setAlignment(layout.getAlignment());
 		zoomed.setAscent(layout.getAscent());

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
@@ -996,6 +996,7 @@ public class ScaledGraphics extends Graphics {
 		}
 
 		if (zoomWidth < -1 || zoomWidth == 0) {
+			zoomed.dispose();
 			return null;
 		}
 


### PR DESCRIPTION
[#436] Fix "Error: SWT Resource was not properly disposed" in ScaledGraphics.zoomTextLayout()

Resolves eclipse/gef-classic#436
Dispose the TextLayout when returning null.

Signed-off-by: Cedric Marin <cedric.dev.780@gmail.com>