### PR TITLE
Use rectangle from ScrollPaneSolver as client area for root figure

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
@@ -319,7 +319,7 @@ public class FigureCanvas extends Canvas {
 			if (getVerticalBar().getVisible() != result.showV) {
 				getVerticalBar().setVisible(result.showV);
 			}
-			Rectangle r = new Rectangle(getClientArea());
+			Rectangle r = new Rectangle(result.viewportArea);
 			r.setLocation(0, 0);
 			getLightweightSystem().getRootFigure().setBounds(r);
 		} finally {


### PR DESCRIPTION
The value returned by getClientArea() might not match the physical size of the canvas. Therefore it might happen that parts of the canvas are hidden behind a scrollbar or not painted at all.

Resolves https://github.com/eclipse/gef-classic/issues/456