### PR TITLE
Fix: Marquee Selection Tool causes unresponsive UI

### DIFF
--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/FlowDiagramTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/swtbot/FlowDiagramTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.gef.test.swtbot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -21,6 +22,7 @@ import java.util.List;
 
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditPart;
 import org.eclipse.swtbot.eclipse.gef.finder.widgets.SWTBotGefEditor;
+import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 
 import org.junit.Test;
 
@@ -104,6 +106,22 @@ public class FlowDiagramTests extends AbstractSWTBotTests {
 
 		bot.toolbarButtonWithTooltip("Redo Delete").click();
 		assertNull(editor.getEditPart("Sleep....."));
+	}
+
+	/**
+	 * Checks whether one or more elements can be selected with the marquee
+	 * selection tool. Note that the current viewer is null at the start of this
+	 * test, as it is only set when the cursor is moved inside the editor.
+	 *
+	 * @see <a href="https://github.com/eclipse/gef-classic/issues/466">here</a>
+	 */
+	@Test
+	public void testMarqueeSelection() {
+		SWTBotGefEditor editor = bot.gefEditor("GEF Flow Example");
+		editor.activateTool("Marquee");
+
+		UIThreadRunnable.syncExec(() -> editor.drag(0, 0, 500, 500));
+		assertFalse("At least one edit part should be selected", editor.selectedEditParts().isEmpty());
 	}
 
 	@Override

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -441,7 +441,7 @@ public class MarqueeSelectionTool extends AbstractTool {
 	 */
 	@Override
 	protected boolean handleButtonDown(int button) {
-		if (!isCurrentViewerGraphical()) {
+		if (!isViewerGraphical(getCurrentViewer())) {
 			return true;
 		}
 		if (button != 1) {
@@ -677,11 +677,11 @@ public class MarqueeSelectionTool extends AbstractTool {
 	 */
 	@Override
 	protected boolean isViewerImportant(EditPartViewer viewer) {
-		return isCurrentViewerGraphical();
+		return isViewerGraphical(viewer);
 	}
 
-	private boolean isCurrentViewerGraphical() {
-		return getCurrentViewer() instanceof GraphicalViewer;
+	private static boolean isViewerGraphical(EditPartViewer viewer) {
+		return viewer instanceof GraphicalViewer;
 	}
 
 	/**


### PR DESCRIPTION
This commit partially reverts d94c624c8cd5b92b0568ac416bc400d68fe0ed7a. When e.g. moving the mouse cursor out and back in the editor, the tool is not properly reactivated.

Reason being that this only happens when the currently selected editor is graphical viewer. But because the editor is still null (as it is set to null when leaving the editor), this check always returns false.

The change was seemingly done as an optimization and is not relevant for the actual commit. So it should be save to rroll it back.

Resolves https://github.com/eclipse/gef-classic/issues/466