### PR TITLE
Force repaint in NativeGraphicsSource to fix broken animation

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
@@ -251,7 +251,7 @@ public class Animation {
 	 * @since 3.2
 	 */
 	public static void run(int duration) {
-		if (state == 0) {
+		if (state == 0 || state == PLAYBACK) {
 			return;
 		}
 		try {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2010 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -56,6 +56,9 @@ public final class NativeGraphicsSource implements GraphicsSource {
 
 		// canvas.update();
 
+		// canvas.update() paints too much and only works on Windows. Use
+		// readAndDispatch() to only paint the redraw() event.
+		canvas.getDisplay().readAndDispatch();
 		return null;
 	}
 

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
@@ -129,7 +129,7 @@ public abstract class AbstractGraphTest {
 				robot = new GraphicalRobot(graph);
 				shell = graph.getShell();
 				// Wait for layout to be applied
-				waitEventLoop(0);
+				waitEventLoop(10);
 				// Run the actual test
 				statement.evaluate();
 			} catch (Throwable e) {

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
@@ -78,7 +78,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.geometry.Point;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -110,7 +109,6 @@ public class GraphSWTTests extends AbstractGraphTest {
 	 * @see <a href="https://github.com/eclipse/gef-classic/issues/376">here</a>
 	 */
 	@Test
-	@Ignore
 	@Snippet(type = AnimationSnippet.class)
 	public void testAnimationSnippet() {
 		AtomicInteger repaintCount = new AtomicInteger();


### PR DESCRIPTION
When the FigureCanvas is created with SWT.DOUBLE_BUFFERED, animations are not painted correctly. This is because an instance of NativeGraphicsSource is used internally, which doesn't paint synchronously.

Because the animation is done inside the UI thread, this paint operation is only processed after the animation is done.

Resolves https://github.com/eclipse/gef-classic/issues/376