### PR TITLE
Fix ConcurrentModificationException in RulerProvider

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/rulers/LogicRulerProvider.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/rulers/LogicRulerProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2022 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -44,12 +44,12 @@ public class LogicRulerProvider extends RulerProvider {
 				} else {
 					guide.removePropertyChangeListener(guideListener);
 				}
-				for (Object listener : listeners) {
-					((RulerChangeListener) listener).notifyGuideReparented(guide);
+				for (RulerChangeListener listener : listeners) {
+					listener.notifyGuideReparented(guide);
 				}
 			} else {
-				for (Object listener : listeners) {
-					((RulerChangeListener) listener).notifyUnitsChanged(ruler.getUnit());
+				for (RulerChangeListener listener : listeners) {
+					listener.notifyUnitsChanged(ruler.getUnit());
 				}
 			}
 		}
@@ -58,13 +58,12 @@ public class LogicRulerProvider extends RulerProvider {
 		@Override
 		public void propertyChange(PropertyChangeEvent evt) {
 			if (evt.getPropertyName().equals(LogicGuide.PROPERTY_CHILDREN)) {
-				for (Object listener : listeners) {
-					((RulerChangeListener) listener).notifyPartAttachmentChanged(evt.getNewValue(),
-							evt.getSource());
+				for (RulerChangeListener listener : listeners) {
+					listener.notifyPartAttachmentChanged(evt.getNewValue(), evt.getSource());
 				}
 			} else {
-				for (Object listener : listeners) {
-					((RulerChangeListener) listener).notifyGuideMoved(evt.getSource());
+				for (RulerChangeListener listener : listeners) {
+					listener.notifyGuideMoved(evt.getSource());
 				}
 			}
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -83,7 +83,7 @@ public abstract class RulerProvider {
 	 * A list of <code>RulerChangeListener</code>s that have to be notified of
 	 * changes in ruler/guide properties.
 	 */
-	protected List listeners = new ArrayList();
+	protected List<RulerChangeListener> listeners = new ArrayList<>();
 
 	/**
 	 * The given listener will be notified of changes in ruler properties.

--- a/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.swt.accessibility.AccessibleControlEvent;
 import org.eclipse.swt.accessibility.AccessibleEvent;
@@ -83,7 +84,7 @@ public abstract class RulerProvider {
 	 * A list of <code>RulerChangeListener</code>s that have to be notified of
 	 * changes in ruler/guide properties.
 	 */
-	protected List<RulerChangeListener> listeners = new ArrayList<>();
+	protected List<RulerChangeListener> listeners = new CopyOnWriteArrayList<>();
 
 	/**
 	 * The given listener will be notified of changes in ruler properties.


### PR DESCRIPTION
Use a thread-safe CopyOnWriteArrayList instead of a plain ArrayList for
storing all registered listeners. Note that writing to this type is
expensive, as the array is copied on every add. But for this use case,
the number of listeners should be negligible.

To reproduce: Enable the ruler in the Logic example and create a new
guide.