### PR TITLE
Move up null check in GEF viewer when the selected editpart is updated.

### DIFF
--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
@@ -26,7 +26,8 @@ import org.junit.runners.Suite;
 	ToolUtilitiesTest.class,
 	DragEditPartsTrackerTest.class,
 	CommandStackTest.class,
-	RulerLayoutTests.class
+	RulerLayoutTests.class,
+	GraphicalViewerTest.class
 })
 public class GEFTestSuite {
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/GraphicalViewerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/GraphicalViewerTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.test;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class GraphicalViewerTest {
+	private GraphicalViewer viewer;
+
+	@Before
+	public void setUp() {
+		viewer = new GraphicalViewerImpl();
+	}
+
+	/**
+	 * Appending a {@code null} edit part shouldn't leave the viewer in an
+	 * inconsistent state.
+	 */
+	@Test
+	public void testAppendNullSelection() {
+		assertThrows(NullPointerException.class, () -> viewer.appendSelection(null));
+		assertTrue(viewer.getSelectedEditParts().isEmpty());
+	}
+
+	/**
+	 * Setting a {@code null} edit part shouldn't leave the viewer in an
+	 * inconsistent state.
+	 */
+	@Test
+	public void testSetNullSelection() {
+		IStructuredSelection selection = new StructuredSelection(new Object[] { null });
+		assertThrows(NullPointerException.class, () -> viewer.setSelection(selection));
+		assertTrue(viewer.getSelectedEditParts().isEmpty());
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/SelectionManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SelectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2010 IBM Corporation and others.
+ * Copyright (c) 2006, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,10 +14,10 @@
 package org.eclipse.gef;
 
 import java.lang.reflect.Field;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.swt.widgets.Control;
 
@@ -218,7 +218,7 @@ public class SelectionManager {
 	 * @param notifier  notifier
 	 * @since 3.2
 	 */
-	public void internalInitialize(EditPartViewer viewer, List selection, Runnable notifier) {
+	public void internalInitialize(EditPartViewer viewer, List<EditPart> selection, Runnable notifier) {
 		this.viewer = viewer;
 		this.selection = selection;
 		this.notifier = notifier;
@@ -269,13 +269,14 @@ public class SelectionManager {
 	 * @since 3.2
 	 */
 	public void setSelection(ISelection newSelection) {
-		if (!(newSelection instanceof IStructuredSelection)) {
+		if (!(newSelection instanceof IStructuredSelection structuredSelection)) {
 			return;
 		}
 
-		List orderedSelection = ((IStructuredSelection) newSelection).toList();
+		@SuppressWarnings("unchecked")
+		List<EditPart> orderedSelection = structuredSelection.toList();
 		// Convert to HashSet to optimize performance.
-		Collection hashset = new HashSet(orderedSelection);
+		Set<EditPart> hashset = new HashSet<>(orderedSelection);
 
 		// Fix for 458416: adjust the focus through the viewer only (to give
 		// AbstractEditPartViewer a change to update its focusPart field).
@@ -289,17 +290,11 @@ public class SelectionManager {
 		}
 		selection.clear();
 
-		if (!orderedSelection.isEmpty()) {
-			Iterator itr = orderedSelection.iterator();
-			while (true) {
-				EditPart part = (EditPart) itr.next();
-				selection.add(part);
-				if (!itr.hasNext()) {
-					part.setSelected(EditPart.SELECTED_PRIMARY);
-					break;
-				}
-				part.setSelected(EditPart.SELECTED);
-			}
+		Iterator<EditPart> itr = orderedSelection.iterator();
+		while (itr.hasNext()) {
+			EditPart part = itr.next();
+			selection.add(part);
+			part.setSelected(itr.hasNext() ? EditPart.SELECTED : EditPart.SELECTED_PRIMARY);
 		}
 		fireSelectionChanged();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/SelectionManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SelectionManager.java
@@ -14,9 +14,9 @@
 package org.eclipse.gef;
 
 import java.lang.reflect.Field;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.swt.widgets.Control;
@@ -72,6 +72,7 @@ public class SelectionManager {
 	 * @since 3.2
 	 */
 	public void appendSelection(EditPart editpart) {
+		Objects.requireNonNull(editpart, "The selected edit part must not be null."); //$NON-NLS-1$
 		if (editpart != getFocus()) {
 			// Fix for 458416: adjust the focus through the viewer only (to give
 			// AbstractEditPartViewer a change to update its focusPart field).
@@ -275,8 +276,8 @@ public class SelectionManager {
 
 		@SuppressWarnings("unchecked")
 		List<EditPart> orderedSelection = structuredSelection.toList();
-		// Convert to HashSet to optimize performance.
-		Set<EditPart> hashset = new HashSet<>(orderedSelection);
+		// Convert to set to optimize performance. (Implicit null check)
+		Set<EditPart> set = Set.copyOf(orderedSelection);
 
 		// Fix for 458416: adjust the focus through the viewer only (to give
 		// AbstractEditPartViewer a change to update its focusPart field).
@@ -284,7 +285,7 @@ public class SelectionManager {
 		// here, so both focus part values should stay in sync.
 		viewer.setFocus(null);
 		for (EditPart part : selection) {
-			if (!hashset.contains(part)) {
+			if (!set.contains(part)) {
 				part.setSelected(EditPart.SELECTED_NONE);
 			}
 		}


### PR DESCRIPTION
The selection inside a GEF viewer is assumed to always be non-null. But
because the (implicit) null check is done after the editpart is added to
the internal list, it leaves the viewer in an inconsistent state.

To avoid this, the null check is done earlier, so that the exception is
thrown before the internal model is modified.