### PR TITLE
Update GitHub workflow actions to their latest versions

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           days-before-issue-stale: 90
           days-before-issue-close: 180

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,25 +14,25 @@ jobs:
     runs-on: ${{ matrix.os }} 
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
         maven-version: 3.9.3
     - name: Build with Maven
-      uses: coactions/setup-xvfb@v1
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
       with:
        run: >- 
         mvn -V -B -fae -ntp clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: test-results-${{ matrix.os }}-java${{ matrix.java }}
         if-no-files-found: error

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
            done
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@30eadd5010312f995f0d3b3cff7fe2984f69409e # v2.16.1
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           files: "artifacts/**/*.xml"


### PR DESCRIPTION
If a version only contains the major version, Dependabot ignores any minor or micro releases. Furthermore, by using the commit hash instead of the version, we decrease the risk of supply-chain attacks, as tags aren't immutable and malicious user may re-tag a release containing harmful content.

Resolves https://github.com/eclipse/gef-classic/issues/471