### PR TITLE
Mark deprecated elements in Draw2D Geometry component as "for Removal"

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -215,8 +215,10 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	 * @param p the Point supplying the dimensional values
 	 * @return <code>this</code> for convenience
 	 * @since 2.0
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #expand(int, int)} instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public Dimension expand(Point p) {
 		return expand(p.x(), p.y());
 	}
@@ -248,8 +250,10 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	 * @param d the dimension being compared
 	 * @return a new dimension representing the difference
 	 * @since 2.0
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #getShrinked(Dimension)} instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public Dimension getDifference(Dimension d) {
 		return getShrinked(d);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -74,8 +74,10 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 * @param x x value
 	 * @param y y value
 	 * @since 2.0
+	 * @noreference This constructor is not intended to be referenced by clients.
 	 * @deprecated Use {@link PrecisionPoint} or {@link #Point(int, int)} instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public Point(double x, double y) {
 		this.x = (int) x;
 		this.y = (int) y;
@@ -195,8 +197,10 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 * @param p The reference Point
 	 * @return distance<sup>2</sup>
 	 * @since 2.0
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #getDistance(Point)} and square the result instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public int getDistance2(Point p) {
 		long i = p.x() - x;
 		long j = p.y() - y;
@@ -213,9 +217,11 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 *
 	 * @param p The reference Point
 	 * @return the orthogonal distance
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated May not be guaranteed by precision subclasses and should thus not
 	 *             be used any more.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public int getDistanceOrthogonal(Point p) {
 		return Math.abs(y - p.y()) + Math.abs(x - p.x());
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,19 +22,21 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * The height in double precision.
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseHeight(double)} and
 	 *             {@link #preciseHeight()} instead. This field will become private
 	 *             in the future.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseHeight;
 	/**
 	 * The width in double precision.
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseWidth(double)} and {@link #preciseWidth()}
 	 *             instead. This field will become private in the future.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseWidth;
 
 	/**
@@ -349,6 +351,7 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * Updates the integer fields using the precise versions.
 	 *
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated This method should not be accessed by clients any more (it will
 	 *             be made private in future releases). The update of integer and
 	 *             precision fields is performed automatically if
@@ -356,6 +359,7 @@ public class PrecisionDimension extends Dimension {
 	 *             not manipulated directly, but only via respective methods offered
 	 *             by this class.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public final void updateInts() {
 		updateWidthInt();
 		updateHeightInt();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,19 +22,21 @@ public class PrecisionPoint extends Point {
 	/**
 	 * Double value for X
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} and {@link #preciseX()} instead.
 	 *             This field will become private in future versions.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseX;
 
 	/**
 	 * Double value for Y
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseY(double)} and {@link #preciseY()} instead.
 	 *             This field will become private in future versions.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseY;
 
 	/**
@@ -301,12 +303,14 @@ public class PrecisionPoint extends Point {
 	/**
 	 * Updates the integer fields using the precise versions.
 	 *
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated This method should not be accessed by clients any more (it will
 	 *             be made private in future releases). The update of integer and
 	 *             precision fields is performed automatically if {@link #preciseX}
 	 *             and {@link #preciseY} field values are not manipulated directly,
 	 *             but only via respective methods offered by this class.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public final void updateInts() {
 		updateXInt();
 		updateYInt();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,38 +26,42 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * Double value for height
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseHeight(double)} and
 	 *             {@link #preciseHeight()} instead. This field will become private
 	 *             in the future.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseHeight;
 
 	/**
 	 * Double value for width
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseWidth(double)} and {@link #preciseWidth()}
 	 *             instead. This field will become private in the future.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseWidth;
 
 	/**
 	 * Double value for X
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} and {@link #preciseX()} instead.
 	 *             This field will become private in the future.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseX;
 
 	/**
 	 * Double value for Y
 	 *
-	 * @noreference
+	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} and {@link #preciseY()} instead.
 	 *             This field will become private in the future.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseY;
 
 	/**
@@ -461,8 +465,10 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the height.
 	 *
 	 * @param value the new height
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseHeight(double)} instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public void setHeight(double value) {
 		setPreciseHeight(value);
 	}
@@ -635,8 +641,10 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the width.
 	 *
 	 * @param value the new width
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseWidth(double)} instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public void setWidth(double value) {
 		setPreciseWidth(value);
 	}
@@ -653,8 +661,10 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the x value.
 	 *
 	 * @param value the new x value
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public void setX(double value) {
 		setPreciseX(value);
 	}
@@ -671,8 +681,10 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the y value.
 	 *
 	 * @param value the new y value
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} instead.
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public void setY(double value) {
 		setPreciseY(value);
 	}
@@ -852,8 +864,10 @@ public final class PrecisionRectangle extends Rectangle {
 	 * @since 3.0
 	 * @param rect the rectangle being unioned
 	 * @return <code>this</code> for convenience
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #union(Rectangle)} instead
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public PrecisionRectangle union(PrecisionRectangle rect) {
 		if (rect == null || rect.isEmpty()) {
 			return this;
@@ -934,6 +948,7 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * Updates the integer values based on the current precise values.
 	 *
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated This method should not be accessed by clients any more (it will
 	 *             be made private in future releases). The update of integer and
 	 *             precision fields is performed automatically if {@link #preciseX},
@@ -943,6 +958,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 *
 	 * @since 3.0
 	 */
+	@Deprecated(since = "3.7", forRemoval = true)
 	public void updateInts() {
 		updateXInt();
 		updateYInt();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,9 @@ package org.eclipse.draw2d.geometry;
  *
  * @deprecated Use {@link Vector} instead, which offers double precision instead
  *             of integer precision.
+ * @noreference This class is not intended to be referenced by clients.
  */
+@Deprecated(since = "3.5", forRemoval = true)
 public final class Ray {
 
 	/** the X value */

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -188,9 +188,10 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @param insets Insets to be removed from the Rectangle
 	 * @return <code>this</code> for convenience
 	 * @since 2.0
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #shrink(Insets)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.7", forRemoval = true)
 	public Rectangle crop(Insets insets) {
 		return shrink(insets);
 	}
@@ -352,8 +353,9 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @param insets Insets being cropped from the Rectangle
 	 * @return Cropped new Rectangle
 	 * @deprecated Use {@link #getShrinked(Insets)} instead.
+	 * @noreference This method is not intended to be referenced by clients.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.7", forRemoval = true)
 	public Rectangle getCropped(Insets insets) {
 		return getShrinked(insets);
 	}
@@ -1261,12 +1263,13 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @param d Dimension being unioned
 	 * @return <code>this</code> for convenience
 	 * @since 2.0
+	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Union with a dimension generally does not make much sense, thus
 	 *             deprecating this. Use {@link Dimension#max(Dimension, Dimension)}
 	 *             and {@link #setSize(Dimension)} to implement the desired behavior
 	 *             instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.7", forRemoval = true)
 	public Rectangle union(Dimension d) {
 		width = Math.max(width, d.width);
 		height = Math.max(height, d.height);


### PR DESCRIPTION
This marks all fields, methods, constructors and classes which have been marked as deprecated as "for-removal", to be deleted or made private in a future release.