### PR TITLE
Mark Draw2D Cursors class as deprecated and for-removal

### DIFF
--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/scrollpane/InternalFrame.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/scrollpane/InternalFrame.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2023 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,11 +12,10 @@
  *******************************************************************************/
 package org.eclipse.draw2d.examples.scrollpane;
 
-import org.eclipse.swt.graphics.Cursor;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.CompoundBorder;
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProvider;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.LabeledContainer;
 import org.eclipse.draw2d.LineBorder;
@@ -123,42 +122,42 @@ public class InternalFrame extends LabeledContainer {
 			}
 			position = getClientArea().getCopy().shrink(4, 4).getPosition(mouseLocation);
 			move = false;
-			Cursor newCursor = null;
+			CursorProvider newCursor = null;
 
 			switch (position) {
 			case PositionConstants.NONE:
 				break;
 			case PositionConstants.SOUTH_EAST:
-				newCursor = Cursors.SIZESE;
+				newCursor = CursorProviders.SIZESE;
 				break;
 			case PositionConstants.SOUTH:
-				newCursor = Cursors.SIZES;
+				newCursor = CursorProviders.SIZES;
 				break;
 			case PositionConstants.EAST:
-				newCursor = Cursors.SIZEE;
+				newCursor = CursorProviders.SIZEE;
 				break;
 			case PositionConstants.NORTH_EAST:
-				newCursor = Cursors.SIZENE;
+				newCursor = CursorProviders.SIZENE;
 				break;
 			case PositionConstants.NORTH_WEST:
-				newCursor = Cursors.SIZENW;
+				newCursor = CursorProviders.SIZENW;
 				break;
 			case PositionConstants.SOUTH_WEST:
-				newCursor = Cursors.SIZESW;
+				newCursor = CursorProviders.SIZESW;
 				break;
 			case PositionConstants.NORTH:
 				if (mouseLocation.y > (getBounds().y + getInsets().left)) {
 					// Special case: MOVE and NOT RESIZE
 					move = true;
 				} else {
-					newCursor = Cursors.SIZEN;
+					newCursor = CursorProviders.SIZEN;
 				}
 				break;
 			case PositionConstants.WEST:
-				newCursor = Cursors.SIZEW;
+				newCursor = CursorProviders.SIZEW;
 				break;
 			}
-			setCursor(newCursor);
+			setCursorProvider(newCursor);
 		}
 
 		@Override
