### PR TITLE
Fix: ConcurrentModificationException in CommandStack

### DIFF
--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
@@ -1,5 +1,10 @@
 package org.eclipse.gef.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,10 +12,9 @@ import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CommandStackEvent;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-public class CommandStackTest extends Assert {
+public class CommandStackTest {
 
 	@SuppressWarnings("static-method")
 	@Test
@@ -25,114 +29,114 @@ public class CommandStackTest extends Assert {
 		};
 
 		// test execution pre and post events
-		Assert.assertEquals(0, commandStackEvents.size());
+		assertEquals(0, commandStackEvents.size());
 		stack.execute(c);
 
-		Assert.assertEquals(2, commandStackEvents.size());
-		Assert.assertEquals(c, commandStackEvents.get(0).getCommand());
-		Assert.assertTrue(commandStackEvents.get(0).isPreChangeEvent());
-		Assert.assertFalse(commandStackEvents.get(0).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(0).getSource());
-		Assert.assertEquals(CommandStack.PRE_EXECUTE, commandStackEvents.get(0).getDetail());
-		Assert.assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
+		assertEquals(2, commandStackEvents.size());
+		assertEquals(c, commandStackEvents.get(0).getCommand());
+		assertTrue(commandStackEvents.get(0).isPreChangeEvent());
+		assertFalse(commandStackEvents.get(0).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(0).getSource());
+		assertEquals(CommandStack.PRE_EXECUTE, commandStackEvents.get(0).getDetail());
+		assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
+		assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
 
-		Assert.assertEquals(c, commandStackEvents.get(1).getCommand());
-		Assert.assertFalse(commandStackEvents.get(1).isPreChangeEvent());
-		Assert.assertTrue(commandStackEvents.get(1).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(1).getSource());
-		Assert.assertEquals(CommandStack.POST_EXECUTE, commandStackEvents.get(1).getDetail());
-		Assert.assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
+		assertEquals(c, commandStackEvents.get(1).getCommand());
+		assertFalse(commandStackEvents.get(1).isPreChangeEvent());
+		assertTrue(commandStackEvents.get(1).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(1).getSource());
+		assertEquals(CommandStack.POST_EXECUTE, commandStackEvents.get(1).getDetail());
+		assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
+		assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
 
 		// // test undo pre and post events
 		commandStackEvents.clear();
-		Assert.assertEquals(0, commandStackEvents.size());
+		assertEquals(0, commandStackEvents.size());
 		stack.undo();
 
-		Assert.assertEquals(2, commandStackEvents.size());
-		Assert.assertEquals(c, commandStackEvents.get(0).getCommand());
-		Assert.assertTrue(commandStackEvents.get(0).isPreChangeEvent());
-		Assert.assertFalse(commandStackEvents.get(0).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(0).getSource());
-		Assert.assertEquals(CommandStack.PRE_UNDO, commandStackEvents.get(0).getDetail());
-		Assert.assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
+		assertEquals(2, commandStackEvents.size());
+		assertEquals(c, commandStackEvents.get(0).getCommand());
+		assertTrue(commandStackEvents.get(0).isPreChangeEvent());
+		assertFalse(commandStackEvents.get(0).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(0).getSource());
+		assertEquals(CommandStack.PRE_UNDO, commandStackEvents.get(0).getDetail());
+		assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
+		assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
 
-		Assert.assertEquals(c, commandStackEvents.get(1).getCommand());
-		Assert.assertFalse(commandStackEvents.get(1).isPreChangeEvent());
-		Assert.assertTrue(commandStackEvents.get(1).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(1).getSource());
-		Assert.assertEquals(CommandStack.POST_UNDO, commandStackEvents.get(1).getDetail());
-		Assert.assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
+		assertEquals(c, commandStackEvents.get(1).getCommand());
+		assertFalse(commandStackEvents.get(1).isPreChangeEvent());
+		assertTrue(commandStackEvents.get(1).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(1).getSource());
+		assertEquals(CommandStack.POST_UNDO, commandStackEvents.get(1).getDetail());
+		assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
+		assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
 
 		// // test redo pre and post events
 		commandStackEvents.clear();
-		Assert.assertEquals(0, commandStackEvents.size());
+		assertEquals(0, commandStackEvents.size());
 		stack.redo();
 
-		Assert.assertEquals(2, commandStackEvents.size());
-		Assert.assertEquals(c, commandStackEvents.get(0).getCommand());
-		Assert.assertTrue(commandStackEvents.get(0).isPreChangeEvent());
-		Assert.assertFalse(commandStackEvents.get(0).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(0).getSource());
-		Assert.assertEquals(CommandStack.PRE_REDO, commandStackEvents.get(0).getDetail());
-		Assert.assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
+		assertEquals(2, commandStackEvents.size());
+		assertEquals(c, commandStackEvents.get(0).getCommand());
+		assertTrue(commandStackEvents.get(0).isPreChangeEvent());
+		assertFalse(commandStackEvents.get(0).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(0).getSource());
+		assertEquals(CommandStack.PRE_REDO, commandStackEvents.get(0).getDetail());
+		assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
+		assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
 
-		Assert.assertEquals(c, commandStackEvents.get(1).getCommand());
-		Assert.assertFalse(commandStackEvents.get(1).isPreChangeEvent());
-		Assert.assertTrue(commandStackEvents.get(1).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(1).getSource());
-		Assert.assertEquals(CommandStack.POST_REDO, commandStackEvents.get(1).getDetail());
-		Assert.assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
+		assertEquals(c, commandStackEvents.get(1).getCommand());
+		assertFalse(commandStackEvents.get(1).isPreChangeEvent());
+		assertTrue(commandStackEvents.get(1).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(1).getSource());
+		assertEquals(CommandStack.POST_REDO, commandStackEvents.get(1).getDetail());
+		assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
+		assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
 
 		// test flush event
 		commandStackEvents.clear();
-		Assert.assertEquals(0, commandStackEvents.size());
+		assertEquals(0, commandStackEvents.size());
 		stack.flush();
 
-		Assert.assertEquals(2, commandStackEvents.size());
-		Assert.assertEquals(null, commandStackEvents.get(0).getCommand());
-		Assert.assertTrue(commandStackEvents.get(0).isPreChangeEvent());
-		Assert.assertFalse(commandStackEvents.get(0).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(0).getSource());
-		Assert.assertEquals(CommandStack.PRE_FLUSH, commandStackEvents.get(0).getDetail());
-		Assert.assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
+		assertEquals(2, commandStackEvents.size());
+		assertEquals(null, commandStackEvents.get(0).getCommand());
+		assertTrue(commandStackEvents.get(0).isPreChangeEvent());
+		assertFalse(commandStackEvents.get(0).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(0).getSource());
+		assertEquals(CommandStack.PRE_FLUSH, commandStackEvents.get(0).getDetail());
+		assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
+		assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
 
-		Assert.assertEquals(null, commandStackEvents.get(1).getCommand());
-		Assert.assertFalse(commandStackEvents.get(1).isPreChangeEvent());
-		Assert.assertTrue(commandStackEvents.get(1).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(1).getSource());
-		Assert.assertEquals(CommandStack.POST_FLUSH, commandStackEvents.get(1).getDetail());
-		Assert.assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
+		assertEquals(null, commandStackEvents.get(1).getCommand());
+		assertFalse(commandStackEvents.get(1).isPreChangeEvent());
+		assertTrue(commandStackEvents.get(1).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(1).getSource());
+		assertEquals(CommandStack.POST_FLUSH, commandStackEvents.get(1).getDetail());
+		assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
+		assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
 
 		// test mark save location event
 		commandStackEvents.clear();
-		Assert.assertEquals(0, commandStackEvents.size());
+		assertEquals(0, commandStackEvents.size());
 		stack.redo();
 		stack.markSaveLocation();
 
-		Assert.assertEquals(2, commandStackEvents.size());
-		Assert.assertEquals(null, commandStackEvents.get(0).getCommand());
-		Assert.assertTrue(commandStackEvents.get(0).isPreChangeEvent());
-		Assert.assertFalse(commandStackEvents.get(0).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(0).getSource());
-		Assert.assertEquals(CommandStack.PRE_MARK_SAVE, commandStackEvents.get(0).getDetail());
-		Assert.assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
+		assertEquals(2, commandStackEvents.size());
+		assertEquals(null, commandStackEvents.get(0).getCommand());
+		assertTrue(commandStackEvents.get(0).isPreChangeEvent());
+		assertFalse(commandStackEvents.get(0).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(0).getSource());
+		assertEquals(CommandStack.PRE_MARK_SAVE, commandStackEvents.get(0).getDetail());
+		assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
+		assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
 
-		Assert.assertEquals(null, commandStackEvents.get(1).getCommand());
-		Assert.assertFalse(commandStackEvents.get(1).isPreChangeEvent());
-		Assert.assertTrue(commandStackEvents.get(1).isPostChangeEvent());
-		Assert.assertEquals(stack, commandStackEvents.get(1).getSource());
-		Assert.assertEquals(CommandStack.POST_MARK_SAVE, commandStackEvents.get(1).getDetail());
-		Assert.assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
-		Assert.assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
+		assertEquals(null, commandStackEvents.get(1).getCommand());
+		assertFalse(commandStackEvents.get(1).isPreChangeEvent());
+		assertTrue(commandStackEvents.get(1).isPostChangeEvent());
+		assertEquals(stack, commandStackEvents.get(1).getSource());
+		assertEquals(CommandStack.POST_MARK_SAVE, commandStackEvents.get(1).getDetail());
+		assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
+		assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
 
 	}
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
@@ -6,11 +6,14 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.EventObject;
 import java.util.List;
 
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.commands.CommandStackEvent;
+import org.eclipse.gef.commands.CommandStackEventListener;
+import org.eclipse.gef.commands.CommandStackListener;
 
 import org.junit.Test;
 
@@ -138,5 +141,35 @@ public class CommandStackTest {
 		assertEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.PRE_MASK);
 		assertNotEquals(0, commandStackEvents.get(1).getDetail() & CommandStack.POST_MASK);
 
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	public void testConcurrentModification() {
+		CommandStack stack = new CommandStack();
+		CommandStackEventListener listener = new CommandStackEventListener() {
+			@Override
+			public void stackChanged(CommandStackEvent event) {
+				stack.removeCommandStackEventListener(this);
+			}
+		};
+		stack.addCommandStackEventListener(listener);
+		stack.execute(new Command() {
+		});
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
+	public void testConcurrentModification2() {
+		CommandStack stack = new CommandStack();
+		CommandStackListener listener = new CommandStackListener() {
+			@Override
+			public void commandStackChanged(EventObject event) {
+				stack.removeCommandStackListener(this);
+			}
+		};
+		stack.addCommandStackListener(listener);
+		stack.execute(new Command() {
+		});
 	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStack.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStack.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.EventObject;
 import java.util.List;
 import java.util.Stack;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * An implementation of a command stack. A stack manages the executing, undoing,
@@ -125,7 +126,7 @@ public class CommandStack {
 	 */
 	public static final int PRE_MASK = PRE_EXECUTE | PRE_UNDO | PRE_REDO | PRE_FLUSH | PRE_MARK_SAVE;
 
-	private final List<CommandStackEventListener> eventListeners = new ArrayList<>();
+	private final List<CommandStackEventListener> eventListeners = new CopyOnWriteArrayList<>();
 
 	/**
 	 * The list of {@link CommandStackListener}s.
@@ -134,7 +135,7 @@ public class CommandStack {
 	 *             {@link #notifyListeners()}
 	 */
 	@Deprecated
-	protected List<CommandStackListener> listeners = new ArrayList<>();
+	protected List<CommandStackListener> listeners = new CopyOnWriteArrayList<>();
 
 	private final Stack<Command> redoable = new Stack<>();
 


### PR DESCRIPTION
Use a CopyOnWriteArrayList instead of a plain ArrayList for storing the registered listeners. Adding or removing from this list always results in a fresh copy of the underlying array, avoiding concurrent modification.

Assuming that the number of times an event is fired far outweighs the times a listener is added and/or removed, this should be more efficient than creating a copy of the listeners, whenever the notify method is called.

Resolves https://github.com/eclipse/gef-classic/issues/454