### PR TITLE
Update feature and plugin version numbers for 3.21 release cycle

### DIFF
--- a/org.eclipse.draw2d-feature/feature.xml
+++ b/org.eclipse.draw2d-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.draw2d"
       label="%featureName"
-      version="3.20.0.qualifier"
+      version="3.21.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.draw2d.sdk-feature/feature.xml
+++ b/org.eclipse.draw2d.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.draw2d.sdk"
       label="%featureName"
-      version="3.20.0.qualifier"
+      version="3.21.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.draw2d"
       license-feature="org.eclipse.license"

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.16.0.qualifier
+Bundle-Version: 3.17.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.gef-feature/feature.xml
+++ b/org.eclipse.gef-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef"
       label="%featureName"
-      version="3.20.0.qualifier"
+      version="3.21.0.qualifier"
       provider-name="%providerName"
       image="eclipse_update_120.jpg"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.examples-feature/feature.xml
+++ b/org.eclipse.gef.examples-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef.examples"
       label="%featureName"
-      version="3.20.0.qualifier"
+      version="3.21.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef.examples.logic"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.sdk-feature/feature.xml
+++ b/org.eclipse.gef.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.gef.sdk"
       label="%featureName"
-      version="3.20.0.qualifier"
+      version="3.21.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.gef"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.18.0.qualifier
+Bundle-Version: 3.19.0.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.zest-feature/feature.xml
+++ b/org.eclipse.zest-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.zest"
       label="%featureName"
-      version="3.20.0.qualifier"
+      version="3.21.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.12.0.qualifier
+Bundle-Version: 1.13.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;visibility:=reexport

--- a/org.eclipse.zest.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.examples
-Bundle-Version: 3.17.0.qualifier
+Bundle-Version: 3.18.0.qualifier
 Export-Package: org.eclipse.zest.examples.jface;x-friends:="org.eclipse.zest.tests",
  org.eclipse.zest.examples.swt;x-friends:="org.eclipse.zest.tests",
  org.eclipse.zest.examples.uml;x-friends:="org.eclipse.zest.tests"

--- a/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.layouts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.layouts;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.zest.layouts,

--- a/org.eclipse.zest.sdk-feature/feature.xml
+++ b/org.eclipse.zest.sdk-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.zest.sdk"
       label="%featureName"
-      version="3.20.0.qualifier"
+      version="3.21.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.zest.core"
       license-feature="org.eclipse.license"

--- a/target-platform/GEF_classic.target
+++ b/target-platform/GEF_classic.target
@@ -7,7 +7,7 @@
 <repository location="http://download.eclipse.org/cbi/updates/license"/>
 </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="http://download.eclipse.org/staging/2024-06"/>
+		<repository location="http://download.eclipse.org/staging/2024-09"/>
 		<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 	</location>
 </locations>


### PR DESCRIPTION
@azoitl 

FYI, I looked into this obscure "The minor version should be incremented in version x.y.z, since execution environments have been changed since version x.y.z" error and I'm fairly confident that this is an issue within Equinox.

In short, the API tool is unable to load the execution environment of the baseline plugins because Equinox ignores the "Require-Capability" header (at least for loading the EE). And therefore, an empty string is compared to the execution environment that is set in the workspace (JavaSE-17), which is therefore marked as an error.