### PR TITLE
Set source/target container figure to null after Zest connection removal

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -163,12 +163,18 @@ public class GraphConnection extends GraphItem {
 			}
 		}
 		connectionFigure = null;
-		if (sourceContainerConnectionFigure != null && sourceContainerConnectionFigure.getParent() != null) {
-			sourceContainerConnectionFigure.getParent().remove(sourceContainerConnectionFigure);
+		if (sourceContainerConnectionFigure != null) {
+			IFigure sourceContainerConnectionParent = sourceContainerConnectionFigure.getParent();
+			if (sourceContainerConnectionParent != null) {
+				sourceContainerConnectionParent.remove(sourceContainerConnectionFigure);
+			}
 			sourceContainerConnectionFigure = null;
 		}
 		if (targetContainerConnectionFigure != null && targetContainerConnectionFigure.getParent() != null) {
-			targetContainerConnectionFigure.getParent().remove(targetContainerConnectionFigure);
+			IFigure targetContainerConnectionParent = targetContainerConnectionFigure.getParent();
+			if (targetContainerConnectionParent != null) {
+				targetContainerConnectionParent.remove(targetContainerConnectionFigure);
+			}
 			targetContainerConnectionFigure = null;
 		}
 


### PR DESCRIPTION
The local variables should be cleared when the figure is removed, even if either of the containers has already been disposed.

Amends 2288625a8c910773a4e3076691b39ad3c13a2cc8