@@ -183,7 +182,7 @@ public class InternalFrame extends LabeledContainer {
 
 		@Override
 		public void mouseExited(MouseEvent me) {
-			setCursor(null);
+			setCursorProvider((CursorProvider) null);
 		}
 	}
 

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FigurePaintingTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/FigurePaintingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -289,12 +289,12 @@ public class FigurePaintingTest extends BaseTestCase {
 		actualLogger.assertEmpty();
 		//
 		// check invoke updateCursor() during setCursor()
-		testFigure.setCursor(null);
+		testFigure.setCursorProvider(null);
 		expectedLogger.log("updateCursor()");
 		actualLogger.assertEquals(expectedLogger);
 		//
 		// check not invoke updateCursor() during setCursor() if cursor not change
-		testFigure.setCursor(null);
+		testFigure.setCursorProvider(null);
 		actualLogger.assertEmpty();
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/CursorProvider.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/CursorProvider.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d;
+
+import java.util.function.Supplier;
+
+import org.eclipse.swt.graphics.Cursor;
+
+/**
+ * This interface is intended to be used by Draw2D to handle dynamic DPI
+ * changes, requiring a refresh of the underlying cursor resource. A call to
+ * {@link #get()} must always return a cursor object whose resolution matches
+ * the current display zoom.
+ *
+ * @since 3.17
+ * @noextend This interface is not intended to be extended by clients.
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface CursorProvider extends Supplier<Cursor> {
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/CursorProviders.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/CursorProviders.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.draw2d;
+
+import org.eclipse.swt.SWT;
+
+import org.eclipse.draw2d.internal.SystemCursorProvider;
+
+/**
+ * A collection of DPI-aware cursors.
+ *
+ * @since 3.17
+ */
+public class CursorProviders {
+
+	/**
+	 * Returns the cursor corresponding to the given direction, defined in
+	 * {@link PositionConstants}. Note that
+	 * {@link #getDirectionalCursor(int, boolean)} should be used for applications
+	 * which want to run properly when running in a mirrored environment. The
+	 * behavior is the same as calling {@link #getDirectionalCursor(int, boolean)
+	 * getDirectionalCursor(direction, false)}.
+	 *
+	 * @param direction the relative direction of the desired cursor
+	 * @return The appropriate directional cursor
+	 */
+	public static CursorProvider getDirectionalCursor(int direction) {
+		return getDirectionalCursor(direction, false);
+	}
+
+	/**
+	 * Returns the cursor corresponding to the given direction and mirroring. The
+	 * direction must be one of:
+	 * <UL>
+	 * <LI>{@link PositionConstants#NORTH}
+	 * <LI>{@link PositionConstants#SOUTH}
+	 * <LI>{@link PositionConstants#EAST}
+	 * <LI>{@link PositionConstants#WEST}
+	 * <LI>{@link PositionConstants#NORTH_EAST}
+	 * <LI>{@link PositionConstants#NORTH_WEST}
+	 * <LI>{@link PositionConstants#SOUTH_EAST}
+	 * <LI>{@link PositionConstants#SOUTH_WEST}
+	 * </UL>
+	 * <P>
+	 * The behavior is undefined for other values. If <code>isMirrored</code> is set
+	 * to <code>true</code>, EAST and WEST will be inverted.
+	 *
+	 * @param direction  the relative direction of the desired cursor
+	 * @param isMirrored <code>true</code> if EAST and WEST should be inverted
+	 * @return The appropriate directional cursor
+	 */
+	public static CursorProvider getDirectionalCursor(int direction, boolean isMirrored) {
+		if (isMirrored && (direction & PositionConstants.EAST_WEST) != 0) {
+			direction = direction ^ PositionConstants.EAST_WEST;
+		}
+		switch (direction) {
+		case PositionConstants.NORTH:
+			return SIZEN;
+		case PositionConstants.SOUTH:
+			return SIZES;
+		case PositionConstants.EAST:
+			return SIZEE;
+		case PositionConstants.WEST:
+			return SIZEW;
+		case PositionConstants.SOUTH_EAST:
+			return SIZESE;
+		case PositionConstants.SOUTH_WEST:
+			return SIZESW;
+		case PositionConstants.NORTH_EAST:
+			return SIZENE;
+		case PositionConstants.NORTH_WEST:
+			return SIZENW;
+		default:
+			break;
+		}
+		return null;
+	}
+
+	/**
+	 * @see SWT#CURSOR_ARROW
+	 */
+	public static final CursorProvider ARROW;
+	/**
+	 * @see SWT#CURSOR_SIZEN
+	 */
+	public static final CursorProvider SIZEN;
+	/**
+	 * @see SWT#CURSOR_SIZENE
+	 */
+	public static final CursorProvider SIZENE;
+	/**
+	 * @see SWT#CURSOR_SIZEE
+	 */
+	public static final CursorProvider SIZEE;
+	/**
+	 * @see SWT#CURSOR_SIZESE
+	 */
+	public static final CursorProvider SIZESE;
+	/**
+	 * @see SWT#CURSOR_SIZES
+	 */
+	public static final CursorProvider SIZES;
+	/**
+	 * @see SWT#CURSOR_SIZESW
+	 */
+	public static final CursorProvider SIZESW;
+	/**
+	 * @see SWT#CURSOR_SIZEW
+	 */
+	public static final CursorProvider SIZEW;
+	/**
+	 * @see SWT#CURSOR_SIZENW
+	 */
+	public static final CursorProvider SIZENW;
+	/**
+	 * @see SWT#CURSOR_APPSTARTING
+	 */
+	public static final CursorProvider APPSTARTING;
+	/**
+	 * @see SWT#CURSOR_CROSS
+	 */
+	public static final CursorProvider CROSS;
+	/**
+	 * @see SWT#CURSOR_HAND
+	 */
+	public static final CursorProvider HAND;
+	/**
+	 * @see SWT#CURSOR_HELP
+	 */
+	public static final CursorProvider HELP;
+	/**
+	 * @see SWT#CURSOR_IBEAM
+	 */
+	public static final CursorProvider IBEAM;
+	/**
+	 * @see SWT#CURSOR_NO
+	 */
+	public static final CursorProvider NO;
+	/**
+	 * @see SWT#CURSOR_SIZEALL
+	 */
+	public static final CursorProvider SIZEALL;
+	/**
+	 * @see SWT#CURSOR_SIZENESW
+	 */
+	public static final CursorProvider SIZENESW;
+	/**
+	 * @see SWT#CURSOR_SIZENWSE
+	 */
+	public static final CursorProvider SIZENWSE;
+	/**
+	 * @see SWT#CURSOR_SIZEWE
+	 */
+	public static final CursorProvider SIZEWE;
+	/**
+	 * @see SWT#CURSOR_SIZENS
+	 */
+	public static final CursorProvider SIZENS;
+	/**
+	 * @see SWT#CURSOR_UPARROW
+	 */
+	public static final CursorProvider UPARROW;
+	/**
+	 * @see SWT#CURSOR_WAIT
+	 */
+	public static final CursorProvider WAIT;
+
+	static {
+		ARROW = new SystemCursorProvider(SWT.CURSOR_ARROW);
+		SIZEN = new SystemCursorProvider(SWT.CURSOR_SIZEN);
+		SIZENE = new SystemCursorProvider(SWT.CURSOR_SIZENE);
+		SIZEE = new SystemCursorProvider(SWT.CURSOR_SIZEE);
+		SIZESE = new SystemCursorProvider(SWT.CURSOR_SIZESE);
+		SIZES = new SystemCursorProvider(SWT.CURSOR_SIZES);
+		SIZESW = new SystemCursorProvider(SWT.CURSOR_SIZESW);
+		SIZEW = new SystemCursorProvider(SWT.CURSOR_SIZEW);
+		SIZENW = new SystemCursorProvider(SWT.CURSOR_SIZENW);
+		SIZENS = new SystemCursorProvider(SWT.CURSOR_SIZENS);
+		SIZEWE = new SystemCursorProvider(SWT.CURSOR_SIZEWE);
+		APPSTARTING = new SystemCursorProvider(SWT.CURSOR_APPSTARTING);
+		CROSS = new SystemCursorProvider(SWT.CURSOR_CROSS);
+		HAND = new SystemCursorProvider(SWT.CURSOR_HAND);
+		HELP = new SystemCursorProvider(SWT.CURSOR_HELP);
+		IBEAM = new SystemCursorProvider(SWT.CURSOR_IBEAM);
+		NO = new SystemCursorProvider(SWT.CURSOR_NO);
+		SIZEALL = new SystemCursorProvider(SWT.CURSOR_SIZEALL);
+		SIZENESW = new SystemCursorProvider(SWT.CURSOR_SIZENESW);
+		SIZENWSE = new SystemCursorProvider(SWT.CURSOR_SIZENWSE);
+		UPARROW = new SystemCursorProvider(SWT.CURSOR_UPARROW);
+		WAIT = new SystemCursorProvider(SWT.CURSOR_WAIT);
+	}
+
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Cursors.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Cursors.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,15 @@ import org.eclipse.swt.widgets.Display;
 
 /**
  * A collection of cursors.
+ *
+ * @deprecated Using static cursors is fundamentally flawed when considering
+ *             dynamic DPI changes. The static cursors created by this class are
+ *             created with respect to the current display zoom. Those objects
+ *             are not updated, should this value change at a later time.
+ *             Clients need to listen to the {@link SWT#ZoomChanged} event and
+ *             update their cursors via {@link CursorProviders}.
  */
+@Deprecated(since = "3.17", forRemoval = true)
 public class Cursors {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -34,6 +34,7 @@ import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.draw2d.internal.WrappedCursorProvider;
 
 /**
  * The base implementation for graphical figures.
@@ -76,7 +77,7 @@ public class Figure implements IFigure {
 
 	private IFigure parent;
 	private IClippingStrategy clippingStrategy = null;
-	private Cursor cursor;
+	private CursorProvider cursor;
 
 	private PropertyChangeSupport propertyListeners;
 	private final EventListenerList eventListeners = new EventListenerList();
@@ -680,7 +681,7 @@ public class Figure implements IFigure {
 		if (cursor == null && getParent() != null) {
 			return getParent().getCursor();
 		}
-		return cursor;
+		return cursor != null ? cursor.get() : null;
 	}
 
 	/**
@@ -1730,7 +1731,12 @@ public class Figure implements IFigure {
 	 */
 	@Override
 	public void setCursor(Cursor cursor) {
-		if (this.cursor == cursor) {
+		setCursorProvider(new WrappedCursorProvider(cursor));
+	}
+
+	@Override
+	public void setCursorProvider(CursorProvider cursor) {
+		if (Objects.equals(this.cursor, cursor)) {
 			return;
 		}
 		this.cursor = cursor;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -886,8 +886,18 @@ public interface IFigure {
 	 * Sets the cursor.
 	 *
 	 * @param cursor The new cursor
+	 * @deprecated Use {@link #setCursorProvider(CursorProvider)} instead.
 	 */
+	@Deprecated(since = "3.17", forRemoval = true)
 	void setCursor(Cursor cursor);
+
+	/**
+	 * Sets the cursor.
+	 *
+	 * @param cursor The new cursor
+	 * @since 3.17
+	 */
+	void setCursorProvider(CursorProvider cursor);
 
 	/**
 	 * Sets this IFigure to be enabled.

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/SystemCursorProvider.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/SystemCursorProvider.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.internal;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.draw2d.CursorProvider;
+
+/**
+ * Convenience class for creating providers over system cursors.
+ */
+public class SystemCursorProvider implements CursorProvider {
+	private final int which;
+
+	public SystemCursorProvider(int which) {
+		this.which = which;
+	}
+
+	/**
+	 * Returns the matching standard platform {@link Cursor} for the given constant,
+	 * which should be one of the {@link Cursor} constants specified in class
+	 * {@link SWT}. This {@link Cursor} should not be free'd because it was
+	 * allocated by the system, not the application. A value of {@code null} will be
+	 * returned if the supplied constant is not an {@link SWT} cursor constant.
+	 * Note: This method should be invoked from within the UI thread if possible, as
+	 * it will attempt to create a new Display instance, if not!
+	 *
+	 * @return the corresponding {@link Cursor} or {@code null}
+	 */
+	@Override
+	public Cursor get() {
+		Display display = Display.getCurrent();
+		if (display != null) {
+			return display.getSystemCursor(which);
+		}
+		display = Display.getDefault();
+		return display.syncCall(() -> Display.getCurrent().getSystemCursor(which));
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/WrappedCursorProvider.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/WrappedCursorProvider.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.internal;
+
+import java.util.Objects;
+
+import org.eclipse.swt.graphics.Cursor;
+
+import org.eclipse.draw2d.CursorProvider;
+
+/**
+ * Convenience class convert a cursor into a cursor provider. Use to bridge the
+ * gap between the methods that still expect a {@link Cursor} and methods that
+ * expect a {@link CursorProvider}.
+ */
+public class WrappedCursorProvider implements CursorProvider {
+	private final Cursor cursor;
+
+	public WrappedCursorProvider(Cursor cursor) {
+		this.cursor = cursor;
+	}
+
+	@Override
+	public Cursor get() {
+		return cursor;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof WrappedCursorProvider other) {
+			return Objects.equals(cursor, other.cursor);
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(cursor);
+	}
+}

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/SelectionRangeDragTracker.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/SelectionRangeDragTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@ package org.eclipse.gef.examples.text.tools;
 
 import org.eclipse.swt.graphics.Cursor;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.tools.SimpleDragTracker;
@@ -57,7 +57,7 @@ public class SelectionRangeDragTracker extends SimpleDragTracker {
 
 	@Override
 	protected Cursor calculateCursor() {
-		return Cursors.IBEAM;
+		return CursorProviders.IBEAM.get();
 	}
 
 	/**

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/tools/TextTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,7 +28,7 @@ import org.eclipse.swt.widgets.Caret;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.UpdateListener;
 import org.eclipse.draw2d.UpdateManager;
@@ -132,7 +132,7 @@ public class TextTool extends SelectionTool implements StyleProvider {
 		EditPart target = getTargetEditPart();
 		if (target instanceof TextEditPart textTarget) {
 			if (textTarget.acceptsCaret()) {
-				return Cursors.IBEAM;
+				return CursorProviders.IBEAM.get();
 			}
 		}
 		return super.calculateCursor();

--- a/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
@@ -25,6 +25,7 @@ import org.eclipse.gef.internal.Internal;
  *
  * @since 2.0
  */
+@SuppressWarnings("removal")
 public class SharedCursors extends Cursors {
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/NonResizableEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.draw2d.ColorConstants;
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.FocusBorder;
 import org.eclipse.draw2d.Graphics;
@@ -30,7 +30,6 @@ import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.Handle;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
-import org.eclipse.gef.SharedCursors;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.handles.AbstractHandle;
 import org.eclipse.gef.handles.HandleBounds;
@@ -105,11 +104,11 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	protected void createDragHandle(List handles, int direction) {
 		if (isDragAllowed()) {
 			// display 'resize' handles to allow dragging (drag tracker)
-			NonResizableHandleKit.addHandle(getHost(), handles, direction, getDragTracker(), SharedCursors.SIZEALL);
+			NonResizableHandleKit.addHandle(getHost(), handles, direction, getDragTracker(), CursorProviders.SIZEALL);
 		} else {
 			// display 'resize' handles to indicate selection only (selection
 			// tracker)
-			NonResizableHandleKit.addHandle(getHost(), handles, direction, getSelectTracker(), SharedCursors.ARROW);
+			NonResizableHandleKit.addHandle(getHost(), handles, direction, getSelectTracker(), CursorProviders.ARROW);
 		}
 	}
 
@@ -144,10 +143,10 @@ public class NonResizableEditPolicy extends SelectionHandlesEditPolicy {
 	protected void createMoveHandle(List handles) {
 		if (isDragAllowed()) {
 			// display 'move' handle to allow dragging
-			ResizableHandleKit.addMoveHandle(getHost(), handles, getDragTracker(), Cursors.SIZEALL);
+			ResizableHandleKit.addMoveHandle(getHost(), handles, getDragTracker(), CursorProviders.SIZEALL);
 		} else {
 			// display 'move' handle only to indicate selection
-			ResizableHandleKit.addMoveHandle(getHost(), handles, getSelectTracker(), SharedCursors.ARROW);
+			ResizableHandleKit.addMoveHandle(getHost(), handles, getSelectTracker(), CursorProviders.ARROW);
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ResizableEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/ResizableEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@ package org.eclipse.gef.editpolicies;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.PositionConstants;
 
 import org.eclipse.gef.Handle;
@@ -90,7 +90,7 @@ public class ResizableEditPolicy extends NonResizableEditPolicy {
 	protected void createResizeHandle(List handles, int direction) {
 		if ((resizeDirections & direction) == direction) {
 			ResizableHandleKit.addHandle(getHost(), handles, direction, getResizeTracker(direction),
-					Cursors.getDirectionalCursor(direction, getHostFigure().isMirrored()));
+					CursorProviders.getDirectionalCursor(direction, getHostFigure().isMirrored()));
 		} else {
 			// display 'resize' handle to allow dragging or indicate selection
 			// only

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointCreationHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointCreationHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.gef.handles;
 
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Locator;
 import org.eclipse.draw2d.MidpointLocator;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -19,7 +20,6 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.RequestConstants;
-import org.eclipse.gef.SharedCursors;
 import org.eclipse.gef.tools.ConnectionBendpointTracker;
 
 /**
@@ -28,7 +28,7 @@ import org.eclipse.gef.tools.ConnectionBendpointTracker;
 public class BendpointCreationHandle extends BendpointHandle {
 
 	{
-		setCursor(SharedCursors.SIZEALL);
+		setCursorProvider(CursorProviders.SIZEALL);
 		setPreferredSize(new Dimension(DEFAULT_HANDLE_SIZE - 2, DEFAULT_HANDLE_SIZE - 2));
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointMoveHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/BendpointMoveHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,12 +13,12 @@
 package org.eclipse.gef.handles;
 
 import org.eclipse.draw2d.BendpointLocator;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Locator;
 
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.RequestConstants;
-import org.eclipse.gef.SharedCursors;
 import org.eclipse.gef.tools.ConnectionBendpointTracker;
 
 /**
@@ -27,7 +27,7 @@ import org.eclipse.gef.tools.ConnectionBendpointTracker;
 public class BendpointMoveHandle extends BendpointHandle {
 
 	{
-		setCursor(SharedCursors.SIZEALL);
+		setCursorProvider(CursorProviders.SIZEALL);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 import org.eclipse.draw2d.Connection;
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 
 /**
  * The base implementation for handles used with editparts whose figure is a
@@ -33,7 +33,7 @@ public abstract class ConnectionHandle extends SquareHandle implements PropertyC
 	 * Creates a new ConnectionHandle.
 	 */
 	public ConnectionHandle() {
-		setCursor(Cursors.CROSS);
+		setCursorProvider(CursorProviders.CROSS);
 	}
 
 	/**
@@ -45,9 +45,9 @@ public abstract class ConnectionHandle extends SquareHandle implements PropertyC
 	public ConnectionHandle(boolean fixed) {
 		setFixed(fixed);
 		if (fixed) {
-			setCursor(Cursors.NO);
+			setCursorProvider(CursorProviders.NO);
 		} else {
-			setCursor(Cursors.CROSS);
+			setCursorProvider(CursorProviders.CROSS);
 		}
 	}
 
@@ -109,9 +109,9 @@ public abstract class ConnectionHandle extends SquareHandle implements PropertyC
 	public void setFixed(boolean fixed) {
 		this.fixed = fixed;
 		if (fixed) {
-			setCursor(Cursors.NO);
+			setCursorProvider(CursorProviders.NO);
 		} else {
-			setCursor(Cursors.CROSS);
+			setCursorProvider(CursorProviders.CROSS);
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.gef.handles;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.Locator;
 import org.eclipse.draw2d.geometry.Point;
@@ -101,7 +101,7 @@ public class MoveHandle extends AbstractHandle {
 	protected void initialize() {
 		setOpaque(false);
 		setBorder(new LineBorder(1));
-		setCursor(Cursors.SIZEALL);
+		setCursorProvider(CursorProviders.SIZEALL);
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.gef.handles;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Locator;
 
 import org.eclipse.gef.EditPart;
@@ -61,7 +61,7 @@ public class NonResizableHandle extends MoveHandle {
 		setOpaque(false);
 		border = new CornerTriangleBorder(false);
 		setBorder(border);
-		setCursor(Cursors.SIZEALL);
+		setCursorProvider(CursorProviders.SIZEALL);
 		setDragTracker(new DragEditPartsTracker(getOwner()));
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandleKit.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandleKit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,12 +16,14 @@ import java.util.List;
 
 import org.eclipse.swt.graphics.Cursor;
 
+import org.eclipse.draw2d.CursorProvider;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.internal.WrappedCursorProvider;
 
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Handle;
-import org.eclipse.gef.SharedCursors;
 import org.eclipse.gef.tools.DragEditPartsTracker;
 
 /**
@@ -38,8 +40,26 @@ public class NonResizableHandleKit {
 	 * @param handles the List to add the four corner handles to
 	 * @param tracker the handles' DragTracker
 	 * @param cursor  the handles' Cursor
+	 * @deprecated Use
+	 *             {@link #addCornerHandles(GraphicalEditPart, List, DragTracker, CursorProvider)}
+	 *             instead.
 	 */
+	@Deprecated(since = "3.19", forRemoval = true)
 	public static void addCornerHandles(GraphicalEditPart part, List handles, DragTracker tracker, Cursor cursor) {
+		addCornerHandles(part, handles, tracker, new WrappedCursorProvider(cursor));
+	}
+
+	/**
+	 * Fills the given List with handles at each corner of a figure.
+	 *
+	 * @param part    the handles' GraphicalEditPart
+	 * @param handles the List to add the four corner handles to
+	 * @param tracker the handles' DragTracker
+	 * @param cursor  the handles' Cursor
+	 * @since 3.19
+	 */
+	public static void addCornerHandles(GraphicalEditPart part, List handles, DragTracker tracker,
+			CursorProvider cursor) {
 		handles.add(createHandle(part, PositionConstants.SOUTH_EAST, tracker, cursor));
 		handles.add(createHandle(part, PositionConstants.SOUTH_WEST, tracker, cursor));
 		handles.add(createHandle(part, PositionConstants.NORTH_WEST, tracker, cursor));
@@ -80,9 +100,29 @@ public class NonResizableHandleKit {
 	 * @param direction the integer constant from PositionConstants that refers to
 	 *                  the handle direction
 	 * @param cursor    the Cursor to use when hovering over this handle
+	 * @deprecated Use
+	 *             {@link #addHandle(GraphicalEditPart, List, int, DragTracker, CursorProvider)}
+	 *             instead.
 	 */
+	@Deprecated(since = "3.19", forRemoval = true)
 	public static void addHandle(GraphicalEditPart part, List handles, int direction, DragTracker tracker,
 			Cursor cursor) {
+		addHandle(part, handles, direction, tracker, new WrappedCursorProvider(cursor));
+	}
+
+	/**
+	 * Adds a single handle in the given direction to the given List.
+	 *
+	 * @param tracker   the DragTracker to assign to this handle
+	 * @param part      the owner GraphicalEditPart of the handle
+	 * @param handles   the List to add the handle to
+	 * @param direction the integer constant from PositionConstants that refers to
+	 *                  the handle direction
+	 * @param cursor    the Cursor to use when hovering over this handle
+	 * @since 3.19
+	 */
+	public static void addHandle(GraphicalEditPart part, List handles, int direction, DragTracker tracker,
+			CursorProvider cursor) {
 		handles.add(createHandle(part, direction, tracker, cursor));
 	}
 
@@ -93,6 +133,7 @@ public class NonResizableHandleKit {
 	 * @param handles the List to add the handles to
 	 * @deprecated
 	 */
+	@Deprecated
 	public static void addHandles(GraphicalEditPart part, List handles) {
 		addMoveHandle(part, handles);
 		addCornerHandles(part, handles);
@@ -136,14 +177,14 @@ public class NonResizableHandleKit {
 
 	static Handle createHandle(GraphicalEditPart owner, int direction) {
 		ResizeHandle handle = new ResizeHandle(owner, direction);
-		handle.setCursor(SharedCursors.SIZEALL);
+		handle.setCursorProvider(CursorProviders.SIZEALL);
 		handle.setDragTracker(new DragEditPartsTracker(owner));
 		return handle;
 	}
 
-	static Handle createHandle(GraphicalEditPart owner, int direction, DragTracker tracker, Cursor cursor) {
+	static Handle createHandle(GraphicalEditPart owner, int direction, DragTracker tracker, CursorProvider cursor) {
 		ResizeHandle handle = new ResizeHandle(owner, direction);
-		handle.setCursor(cursor);
+		handle.setCursorProvider(cursor);
 		handle.setDragTracker(tracker);
 		return handle;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ResizableHandleKit.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ResizableHandleKit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,9 @@ import java.util.List;
 
 import org.eclipse.swt.graphics.Cursor;
 
+import org.eclipse.draw2d.CursorProvider;
 import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.internal.WrappedCursorProvider;
 
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.GraphicalEditPart;
@@ -52,9 +54,30 @@ public class ResizableHandleKit {
 	 * @param direction the integer constant from PositionConstants that refers to
 	 *                  the handle direction
 	 * @param cursor    the Cursor to use when hovering over this handle
+	 * @deprecated Use
+	 *             {@link #addHandle(GraphicalEditPart, List, int, DragTracker, CursorProvider)}
+	 *             instead.
 	 */
+	@Deprecated(since = "3.19", forRemoval = true)
 	public static void addHandle(GraphicalEditPart part, List handles, int direction, DragTracker tracker,
 			Cursor cursor) {
+		addHandle(part, handles, direction, tracker, new WrappedCursorProvider(cursor));
+	}
+
+	/**
+	 * Adds a single handle in the given direction to the given List with the given
+	 * DragTracker
+	 *
+	 * @param tracker   the DragTracker to assign to this handle
+	 * @param part      the owner GraphicalEditPart of the handle
+	 * @param handles   the List to add the handle to
+	 * @param direction the integer constant from PositionConstants that refers to
+	 *                  the handle direction
+	 * @param cursor    the Cursor to use when hovering over this handle
+	 * @since 3.19
+	 */
+	public static void addHandle(GraphicalEditPart part, List handles, int direction, DragTracker tracker,
+			CursorProvider cursor) {
 		handles.add(createHandle(part, direction, tracker, cursor));
 	}
 
@@ -66,6 +89,7 @@ public class ResizableHandleKit {
 	 * @param handles the List to add the handles to
 	 * @deprecated
 	 */
+	@Deprecated
 	public static void addHandles(GraphicalEditPart part, List handles) {
 		addMoveHandle(part, handles);
 		addCornerAndSideHandles(part, handles);
@@ -97,9 +121,27 @@ public class ResizableHandleKit {
 	 * @param tracker the handles' DragTracker
 	 * @param cursor  the handles' Cursor
 	 * @since 3.7
+	 * @deprecated Use
+	 *             {@link #addCornerAndSideHandles(GraphicalEditPart, List, DragTracker, CursorProvider)}
+	 *             instead.
 	 */
+	@Deprecated(since = "3.19", forRemoval = true)
 	public static void addCornerAndSideHandles(GraphicalEditPart part, List handles, DragTracker tracker,
 			Cursor cursor) {
+		addCornerAndSideHandles(part, handles, tracker, new WrappedCursorProvider(cursor));
+	}
+
+	/**
+	 * Fills the given List with handles at each corner and side of a figure.
+	 *
+	 * @param part    the handles' GraphicalEditPart
+	 * @param handles the List to add the four corner handles to
+	 * @param tracker the handles' DragTracker
+	 * @param cursor  the handles' Cursor
+	 * @since 3.19
+	 */
+	public static void addCornerAndSideHandles(GraphicalEditPart part, List handles, DragTracker tracker,
+			CursorProvider cursor) {
 		handles.add(createHandle(part, PositionConstants.EAST, tracker, cursor));
 		handles.add(createHandle(part, PositionConstants.SOUTH_EAST, tracker, cursor));
 		handles.add(createHandle(part, PositionConstants.SOUTH, tracker, cursor));
@@ -128,8 +170,26 @@ public class ResizableHandleKit {
 	 * @param f       the GraphicalEditPart thatis the owner of the handles
 	 * @param handles the List to add the handles to
 	 * @param cursor  the Cursor to use when hovering over this handle
+	 * @deprecated Use
+	 *             {@link #addMoveHandle(GraphicalEditPart, List, DragTracker, CursorProvider)}
+	 *             instead.
 	 */
+	@Deprecated(since = "3.19", forRemoval = true)
 	public static void addMoveHandle(GraphicalEditPart f, List handles, DragTracker tracker, Cursor cursor) {
+		addMoveHandle(f, handles, tracker, new WrappedCursorProvider(cursor));
+	}
+
+	/**
+	 * Fills the given List with move borders with the given DragTracker at each
+	 * side of a figure.
+	 *
+	 * @param tracker the DragTracker to assign to this handle
+	 * @param f       the GraphicalEditPart thatis the owner of the handles
+	 * @param handles the List to add the handles to
+	 * @param cursor  the Cursor to use when hovering over this handle
+	 * @since 3.19
+	 */
+	public static void addMoveHandle(GraphicalEditPart f, List handles, DragTracker tracker, CursorProvider cursor) {
 		handles.add(moveHandle(f, tracker, cursor));
 	}
 
@@ -137,10 +197,10 @@ public class ResizableHandleKit {
 		return new ResizeHandle(owner, direction);
 	}
 
-	static Handle createHandle(GraphicalEditPart owner, int direction, DragTracker tracker, Cursor cursor) {
+	static Handle createHandle(GraphicalEditPart owner, int direction, DragTracker tracker, CursorProvider cursor) {
 		ResizeHandle handle = new ResizeHandle(owner, direction);
 		handle.setDragTracker(tracker);
-		handle.setCursor(cursor);
+		handle.setCursorProvider(cursor);
 		return handle;
 	}
 
@@ -161,11 +221,28 @@ public class ResizableHandleKit {
 	 * @param owner   the GraphicalEditPart that is the owner of the new MoveHandle
 	 * @return the new MoveHandle
 	 * @param cursor the Cursor to use when hovering over this handle
+	 * @deprecated Use
+	 *             {@link #moveHandle(GraphicalEditPart, DragTracker, CursorProvider)}
+	 *             instead.
 	 */
+	@Deprecated(since = "3.17", forRemoval = true)
 	public static Handle moveHandle(GraphicalEditPart owner, DragTracker tracker, Cursor cursor) {
+		return moveHandle(owner, tracker, new WrappedCursorProvider(cursor));
+	}
+
+	/**
+	 * Returns a new {@link MoveHandle} with the given owner and DragTracker.
+	 *
+	 * @param tracker the DragTracker to assign to this handle
+	 * @param owner   the GraphicalEditPart that is the owner of the new MoveHandle
+	 * @return the new MoveHandle
+	 * @param cursor the Cursor to use when hovering over this handle
+	 * @since 3.19
+	 */
+	public static Handle moveHandle(GraphicalEditPart owner, DragTracker tracker, CursorProvider cursor) {
 		MoveHandle moveHandle = new MoveHandle(owner);
 		moveHandle.setDragTracker(tracker);
-		moveHandle.setCursor(cursor);
+		moveHandle.setCursorProvider(cursor);
 		return moveHandle;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ResizeHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ResizeHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@ package org.eclipse.gef.handles;
 
 import org.eclipse.swt.graphics.Cursor;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Locator;
 
 import org.eclipse.gef.DragTracker;
@@ -41,7 +41,7 @@ public class ResizeHandle extends SquareHandle {
 	public ResizeHandle(GraphicalEditPart owner, int direction) {
 		setOwner(owner);
 		setLocator(new RelativeHandleLocator(owner.getFigure(), direction));
-		setCursor(Cursors.getDirectionalCursor(direction, owner.getFigure().isMirrored()));
+		setCursorProvider(CursorProviders.getDirectionalCursor(direction, owner.getFigure().isMirrored()));
 		cursorDirection = direction;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/DragGuidePolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/DragGuidePolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.gef.internal.ui.rulers;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
@@ -23,7 +24,6 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
-import org.eclipse.gef.SharedCursors;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.UnexecutableCommand;
 import org.eclipse.gef.editparts.ZoomManager;
@@ -229,7 +229,7 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 		if (isDeleteRequest(req)) {
 			getHostFigure().setVisible(false);
 			getGuideEditPart().getGuideLineFigure().setVisible(false);
-			getGuideEditPart().setCurrentCursor(SharedCursors.ARROW);
+			getGuideEditPart().setCurrentCursor(CursorProviders.ARROW);
 			eraseAttachedPartsFeedback(request);
 		} else {
 			int newPosition;
@@ -245,7 +245,7 @@ public class DragGuidePolicy extends GraphicalEditPolicy {
 				getGuideEditPart().updateLocationOfFigures(newPosition);
 				showAttachedPartsFeedback(req);
 			} else {
-				getGuideEditPart().setCurrentCursor(SharedCursors.NO);
+				getGuideEditPart().setCurrentCursor(CursorProviders.NO);
 				getGuideEditPart().updateLocationOfFigures(getGuideEditPart().getZoomedPosition());
 				eraseAttachedPartsFeedback(request);
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,8 @@ import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Cursor;
 
 import org.eclipse.draw2d.ColorConstants;
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProvider;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
@@ -51,7 +52,7 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 
 	private AccessibleEditPart accPart;
 	private GuideLineFigure guideLineFig;
-	private Cursor cursor = null;
+	private CursorProvider cursor = null;
 	private final ZoomListener zoomListener = zoom -> handleZoomChanged();
 
 	private final RulerChangeListener listener = new RulerChangeListener.Stub() {
@@ -180,7 +181,7 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 		if (cursor == null) {
 			return getFigure().getCursor();
 		}
-		return cursor;
+		return cursor.get();
 	}
 
 	/*
@@ -195,7 +196,7 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 			@Override
 			protected Cursor calculateCursor() {
 				if (isInState(STATE_INVALID)) {
-					return Cursors.NO;
+					return CursorProviders.NO.get();
 				}
 				return getCurrentCursor();
 			}
@@ -292,7 +293,7 @@ public class GuideEditPart extends AbstractGraphicalEditPart {
 		}
 	}
 
-	public void setCurrentCursor(Cursor c) {
+	public void setCurrentCursor(CursorProvider c) {
 		cursor = c;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/GuideFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,14 +13,13 @@
 package org.eclipse.gef.internal.ui.rulers;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FocusEvent;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
-
-import org.eclipse.gef.SharedCursors;
 
 /**
  * @author Pratik Shah
@@ -37,9 +36,9 @@ public class GuideFigure extends Figure {
 		horizontal = isHorizontal;
 		setBackgroundColor(ColorConstants.button);
 		if (horizontal) {
-			setCursor(SharedCursors.SIZENS);
+			setCursorProvider(CursorProviders.SIZENS);
 		} else {
-			setCursor(SharedCursors.SIZEWE);
+			setCursorProvider(CursorProviders.SIZEWE);
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerDragTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerDragTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@ import java.util.Iterator;
 
 import org.eclipse.swt.graphics.Cursor;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -95,9 +95,9 @@ public class RulerDragTracker extends SimpleDragTracker {
 			return super.getDefaultCursor();
 		}
 		if (isCreationValid()) {
-			return source.isHorizontal() ? Cursors.SIZEE : Cursors.SIZEN;
+			return source.isHorizontal() ? CursorProviders.SIZEE.get() : CursorProviders.SIZEN.get();
 		}
-		return Cursors.NO;
+		return CursorProviders.NO.get();
 	}
 
 	@Override

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ConnectionEndpointTracker.java
@@ -21,7 +21,7 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Cursor;
 
 import org.eclipse.draw2d.Connection;
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
@@ -55,7 +55,7 @@ public class ConnectionEndpointTracker extends TargetingTool implements DragTrac
 	 */
 	public ConnectionEndpointTracker(ConnectionEditPart cep) {
 		setConnectionEditPart(cep);
-		setDisabledCursor(Cursors.NO);
+		setDisabledCursor(CursorProviders.NO.get());
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@ package org.eclipse.gef.tools;
 
 import org.eclipse.swt.graphics.Cursor;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -54,7 +54,7 @@ public class CreationTool extends TargetingTool {
 	 */
 	public CreationTool() {
 		setDefaultCursor(SharedCursors.CURSOR_TREE_ADD);
-		setDisabledCursor(Cursors.NO);
+		setDisabledCursor(CursorProviders.NO.get());
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,7 @@ import org.eclipse.swt.graphics.Cursor;
 
 import org.eclipse.core.runtime.Platform;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -88,7 +88,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 		super(sourceEditPart);
 
 		cloneActive = false;
-		setDisabledCursor(Cursors.NO);
+		setDisabledCursor(CursorProviders.NO.get());
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
@@ -24,7 +24,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Connection;
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.Graphics;
@@ -221,7 +221,7 @@ public class MarqueeSelectionTool extends AbstractTool {
 	 * {@link #BEHAVIOR_NODES_CONTAINED}.
 	 */
 	public MarqueeSelectionTool() {
-		setDefaultCursor(Cursors.CROSS);
+		setDefaultCursor(CursorProviders.CROSS.get());
 		setUnloadWhenFinished(false);
 	}
 
@@ -759,9 +759,9 @@ public class MarqueeSelectionTool extends AbstractTool {
 		}
 		super.setViewer(viewer);
 		if (viewer instanceof GraphicalViewer) {
-			setDefaultCursor(Cursors.CROSS);
+			setDefaultCursor(CursorProviders.CROSS.get());
 		} else {
-			setDefaultCursor(Cursors.NO);
+			setDefaultCursor(CursorProviders.NO.get());
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/PanningSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/PanningSelectionTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Cursor;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.geometry.Point;
 
@@ -85,7 +85,7 @@ public class PanningSelectionTool extends SelectionTool {
 	@Override
 	protected Cursor getDefaultCursor() {
 		if (isInState(PAN | PAN_IN_PROGRESS)) {
-			return Cursors.HAND;
+			return CursorProviders.HAND.get();
 		}
 		return super.getDefaultCursor();
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/ResizeTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@ import org.eclipse.swt.graphics.Cursor;
 
 import org.eclipse.core.runtime.Platform;
 
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -31,7 +31,6 @@ import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
-import org.eclipse.gef.SharedCursors;
 import org.eclipse.gef.SnapToHelper;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
@@ -103,7 +102,7 @@ public class ResizeTracker extends SimpleDragTracker {
 	public ResizeTracker(GraphicalEditPart owner, int direction) {
 		this.owner = owner;
 		this.direction = direction;
-		setDisabledCursor(SharedCursors.NO);
+		setDisabledCursor(CursorProviders.NO.get());
 	}
 
 	/**
@@ -210,7 +209,7 @@ public class ResizeTracker extends SimpleDragTracker {
 	 */
 	@Override
 	protected Cursor getDefaultCursor() {
-		return Cursors.getDirectionalCursor(direction, getTargetEditPart().getFigure().isMirrored());
+		return CursorProviders.getDirectionalCursor(direction, getTargetEditPart().getFigure().isMirrored()).get();
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -69,7 +69,7 @@ import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.Button;
 import org.eclipse.draw2d.ButtonBorder;
 import org.eclipse.draw2d.ColorConstants;
-import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.CursorProviders;
 import org.eclipse.draw2d.FocusEvent;
 import org.eclipse.draw2d.FocusListener;
 import org.eclipse.draw2d.Graphics;
@@ -809,7 +809,7 @@ public class FlyoutPaletteComposite extends Composite {
 		}
 
 		private void updateState() {
-			setCursor(isInState(STATE_EXPANDED | STATE_PINNED_OPEN) ? Cursors.SIZEWE : null);
+			setCursor(isInState(STATE_EXPANDED | STATE_PINNED_OPEN) ? CursorProviders.SIZEWE.get() : null);
 		}
 
 		private class SashDragManager extends MouseAdapter implements MouseMoveListener {
@@ -887,7 +887,7 @@ public class FlyoutPaletteComposite extends Composite {
 			final Tracker tracker = new Tracker(FlyoutPaletteComposite.this, SWT.RIGHT | SWT.LEFT);
 			Rectangle[] rects = new Rectangle[1];
 			rects[0] = sash.getBounds();
-			tracker.setCursor(Cursors.SIZEE);
+			tracker.setCursor(CursorProviders.SIZEE.get());
 			tracker.setRectangles(rects);
 			if (tracker.open()) {
 				int deltaX = sash.getBounds().x - tracker.getRectangles()[0].x;
@@ -1183,7 +1183,7 @@ public class FlyoutPaletteComposite extends Composite {
 		}
 
 		private void init() {
-			setCursor(Cursors.ARROW);
+			setCursor(CursorProviders.ARROW.get());
 			lws = new LightweightSystem();
 			lws.setControl(this);
 			final ArrowButton b = new ArrowButton(getArrowDirection());
@@ -1326,7 +1326,7 @@ public class FlyoutPaletteComposite extends Composite {
 			lws = new LightweightSystem();
 			lws.setControl(this);
 			lws.setContents(contents);
-			setCursor(Cursors.SIZEALL);
+			setCursor(CursorProviders.SIZEALL.get());
 			FONT_MGR.register(this);
 			new TitleDragManager(this);
 			final MenuManager manager = new MenuManager();


### PR DESCRIPTION
Using static cursors is fundamentally flawed when considering dynamic DPI changes. The static cursors created by this class are created with respect to the current display zoom. Those objects are not updated, should this value change at a later time. Clients need to listen to the SWT.ZoomChanged event and update their cursors via the CursorProvider interface.