### PR TITLE
Fix: Adding a node to a graph container adds it to the graph instead

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -101,7 +101,7 @@ public class GraphNode extends GraphItem {
 	}
 
 	public GraphNode(IContainer graphModel, int style, Object data) {
-		this(graphModel.getGraph(), style, "" /* text */, null /* image */, data);
+		this(graphModel, style, "" /* text */, null /* image */, data);
 	}
 
 	public GraphNode(IContainer graphModel, int style, String text) {
@@ -109,7 +109,7 @@ public class GraphNode extends GraphItem {
 	}
 
 	public GraphNode(IContainer graphModel, int style, String text, Object data) {
-		this(graphModel.getGraph(), style, text, null /* image */, data);
+		this(graphModel, style, text, null /* image */, data);
 	}
 
 	public GraphNode(IContainer graphModel, int style, String text, Image image) {


### PR DESCRIPTION
When the constructors in the GraphNode class have been unified, we wrongfully pass "graphModel.getGraph()" as an argument instead of the current container. This causes all nodes to be added to the parent graph.

See the UML example for reference. One of the class diagrams should be contained by the UML container, but all three are part of the parent graph instead.

Amends a13541fd21b23c8fdfb5c64a99321f7b8be44706