### PR TITLE
Fix errors in drag cursors when using high-DPI screens

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,10 +15,11 @@ package org.eclipse.gef;
 import org.eclipse.swt.graphics.Cursor;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.core.runtime.Platform;
+
 import org.eclipse.draw2d.Cursors;
 
 import org.eclipse.gef.internal.Internal;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 
 /**
  * A shared collection of Cursors.
@@ -44,8 +45,6 @@ public class SharedCursors extends Cursors {
 	 */
 	public static final Cursor CURSOR_TREE_MOVE;
 
-	private static int deviceZoom = -1;
-
 	static {
 		CURSOR_PLUG = createCursor("icons/plug-cursor.png"); //$NON-NLS-1$
 		CURSOR_PLUG_NOT = createCursor("icons/plugnot-cursor.png"); //$NON-NLS-1$
@@ -55,26 +54,8 @@ public class SharedCursors extends Cursors {
 
 	private static Cursor createCursor(String sourceName) {
 		ImageDescriptor src = ImageDescriptor.createFromFile(Internal.class, sourceName);
-		return new Cursor(null, src.getImageData(getDeviceZoom()), 0, 0);
-	}
-
-	private static int getDeviceZoom() {
-		if (deviceZoom == -1) {
-			deviceZoom = 100; // default value
-			String deviceZoomProperty = System.getProperty("org.eclipse.swt.internal.deviceZoom"); //$NON-NLS-1$
-			if (deviceZoomProperty != null) {
-				try {
-					deviceZoom = Integer.parseInt(deviceZoomProperty);
-				} catch (NumberFormatException ex) {
-					// if the property can not be parsed we keep the default 100% zoom level
-				}
-			}
-		}
-		// On Mac and Linux X11 ImageData for cursors should always be created with 100% device zoom 
-		return Platform.getOS().equals(Platform.OS_MACOSX) ||
-				(Platform.getOS().equals(Platform.OS_LINUX) && "x11".equalsIgnoreCase(System.getenv("XDG_SESSION_TYPE"))) //$NON-NLS-1$ //$NON-NLS-2$
-				? 100 
-				: deviceZoom;
+		int deviceZoom = InternalGEFPlugin.getOrDefaultDeviceZoom();
+		return new Cursor(null, InternalGEFPlugin.scaledImageData(src, deviceZoom), 0, 0);
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
@@ -13,6 +13,11 @@
 
 package org.eclipse.gef.internal;
 
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -67,4 +72,43 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 		super.stop(context);
 	}
 
+	/**
+	 * Convenience method for getting the current zoom level of the active device.If
+	 * on MacOS or Linux (x11 window system) or if the device zoom couldn't
+	 * otherwise be determined, this method returns {@code 100} as default value.
+	 */
+	public static int getOrDefaultDeviceZoom() {
+		// On Mac and Linux X11 ImageData for cursors should always be created with 100%
+		// device zoom
+		if (Platform.getOS().equals(Platform.OS_MACOSX) || (Platform.getOS().equals(Platform.OS_LINUX)
+				&& "x11".equalsIgnoreCase(System.getenv("XDG_SESSION_TYPE")))) { //$NON-NLS-1$//$NON-NLS-2$
+			return 100;
+		}
+		String deviceZoom = System.getProperty("org.eclipse.swt.internal.deviceZoom", "100"); //$NON-NLS-1$ //$NON-NLS-2$
+		try {
+			return Integer.parseInt(deviceZoom);
+		} catch (NumberFormatException e) {
+			return 100;
+		}
+	}
+
+	/**
+	 * Convenience method to get the image data for a given zoom level. If no image
+	 * for the requested zoom level exists, the image data may be an auto-scaled
+	 * version of the native image and may look blurred or mangled.
+	 */
+	public static ImageData scaledImageData(ImageDescriptor descriptor, int zoom) {
+		// Default case: Image in matching resolution has been found
+		ImageData data = descriptor.getImageData(zoom);
+		if (data != null) {
+			return data;
+		}
+		// Otherwise artifically scale the image
+		Image image = descriptor.createImage();
+		try {
+			return image.getImageData(zoom);
+		} finally {
+			image.dispose();
+		}
+	}
 }


### PR DESCRIPTION
The cursors used in the flyout palette only exist for the default 100%. If a system is using a higher zoom level, the creation of those cursors fails with an IllegalArgumentException. Instead, we should scale the cursor image to match the current level.

Instead of reading the zoom level only once, it is now calculated dynamically, as the zoom may change depending on the display or because it has been changed. The methods for handling this case have also been moved from the SharedCursors class to the InternalGEFPlugin, so that it becomes available to the DragCursors class.

From there, we call asImageDataProvider() to convert the image descriptor to image data which internally scales the image via DPIUtil magic, if necessary.

See https://github.com/eclipse/gef-classic/issues/464