### PR TITLE
Bug 226103 - findMouseEventTargetAt problem with local coordinate system

### DIFF
--- a/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.examples
-Bundle-Version: 3.15.400.qualifier
+Bundle-Version: 3.16.0.qualifier
+Export-Package: gef.bugs;x-friends:="org.eclipse.draw2d.tests"
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.draw2d;bundle-version="[3.16.0,4.0.0)"
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.draw2d.examples/sandbox/gef/bugs/BugWithLocalCoordinateSystem.java
+++ b/org.eclipse.draw2d.examples/sandbox/gef/bugs/BugWithLocalCoordinateSystem.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2024 Manuel Selva and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Manuel Selva - initial API and implementation
+ *******************************************************************************/
+package gef.bugs;
+
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.FigureCanvas;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.Label;
+import org.eclipse.draw2d.LineBorder;
+import org.eclipse.draw2d.MouseEvent;
+import org.eclipse.draw2d.MouseListener;
+import org.eclipse.draw2d.Panel;
+import org.eclipse.draw2d.RectangleFigure;
+import org.eclipse.draw2d.XYLayout;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+/**
+ * Sample class showing a bug when using local coordinate system. Launch the
+ * main and click on the blue label => The yellow rectangle is notified with a
+ * MousePressed event.
+ *
+ * @author Manuel Selva
+ * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=226103">[1]
+ *      here</a>
+ * @see <a href="https://github.com/eclipse/gef-classic/issues/495">[2] here</a>
+ */
+public class BugWithLocalCoordinateSystem {
+
+	private static Shell shell;
+
+	/**
+	 * RectangleFigure using local coordinate system.
+	 *
+	 * @author Manuel Selva
+	 */
+	private class LocalCoordinateRectangle extends RectangleFigure {
+
+		/*
+		 * (non-Javadoc)
+		 *
+		 * @see org.eclipse.draw2d.Figure#useLocalCoordinates()
+		 */
+		@Override
+		protected boolean useLocalCoordinates() {
+			return true;
+		}
+
+	}
+
+	/**
+	 * Opens a shell showing the bug.
+	 */
+	public BugWithLocalCoordinateSystem() {
+
+		// Creates display and shell
+		shell = new Shell();
+		Display display = shell.getDisplay();
+		shell.setLayout(new FillLayout());
+
+		// Creates the canvas
+		FigureCanvas canvas = new FigureCanvas(shell);
+		Panel panel = new Panel();
+		panel.setLayoutManager(new XYLayout());
+
+		// Creates the canvas content
+		RectangleFigure rect = new LocalCoordinateRectangle();
+		rect.setBackgroundColor(ColorConstants.red);
+		rect.setLayoutManager(new XYLayout());
+		panel.add(rect, new Rectangle(5, 5, 250, 100));
+
+		RectangleFigure child = new RectangleFigure();
+		child.setBackgroundColor(ColorConstants.yellow);
+		rect.add(child, new Rectangle(10, 10, 100, 30));
+		child.setLineWidth(0);
+		child.addMouseListener(new MouseListener() {
+
+			@Override
+			public void mouseDoubleClicked(MouseEvent me) {
+				//
+			}
+
+			@Override
+			public void mousePressed(MouseEvent me) {
+				System.out.println(me);
+				IFigure source = (IFigure) me.getSource();
+				if (source.getBorder() == null) {
+					source.setBorder(new LineBorder(5));
+				} else {
+					source.setBorder(null);
+				}
+			}
+
+			@Override
+			public void mouseReleased(MouseEvent me) {
+				//
+			}
+		});
+
+		RectangleFigure rect2 = new LocalCoordinateRectangle();
+		rect2.setBackgroundColor(ColorConstants.orange);
+		rect2.setLayoutManager(new XYLayout());
+		panel.add(rect2, new Rectangle(5, 110, 250, 100));
+
+		Label label = new Label("Click Here");
+		label.setBackgroundColor(ColorConstants.blue);
+		label.setOpaque(true);
+		label.setForegroundColor(ColorConstants.white);
+		rect2.add(label, new Rectangle(10, 10, 100, 30));
+
+		canvas.setContents(panel);
+
+		// Opens the shell and start UI loop
+		shell.pack();
+		shell.setText("Local Coordinates");
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+		display.dispose();
+	}
+
+	/**
+	 * Main method.
+	 *
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		new BugWithLocalCoordinateSystem();
+	}
+}

--- a/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d.tests/META-INF/MANIFEST.MF
@@ -2,14 +2,17 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d.tests
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.14.0.qualifier
+Import-Package: org.slf4j
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.draw2d;bundle-version="[3.16.0,4.0.0)",
+ org.eclipse.draw2d.examples,
  org.junit,
- org.eclipse.jface;bundle-version="[3.2.0,4.0.0)"
+ org.eclipse.jface;bundle-version="[3.2.0,4.0.0)",
+ org.eclipse.swtbot.swt.finder;bundle-version="4.2.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.draw2d.tests
 

--- a/org.eclipse.draw2d.tests/pom.xml
+++ b/org.eclipse.draw2d.tests/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.draw2d.plugins</groupId>
 	<artifactId>org.eclipse.draw2d.tests</artifactId>
-	<version>3.13.100-SNAPSHOT</version>
+	<version>3.14.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 	<profiles>
 		<profile>
@@ -44,12 +44,36 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
+				<executions>
+					<execution>
+						<!-- Overwrites default goal! -->
+						<id>default-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/Draw2dTestSuite.class</include>
+							</includes>
+							<useUIHarness>false</useUIHarness>
+							<useUIThread>false</useUIThread>
+						</configuration>
+					</execution>
+					<execution>
+						<id>swtbot-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/SWTBotTestSuite.class</include>
+							</includes>
+							<useUIHarness>true</useUIHarness>
+							<useUIThread>false</useUIThread>
+						</configuration>
+					</execution>
+				</executions>
 				<configuration>
-					<includes>
-						<include>**/Draw2dTestSuite.class</include>
-					</includes>
-					<useUIHarness>false</useUIHarness>
-					<useUIThread>false</useUIThread>
 					<argLine>${test.vmargs}</argLine>
 				</configuration>
 			</plugin>

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/swtbot/AbstractSWTBotTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/swtbot/AbstractSWTBotTests.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test.swtbot;
+
+import static org.junit.Assert.fail;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotCanvas;
+
+import org.eclipse.draw2d.FigureCanvas;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.test.utils.Snippet;
+
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+
+/**
+ * To be able to execute these tests in the Eclipse IDE, the tests must
+ * <b>NOT</b> be run in the UI thread.
+ */
+@SuppressWarnings("nls")
+public abstract class AbstractSWTBotTests {
+	protected SWTBotCanvas bot;
+	protected FigureCanvas canvas;
+	protected IFigure root;
+
+	@Rule
+	public TestRule rule = (base, description) -> new Statement() {
+		@Override
+		public void evaluate() throws Throwable {
+			Snippet annotation = description.getAnnotation(Snippet.class);
+			Objects.requireNonNull(annotation, "Test is missing @Snippet annotation."); //$NON-NLS-1$
+			doTest(annotation, base);
+		}
+	};
+
+	/**
+	 * Wrapper method to handle the instantiation of the example class and the
+	 * execution of the unit test. Each example must satisfy the following
+	 * requirements:
+	 * <ul>
+	 * <li>It must have a static main(String[]) method.</li>
+	 * <li>It must not create a display.</li>
+	 * <li>It must store the created {@link Shell} in a static variable.
+	 * <ul>
+	 *
+	 * @param annotation The annotation containing the class to test.
+	 * @param statement  The test to execute once the example has been created.
+	 * @throws Throwable If the example could not be instantiated.
+	 */
+	protected void doTest(Snippet annotation, Statement statement) throws Throwable {
+		if (Display.getCurrent() != null) {
+			fail("""
+					SWTBot test needs to run in a non-UI thread.
+					Make sure that "Run in UI thread" is unchecked in your launch configuration or that useUIThread is set to false in the pom.xml
+					""");
+		}
+
+		Class<?> clazz = annotation.type();
+		Semaphore lock = new Semaphore(0);
+		AtomicReference<Throwable> throwable = new AtomicReference<>();
+		Lookup lookup = MethodHandles.privateLookupIn(clazz, MethodHandles.lookup());
+
+		// Fail early, otherwise the example might block indefinitely
+		Assert.isTrue(hasShell(lookup, annotation), "Shell not found for " + clazz); //$NON-NLS-1$
+
+		// The widget needs to be explicitly created in the UI thread. Note that the
+		// lock is released by the test once it invokes "readAndDispatch()".
+		Display.getDefault().asyncExec(() -> {
+			try {
+				Display.getCurrent().asyncExec(lock::release);
+				createInstance(lookup, annotation);
+			} catch (Throwable e) {
+				throwable.set(e);
+			}
+		});
+
+		// Run the actual test
+		Shell shell = null;
+		try {
+			// Wait for example to initialize
+			lock.acquire();
+
+			shell = getShell(lookup, annotation);
+
+			// Propagate any errors
+			if (throwable.get() != null) {
+				throw throwable.get();
+			}
+
+			bot = new SWTBot(shell).canvas(1); // 0 is the shell itself
+			canvas = (FigureCanvas) bot.widget;
+			root = canvas.getLightweightSystem().getRootFigure();
+			// Run the actual test
+			statement.evaluate();
+		} finally {
+			// Close the snippet
+			if (shell != null) {
+				Display.getDefault().syncExec(shell::dispose);
+			}
+			lock.release();
+		}
+	}
+
+	private static boolean hasShell(Lookup lookup, Snippet snippet) throws ReflectiveOperationException {
+		try {
+			getShell(lookup, snippet);
+			return true;
+		} catch (NoSuchFieldException ignore) {
+			return false;
+		}
+	}
+
+	private static Shell getShell(Lookup lookup, Snippet snippet) throws ReflectiveOperationException {
+		VarHandle shell = lookup.findStaticVarHandle(snippet.type(), snippet.field(), Shell.class);
+		return (Shell) shell.get();
+	}
+
+	private static void createInstance(Lookup lookup, Snippet snippet) throws Throwable {
+		MethodType type = MethodType.methodType(void.class, String[].class);
+		MethodHandle methodHandle = lookup.findStatic(snippet.type(), "main", type); //$NON-NLS-1$
+		methodHandle.invoke(null);
+	}
+
+}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/swtbot/FigureTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/swtbot/FigureTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test.swtbot;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.test.utils.Snippet;
+
+import gef.bugs.BugWithLocalCoordinateSystem;
+import org.junit.Test;
+
+public class FigureTest extends AbstractSWTBotTests {
+
+	@Test
+	@Snippet(type = BugWithLocalCoordinateSystem.class)
+	public void testMouseEventTargetWithLocalCoordinates() {
+		IFigure label = root.findFigureAt(20, 125);
+		IFigure rectangle = root.findFigureAt(20, 25);
+
+		assertNotNull(label);
+		assertNotNull(rectangle);
+		assertNull(rectangle.getBorder());
+
+		bot.click(20, 125);
+		assertNull(rectangle.getBorder());
+	}
+}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/swtbot/SWTBotTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/swtbot/SWTBotTestSuite.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test.swtbot;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Test suite containing all tests that require the SWTBot. These tests must
+ * <b>NOT</b> be executed within the UI thread.
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(FigureTest.class)
+public class SWTBotTestSuite {
+}

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/utils/Snippet.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/utils/Snippet.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test.utils;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * This annotation is used for testing the example classes, in order to indicate
+ * which test covers which class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { METHOD })
+public @interface Snippet {
+	/**
+	 * @return The class under test.
+	 */
+	Class<?> type();
+
+	/**
+	 * @return The name of the static field containing the {@link Shell}.
+	 */
+	String field() default "shell";
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -479,13 +479,16 @@ public class Figure implements IFigure {
 		PRIVATE_POINT.setLocation(x, y);
 		translateFromParent(PRIVATE_POINT);
 
-		if (!getClientArea(Rectangle.SINGLETON).contains(PRIVATE_POINT)) {
+		x = PRIVATE_POINT.x;
+		y = PRIVATE_POINT.y;
+
+		if (!getClientArea(Rectangle.SINGLETON).contains(x, y)) {
 			return null;
 		}
 
 		for (IFigure fig : getChildrenRevIterable()) {
-			if (fig.isVisible() && fig.isEnabled() && fig.containsPoint(PRIVATE_POINT.x, PRIVATE_POINT.y)) {
-				fig = fig.findMouseEventTargetAt(PRIVATE_POINT.x, PRIVATE_POINT.y);
+			if (fig.isVisible() && fig.isEnabled() && fig.containsPoint(x, y)) {
+				fig = fig.findMouseEventTargetAt(x, y);
 				if (fig != null) {
 					return fig;
 				}


### PR DESCRIPTION
A figure using local coordinates translates the given point for its children at the beginning of findMouseEventTargetInDescendantsAt(int, int). However, during iteration over its children, the translated point is stored in a  static variable PRIVATE_POINT. The value would be changed by a child, if the child also uses local coordinates. This affects the following queries to the rest of children, if no figure is found under that child.

Fixes https://github.com/eclipse/gef-classic/issues/495