### PR TITLE
Revert "Force repaint in NativeGraphicsSource to fix broken animation"

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Animation.java
@@ -251,7 +251,7 @@ public class Animation {
 	 * @since 3.2
 	 */
 	public static void run(int duration) {
-		if (state == 0 || state == PLAYBACK) {
+		if (state == 0) {
 			return;
 		}
 		try {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/NativeGraphicsSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2024 IBM Corporation and others.
+ * Copyright (c) 2005, 2010 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -56,9 +56,6 @@ public final class NativeGraphicsSource implements GraphicsSource {
 
 		// canvas.update();
 
-		// canvas.update() paints too much and only works on Windows. Use
-		// readAndDispatch() to only paint the redraw() event.
-		canvas.getDisplay().readAndDispatch();
 		return null;
 	}
 

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
@@ -129,7 +129,7 @@ public abstract class AbstractGraphTest {
 				robot = new GraphicalRobot(graph);
 				shell = graph.getShell();
 				// Wait for layout to be applied
-				waitEventLoop(10);
+				waitEventLoop(0);
 				// Run the actual test
 				statement.evaluate();
 			} catch (Throwable e) {

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
@@ -78,6 +78,7 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.geometry.Point;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -109,6 +110,7 @@ public class GraphSWTTests extends AbstractGraphTest {
 	 * @see <a href="https://github.com/eclipse/gef-classic/issues/376">here</a>
 	 */
 	@Test
+	@Ignore
 	@Snippet(type = AnimationSnippet.class)
 	public void testAnimationSnippet() {
 		AtomicInteger repaintCount = new AtomicInteger();


### PR DESCRIPTION
Because animations are drawn again, the SWTBot tests check the state of the editor before the animation has finished.
This reverts commit ee7f7eed4ed1544bd4ddc4ad92e8f3986e939947.