### PR TITLE
Throw IllegalArgumentException when removing null child from figure

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -1370,7 +1370,7 @@ public class Figure implements IFigure {
 	 */
 	@Override
 	public void remove(IFigure figure) {
-		if ((figure.getParent() != this)) {
+		if (figure == null || figure.getParent() != this) {
 			throw new IllegalArgumentException("Figure is not a child"); //$NON-NLS-1$
 		}
 		if (getFlag(FLAG_REALIZED)) {


### PR DESCRIPTION
The Figure#remove() method throws a NullPointerException when trying to remove a "null" child, due to a call to figure.getParent(). To remain consistent with the case where the child belongs to a different parent, this should also throw an IllegalArgumentException.