### PR TITLE
Added type information to getEditPartRegisry #155

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicEditPart.java
@@ -23,7 +23,6 @@ import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.ConnectionEditPart;
-import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.NodeEditPart;
@@ -185,12 +184,12 @@ public abstract class LogicEditPart extends org.eclipse.gef.editparts.AbstractGr
 	public void propertyChange(PropertyChangeEvent evt) {
 		String prop = evt.getPropertyName();
 		if (LogicElement.CHILDREN.equals(prop)) {
-			if (evt.getOldValue() instanceof Integer) {
+			if (evt.getOldValue() instanceof Integer intVal) {
 				// new child
-				addChild(createChild(evt.getNewValue()), ((Integer) evt.getOldValue()).intValue());
+				addChild(createChild(evt.getNewValue()), intVal.intValue());
 			} else {
 				// remove child
-				removeChild((EditPart) getViewer().getEditPartRegistry().get(evt.getOldValue()));
+				removeChild(getViewer().getEditPartForModel(evt.getOldValue()));
 			}
 		} else if (LogicElement.INPUTS.equals(prop)) {
 			refreshTargetConnections();

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeEditPart.java
@@ -21,7 +21,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 
-import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 
 import org.eclipse.gef.examples.logicdesigner.model.LED;
@@ -92,12 +91,12 @@ public class LogicTreeEditPart extends org.eclipse.gef.editparts.AbstractTreeEdi
 	@Override
 	public void propertyChange(PropertyChangeEvent change) {
 		if (change.getPropertyName().equals(LogicElement.CHILDREN)) {
-			if (change.getOldValue() instanceof Integer) {
+			if (change.getOldValue() instanceof Integer intVal) {
 				// new child
-				addChild(createChild(change.getNewValue()), ((Integer) change.getOldValue()).intValue());
+				addChild(createChild(change.getNewValue()), intVal.intValue());
 			} else {
 				// remove child
-				removeChild((EditPart) getViewer().getEditPartRegistry().get(change.getOldValue()));
+				removeChild(getViewer().getEditPartForModel(change.getOldValue()));
 			}
 		} else {
 			refreshVisuals();

--- a/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/DiagramTreeEditPart.java
+++ b/org.eclipse.gef.examples.shapes/src/org/eclipse/gef/examples/shapes/parts/DiagramTreeEditPart.java
@@ -97,7 +97,7 @@ class DiagramTreeEditPart extends AbstractTreeEditPart implements PropertyChange
 	 * @return the corresponding EditPart or null
 	 */
 	private EditPart getEditPartForChild(Object child) {
-		return (EditPart) getViewer().getEditPartRegistry().get(child);
+		return getViewer().getEditPartForModel(child);
 	}
 
 	/*

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/ExampleTextCommand.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/model/commands/ExampleTextCommand.java
@@ -38,7 +38,7 @@ public abstract class ExampleTextCommand extends Command implements TextCommand 
 	}
 
 	protected static TextEditPart lookupModel(GraphicalTextViewer viewer, ModelElement model) {
-		return (TextEditPart) viewer.getEditPartRegistry().get(model);
+		return (TextEditPart) viewer.getEditPartForModel(model);
 	}
 
 }

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -64,6 +64,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/gef/EditPartViewer.java" type="org.eclipse.gef.EditPartViewer">
+        <filter id="403804204">
+            <message_arguments>
+                <message_argument value="org.eclipse.gef.EditPartViewer"/>
+                <message_argument value="getEditPartForModel(Object)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/gef/ui/actions/AlignmentRetargetAction.java" type="org.eclipse.gef.ui.actions.AlignmentRetargetAction">
         <filter id="571473929">
             <message_arguments>

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
@@ -281,7 +281,20 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 *
 	 * @return the registry map
 	 */
-	Map getEditPartRegistry();
+	Map<Object, EditPart> getEditPartRegistry();
+
+	/**
+	 * Convenience method to look up an edit part for a given model element in the
+	 * EditPart registry.
+	 *
+	 * See also {@link #getEditPartRegistry()} for details on the EditPart registry.
+	 *
+	 * @param model the model object for which an EditPart is looked up
+	 * @return the edit part or null if for the given model no EditPart is
+	 *         registered
+	 * @since 3.19
+	 */
+	EditPart getEditPartForModel(Object model);
 
 	/**
 	 * Returns the <i>focus</i> <code>EditPart</code>. Focus refers to keyboard

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDropTargetListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/TemplateTransferDropTargetListener.java
@@ -127,8 +127,7 @@ public class TemplateTransferDropTargetListener extends AbstractTransferDropTarg
 		}
 		EditPartViewer viewer = getViewer();
 		viewer.getControl().forceFocus();
-		Object editpart = viewer.getEditPartRegistry().get(model);
-		if (editpart instanceof EditPart ep) {
+		if (viewer.getEditPartForModel(model) instanceof EditPart ep) {
 			// Force a layout first.
 			getViewer().flush();
 			viewer.select(ep);

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
@@ -1190,7 +1190,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * this method if they need to unregister this EditPart in additional ways.
 	 */
 	protected void unregisterModel() {
-		Map registry = getViewer().getEditPartRegistry();
+		Map<Object, EditPart> registry = getViewer().getEditPartRegistry();
 		if (registry.get(getModel()) == this) {
 			registry.remove(getModel());
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
@@ -326,8 +326,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 	 * @return the ConnectionEditPart
 	 */
 	protected ConnectionEditPart createOrFindConnection(Object model) {
-		ConnectionEditPart conx = (ConnectionEditPart) getViewer().getEditPartRegistry().get(model);
-		if (conx != null) {
+		if (getViewer().getEditPartForModel(model) instanceof ConnectionEditPart conx) {
 			return conx;
 		}
 		return createConnection(model);
@@ -484,8 +483,7 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 	 * @return The requested layer or <code>null</code> if it doesn't exist
 	 */
 	protected IFigure getLayer(Object layer) {
-		LayerManager manager = (LayerManager) getViewer().getEditPartRegistry().get(LayerManager.ID);
-		return manager.getLayer(layer);
+		return LayerManager.Helper.find(this).getLayer(layer);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/LayerManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/LayerManager.java
@@ -15,6 +15,7 @@ package org.eclipse.gef.editparts;
 import org.eclipse.draw2d.IFigure;
 
 import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
 
 /**
  * Responsible for locating <i>layers</i> in a <code>GraphicalViewer</code>.
@@ -57,7 +58,18 @@ public interface LayerManager {
 		 * @return the <code>LayerManager</code>
 		 */
 		public static LayerManager find(EditPart part) {
-			return (LayerManager) part.getViewer().getEditPartRegistry().get(ID);
+			return find(part.getViewer());
+		}
+
+		/**
+		 * Finds the LayerManager given a Viewer.
+		 *
+		 * @param viewer the viewer for which to search in
+		 * @return the <code>LayerManager</code>
+		 * @since 3.19
+		 */
+		public static LayerManager find(EditPartViewer viewer) {
+			return (LayerManager) viewer.getEditPartForModel(ID);
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerEditPart.java
@@ -104,7 +104,7 @@ public class DrawerEditPart extends PaletteEditPart implements IPinnableEditPart
 	}
 
 	private PaletteAnimator getPaletteAnimator() {
-		return (PaletteAnimator) getViewer().getEditPartRegistry().get(PaletteAnimator.class);
+		return getViewer().getPaletteAnimator();
 	}
 
 	@Override

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java
@@ -115,7 +115,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 	public void activate() {
 		// in case the model is out of sync
 		checkActiveEntrySync();
-		getPaletteViewer().addPaletteListener(paletteListener);
+		getViewer().addPaletteListener(paletteListener);
 		super.activate();
 	}
 
@@ -130,7 +130,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 		Clickable clickable = null;
 
 		if (newValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(newValue);
+			part = (GraphicalEditPart) getViewer().getEditPartForModel(newValue);
 			clickable = (Clickable) part.getFigure();
 			clickable.setVisible(true);
 			clickable.addChangeListener(clickableListener);
@@ -140,7 +140,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 		}
 
 		if (oldValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(oldValue);
+			part = (GraphicalEditPart) getViewer().getEditPartForModel(oldValue);
 			// if part is null, its no longer a child.
 			if (part != null) {
 				clickable = (Clickable) part.getFigure();
@@ -198,7 +198,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 		}
 		arrowFigure.removeActionListener(actionListener);
 		arrowFigure.removeChangeListener(clickableArrowListener);
-		getPaletteViewer().removePaletteListener(paletteListener);
+		getViewer().removePaletteListener(paletteListener);
 		super.deactivate();
 	}
 
@@ -232,17 +232,17 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 
 		getChildren().forEach(part -> {
 			PaletteEntry entry = part.getModel();
-			menuManager.add(new SetActivePaletteToolAction(getPaletteViewer(), entry.getLabel(), entry.getSmallIcon(),
+			menuManager.add(new SetActivePaletteToolAction(getViewer(), entry.getLabel(), entry.getSmallIcon(),
 					getStack().getActiveEntry().equals(entry), (ToolEntry) entry));
 		});
 
-		menu = menuManager.createContextMenu(getPaletteViewer().getControl());
+		menu = menuManager.createContextMenu(getViewer().getControl());
 
 		// make the menu open below the figure
 		Rectangle figureBounds = getFigure().getBounds().getCopy();
 		getFigure().translateToAbsolute(figureBounds);
 
-		Point menuLocation = getPaletteViewer().getControl().toDisplay(figureBounds.getBottomLeft().x,
+		Point menuLocation = getViewer().getControl().toDisplay(figureBounds.getBottomLeft().x,
 				figureBounds.getBottomLeft().y);
 
 		// remove feedback from the arrow Figure and children figures
@@ -293,7 +293,7 @@ public class PaletteStackEditPart extends PaletteEditPart implements IPaletteSta
 
 	@Override
 	public PaletteEditPart getActiveEntry() {
-		return (PaletteEditPart) getViewer().getEditPartRegistry().get(getStack().getActiveEntry());
+		return (PaletteEditPart) getViewer().getEditPartForModel(getStack().getActiveEntry());
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackEditPart.java
@@ -62,7 +62,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 	public void activate() {
 		// in case the model is out of sync
 		checkActiveEntrySync();
-		getPaletteViewer().addPaletteListener(paletteListener);
+		getViewer().addPaletteListener(paletteListener);
 		super.activate();
 	}
 
@@ -79,7 +79,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 		int index = -1;
 
 		if (oldValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(oldValue);
+			part = (GraphicalEditPart) getViewer().getEditPartForModel(oldValue);
 			// if part is null, its no longer a child.
 			if (part != null) {
 				oldFigure = part.getFigure();
@@ -90,7 +90,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 		}
 
 		if (newValue != null) {
-			part = (GraphicalEditPart) getViewer().getEditPartRegistry().get(newValue);
+			part = (GraphicalEditPart) getViewer().getEditPartForModel(newValue);
 			newFigure = part.getFigure();
 		}
 
@@ -115,7 +115,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 
 	@Override
 	public void deactivate() {
-		getPaletteViewer().removePaletteListener(paletteListener);
+		getViewer().removePaletteListener(paletteListener);
 		super.deactivate();
 	}
 
@@ -229,7 +229,7 @@ public class PinnablePaletteStackEditPart extends PaletteEditPart implements IPa
 
 	@Override
 	public PaletteEditPart getActiveEntry() {
-		return (PaletteEditPart) getViewer().getEditPartRegistry().get(getStack().getActiveEntry());
+		return (PaletteEditPart) getViewer().getEditPartForModel(getStack().getActiveEntry());
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SliderPaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SliderPaletteEditPart.java
@@ -18,14 +18,11 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ToolbarLayout;
 
 import org.eclipse.gef.palette.PaletteRoot;
-import org.eclipse.gef.ui.palette.PaletteViewer;
 import org.eclipse.gef.ui.palette.editparts.PaletteAnimator;
 import org.eclipse.gef.ui.palette.editparts.PaletteEditPart;
 import org.eclipse.gef.ui.palette.editparts.PaletteToolbarLayout;
 
 public class SliderPaletteEditPart extends PaletteEditPart {
-
-	private PaletteAnimator controller;
 
 	public SliderPaletteEditPart(PaletteRoot paletteRoot) {
 		super(paletteRoot);
@@ -55,8 +52,8 @@ public class SliderPaletteEditPart extends PaletteEditPart {
 	@Override
 	protected void registerVisuals() {
 		super.registerVisuals();
-		controller = new PaletteAnimator(((PaletteViewer) getViewer()).getPaletteViewerPreferences());
-		getViewer().getEditPartRegistry().put(PaletteAnimator.class, controller);
+		PaletteAnimator controller = new PaletteAnimator(getViewer().getPaletteViewerPreferences());
+		getViewer().setPaletteAnimator(controller);
 		ToolbarLayout layout = new PaletteToolbarLayout();
 		getFigure().setLayoutManager(layout);
 		getFigure().addLayoutListener(controller);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolEntryEditPart.java
@@ -118,7 +118,7 @@ public class ToolEntryEditPart extends PaletteEditPart {
 
 		@Override
 		protected boolean handleNativeDragFinished(DragSourceEvent event) {
-			getPaletteViewer().setActiveTool(null);
+			getViewer().setActiveTool(null);
 			return true;
 		}
 	}
@@ -195,7 +195,7 @@ public class ToolEntryEditPart extends PaletteEditPart {
 
 			// win hack because button down is delayed
 			if (getParent() instanceof IPaletteStackEditPart psEP && SWT.getPlatform().equals("win32")) { //$NON-NLS-1$
-				Point nds = getPaletteViewer().getControl().toControl(event.display.getCursorLocation());
+				Point nds = getViewer().getControl().toControl(event.display.getCursorLocation());
 				if (mouseDownLoc != null
 						&& (Math.abs(nds.x - mouseDownLoc.x) + Math.abs(nds.y - mouseDownLoc.y)) < WIN_THRESHOLD) {
 					getButtonModel().setArmed(false);
@@ -393,7 +393,7 @@ public class ToolEntryEditPart extends PaletteEditPart {
 	public IFigure createFigure() {
 		customLabel = new DetailedLabelFigure();
 		Clickable button = new ToolEntryToggle(customLabel);
-		button.addActionListener(event -> getPaletteViewer().setActiveTool(getModel()));
+		button.addActionListener(event -> getViewer().setActiveTool(getModel()));
 		return button;
 	}
 
@@ -498,7 +498,7 @@ public class ToolEntryEditPart extends PaletteEditPart {
 	@Override
 	public void removeNotify() {
 		if (getButtonModel().isSelected()) {
-			getPaletteViewer().setActiveTool(null);
+			getViewer().setActiveTool(null);
 		}
 		super.removeNotify();
 	}
@@ -510,14 +510,14 @@ public class ToolEntryEditPart extends PaletteEditPart {
 	@Override
 	public void restoreState(IMemento memento) {
 		if (Boolean.parseBoolean(memento.getString(ACTIVE_STATE))) {
-			getPaletteViewer().setActiveTool(getModel());
+			getViewer().setActiveTool(getModel());
 		}
 		super.restoreState(memento);
 	}
 
 	@Override
 	public void saveState(IMemento memento) {
-		memento.putString(ACTIVE_STATE, Boolean.toString(getPaletteViewer().getActiveTool() == getModel()));
+		memento.putString(ACTIVE_STATE, Boolean.toString(getViewer().getActiveTool() == getModel()));
 		super.saveState(memento);
 	}
 
@@ -536,8 +536,8 @@ public class ToolEntryEditPart extends PaletteEditPart {
 	@Override
 	public void setSelected(int value) {
 		super.setSelected(value);
-		if (value == SELECTED_PRIMARY && getPaletteViewer().getControl() != null
-				&& !getPaletteViewer().getControl().isDisposed() && getPaletteViewer().getControl().isFocusControl()) {
+		if (value == SELECTED_PRIMARY && getViewer().getControl() != null && !getViewer().getControl().isDisposed()
+				&& getViewer().getControl().isFocusControl()) {
 			getFigure().requestFocus();
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPart.java
@@ -164,7 +164,7 @@ public class RulerEditPart extends AbstractGraphicalEditPart {
 	}
 
 	public IFigure getGuideLayer() {
-		LayerManager lm = (LayerManager) diagramViewer.getEditPartRegistry().get(LayerManager.ID);
+		LayerManager lm = LayerManager.Helper.find(diagramViewer);
 		if (lm != null) {
 			return lm.getLayer(LayerConstants.GUIDE_LAYER);
 		}
@@ -208,7 +208,7 @@ public class RulerEditPart extends AbstractGraphicalEditPart {
 
 	public void handleGuideReparented(Object guide) {
 		refreshChildren();
-		EditPart guidePart = (EditPart) getViewer().getEditPartRegistry().get(guide);
+		EditPart guidePart = getViewer().getEditPartForModel(guide);
 		if (guidePart != null) {
 			getViewer().select(guidePart);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/print/PrintGraphicalViewerOperation.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/print/PrintGraphicalViewerOperation.java
@@ -47,7 +47,7 @@ public class PrintGraphicalViewerOperation extends PrintFigureOperation {
 	public PrintGraphicalViewerOperation(Printer p, GraphicalViewer g) {
 		super(p);
 		viewer = g;
-		LayerManager lm = (LayerManager) viewer.getEditPartRegistry().get(LayerManager.ID);
+		LayerManager lm = LayerManager.Helper.find(viewer);
 		IFigure f = lm.getLayer(LayerConstants.PRINTABLE_LAYERS);
 		setPrintSource(f);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
@@ -161,7 +161,7 @@ public abstract class RulerProvider {
 		List<EditPart> attachedEditParts = new ArrayList<>(attachedModelObjects.size());
 
 		for (Object attachedModelObject : attachedModelObjects) {
-			EditPart editPart = (EditPart) viewer.getEditPartRegistry().get(attachedModelObject);
+			EditPart editPart = viewer.getEditPartForModel(attachedModelObject);
 			if (editPart != null) {
 				attachedEditParts.add(editPart);
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractTool.java
@@ -296,7 +296,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param figure the feedback being added
 	 */
 	protected void addFeedback(IFigure figure) {
-		LayerManager lm = (LayerManager) getCurrentViewer().getEditPartRegistry().get(LayerManager.ID);
+		LayerManager lm = LayerManager.Helper.find(getCurrentViewer());
 		if (lm == null) {
 			return;
 		}
@@ -1376,7 +1376,7 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @param figure the figure being removed
 	 */
 	protected void removeFeedback(IFigure figure) {
-		LayerManager lm = (LayerManager) getCurrentViewer().getEditPartRegistry().get(LayerManager.ID);
+		LayerManager lm = LayerManager.Helper.find(getCurrentViewer());
 		if (lm == null) {
 			return;
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/CreationTool.java
@@ -292,11 +292,11 @@ public class CreationTool extends TargetingTool {
 		if (model == null || viewer == null) {
 			return;
 		}
-		Object editpart = viewer.getEditPartRegistry().get(model);
+		EditPart editpart = viewer.getEditPartForModel(model);
 		viewer.flush();
-		if (editpart instanceof EditPart ep && ep.isSelectable()) {
+		if (editpart != null && editpart.isSelectable()) {
 			// Force the new object to get positioned in the viewer.
-			viewer.select((EditPart) editpart);
+			viewer.select(editpart);
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DragEditPartsTracker.java
@@ -363,7 +363,7 @@ public class DragEditPartsTracker extends SelectEditPartTracker {
 				GraphicalEditPart editpart = (GraphicalEditPart) element;
 				exclusionSet.add(editpart.getFigure());
 			}
-			LayerManager layerManager = (LayerManager) getCurrentViewer().getEditPartRegistry().get(LayerManager.ID);
+			LayerManager layerManager = LayerManager.Helper.find(getCurrentViewer());
 			if (layerManager != null) {
 				exclusionSet.add(layerManager.getLayer(LayerConstants.CONNECTION_LAYER));
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CreateGuideAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CreateGuideAction.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 
 import org.eclipse.jface.action.Action;
 
-import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.internal.GEFMessages;
 import org.eclipse.gef.internal.ui.rulers.GuideEditPart;
@@ -31,7 +30,7 @@ import org.eclipse.gef.rulers.RulerProvider;
  */
 public class CreateGuideAction extends Action {
 
-	private EditPartViewer viewer;
+	private final EditPartViewer viewer;
 
 	/**
 	 * Constructor
@@ -71,7 +70,7 @@ public class CreateGuideAction extends Action {
 
 		// Create the guide and reveal it
 		viewer.getEditDomain().getCommandStack().execute(provider.getCreateGuideCommand(newPosition));
-		viewer.reveal((EditPart) viewer.getEditPartRegistry().get(provider.getGuideAt(newPosition)));
+		viewer.reveal(viewer.getEditPartForModel(provider.getGuideAt(newPosition)));
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SetActivePaletteToolAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SetActivePaletteToolAction.java
@@ -24,8 +24,8 @@ import org.eclipse.gef.ui.palette.PaletteViewer;
  */
 public class SetActivePaletteToolAction extends Action {
 
-	private PaletteViewer viewer;
-	private ToolEntry entry;
+	private final PaletteViewer viewer;
+	private final ToolEntry entry;
 
 	/**
 	 * Creates a new SetActivePaletteToolAction with the given entry to set, as well
@@ -57,7 +57,7 @@ public class SetActivePaletteToolAction extends Action {
 			// context menu is open for palette stacks so we need to indicate
 			// that the focus needs to change to the tool entry that the user
 			// has just selected. See GraphicalViewerKeyHandler.procesSelect().
-			EditPart part = (EditPart) viewer.getEditPartRegistry().get(entry);
+			EditPart part = viewer.getEditPartForModel(entry);
 			viewer.appendSelection(part);
 			viewer.setFocus(part);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
@@ -42,6 +42,7 @@ import org.eclipse.gef.palette.PaletteRoot;
 import org.eclipse.gef.palette.PaletteStack;
 import org.eclipse.gef.palette.ToolEntry;
 import org.eclipse.gef.ui.palette.customize.PaletteCustomizerDialog;
+import org.eclipse.gef.ui.palette.editparts.PaletteAnimator;
 import org.eclipse.gef.ui.palette.editparts.PaletteEditPart;
 import org.eclipse.gef.ui.parts.PaletteViewerKeyHandler;
 import org.eclipse.gef.ui.parts.ScrollingGraphicalViewer;
@@ -89,6 +90,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	private final PreferenceListener prefListener = new PreferenceListener();
 	private PaletteViewerPreferences prefs = PREFERENCE_STORE;
 	private Font font = null;
+	private PaletteAnimator paletteAnimator;
 
 	/**
 	 * Constructor
@@ -196,6 +198,16 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	}
 
 	/**
+	 * Gets the PaletteAnimator for this palette
+	 *
+	 * @return the palletteAnimator to be used for palette animations
+	 * @since 3.19
+	 */
+	public PaletteAnimator getPaletteAnimator() {
+		return paletteAnimator;
+	}
+
+	/**
 	 * Returns the palette's root model.
 	 *
 	 * @return the palette root
@@ -214,7 +226,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	}
 
 	private ToolEntryEditPart getToolEntryEditPart(ToolEntry entry) {
-		return (ToolEntryEditPart) getEditPartRegistry().get(entry);
+		return (ToolEntryEditPart) getEditPartForModel(entry);
 	}
 
 	/**
@@ -271,7 +283,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 * @return true if expanded
 	 */
 	public boolean isExpanded(PaletteDrawer drawer) {
-		EditPart ep = (EditPart) getEditPartRegistry().get(drawer);
+		EditPart ep = getEditPartForModel(drawer);
 		if (ep instanceof DrawerEditPart dep) {
 			return dep.isExpanded();
 		}
@@ -285,7 +297,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 * @return true if pinned
 	 */
 	public boolean isPinned(PaletteDrawer drawer) {
-		EditPart ep = (EditPart) getEditPartRegistry().get(drawer);
+		EditPart ep = getEditPartForModel(drawer);
 		if (ep instanceof DrawerEditPart dep) {
 			return dep.isPinnedOpen();
 		}
@@ -316,7 +328,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	public boolean restoreState(IMemento memento) {
 		try {
-			PaletteEditPart part = (PaletteEditPart) getEditPartRegistry().get(getPaletteRoot());
+			PaletteEditPart part = (PaletteEditPart) getEditPartForModel(getPaletteRoot());
 			if (part != null) {
 				part.restoreState(memento);
 			}
@@ -357,7 +369,7 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	public void saveState(IMemento memento) {
 		// Bug# 69026 - The PaletteRoot can be null initially for VEP
-		PaletteEditPart base = (PaletteEditPart) getEditPartRegistry().get(getPaletteRoot());
+		PaletteEditPart base = (PaletteEditPart) getEditPartForModel(getPaletteRoot());
 		if (base != null) {
 			base.saveState(memento);
 		}
@@ -394,6 +406,17 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 			}
 		}
 		fireModeChanged();
+	}
+
+	/**
+	 * Sets the PaletteAnimator for this palette
+	 *
+	 * @param paletteAnimator the PaletteAnimator to be used for this
+	 *                        palletteViewer's children
+	 * @since 3.19
+	 */
+	public void setPaletteAnimator(PaletteAnimator paletteAnimator) {
+		this.paletteAnimator = paletteAnimator;
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
@@ -274,9 +274,9 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 	 * Get the model element for this palette edit part.
 	 *
 	 * @return the model element.
-	 * @deprecated use getModel() instead
+	 * @deprecated use {@link #getModel()} instead
 	 */
-	@Deprecated
+	@Deprecated(since = "3.19", forRemoval = true)
 	protected PaletteEntry getPaletteEntry() {
 		return getModel();
 	}
@@ -285,9 +285,11 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 	 * Get the palette viewer for this palette edit part.
 	 *
 	 * @return the palette viewer.
+	 * @deprecated use {@link #getViewer()} instead
 	 */
+	@Deprecated(since = "3.19", forRemoval = true)
 	protected PaletteViewer getPaletteViewer() {
-		return (PaletteViewer) getViewer();
+		return getViewer();
 	}
 
 	/**
@@ -296,7 +298,7 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 	 * @return the palette viewer preferences.
 	 */
 	protected PaletteViewerPreferences getPreferenceSource() {
-		return ((PaletteViewer) getViewer()).getPaletteViewerPreferences();
+		return getViewer().getPaletteViewerPreferences();
 	}
 
 	/**
@@ -334,6 +336,15 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 			return null;
 		}
 		return text;
+	}
+
+	/**
+	 * @see org.eclipse.gef.EditPart#getViewer()
+	 * @since 3.19
+	 */
+	@Override
+	public PaletteViewer getViewer() {
+		return (PaletteViewer) super.getViewer();
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -354,8 +354,16 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @see EditPartViewer#getEditPartRegistry()
 	 */
 	@Override
-	public Map getEditPartRegistry() {
+	public Map<Object, EditPart> getEditPartRegistry() {
 		return mapIDToEditPart;
+	}
+
+	/**
+	 * @see EditPartViewer#getEditPartForModel(Object)
+	 */
+	@Override
+	public final EditPart getEditPartForModel(Object model) {
+		return getEditPartRegistry().get(model);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
@@ -140,7 +140,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 */
 	@Override
 	public Handle findHandleAt(Point p) {
-		LayerManager layermanager = (LayerManager) getEditPartRegistry().get(LayerManager.ID);
+		LayerManager layermanager = getLayerManager();
 		if (layermanager == null) {
 			return null;
 		}
@@ -216,7 +216,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 * @return the LayerManager
 	 */
 	protected LayerManager getLayerManager() {
-		return (LayerManager) getEditPartRegistry().get(LayerManager.ID);
+		return LayerManager.Helper.find(this);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/PaletteViewerKeyHandler.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/PaletteViewerKeyHandler.java
@@ -266,7 +266,7 @@ public class PaletteViewerKeyHandler extends GraphicalViewerKeyHandler {
 		}
 		if (part instanceof IPaletteStackEditPart) {
 			PaletteEntry activeEntry = ((PaletteStack) part.getModel()).getActiveEntry();
-			part = (EditPart) getViewer().getEditPartRegistry().get(activeEntry);
+			part = getViewer().getEditPartForModel(activeEntry);
 		}
 		getViewer().select(part);
 		getViewer().reveal(part);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/SelectionSynchronizer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/SelectionSynchronizer.java
@@ -61,13 +61,9 @@ public class SelectionSynchronizer implements ISelectionChangedListener {
 	 * @param part   a part from another viewer
 	 * @return <code>null</code> or a corresponding editpart
 	 */
+	@SuppressWarnings("static-method")
 	protected EditPart convert(EditPartViewer viewer, EditPart part) {
-		Object temp = viewer.getEditPartRegistry().get(part.getModel());
-		EditPart newPart = null;
-		if (temp != null) {
-			newPart = (EditPart) temp;
-		}
-		return newPart;
+		return viewer.getEditPartForModel(part.getModel());
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDragListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDragListener.java
@@ -35,6 +35,7 @@ class TreeViewerTransferDragListener extends AbstractTransferDragSourceListener 
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	public TreeViewerTransferDragListener(EditPartViewer viewer, Transfer xfer) {
 		super(viewer, xfer);
 	}
@@ -67,7 +68,7 @@ class TreeViewerTransferDragListener extends AbstractTransferDragSourceListener 
 		List list = new ArrayList();
 		Object editpart;
 		for (int i = 0; i < modelSelection.size(); i++) {
-			editpart = getViewer().getEditPartRegistry().get(modelSelection.get(i));
+			editpart = getViewer().getEditPartForModel(modelSelection.get(i));
 			if (editpart != null) {
 				list.add(editpart);
 			}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteViewerPage.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/views/palette/PaletteViewerPage.java
@@ -84,12 +84,12 @@ public class PaletteViewerPage extends Page implements PalettePage, IAdaptable {
 	@Override
 	public <T> T getAdapter(final Class<T> adapter) {
 		if (adapter == EditPart.class && viewer != null) {
-			return adapter.cast(viewer.getEditPartRegistry().get(viewer.getPaletteRoot()));
+			return adapter.cast(viewer.getEditPartForModel(viewer.getPaletteRoot()));
 		}
 		if (adapter == IFigure.class && viewer != null) {
-			Object obj = viewer.getEditPartRegistry().get(viewer.getPaletteRoot());
-			if (obj instanceof GraphicalEditPart) {
-				return adapter.cast(((GraphicalEditPart) obj).getFigure());
+			EditPart ep = viewer.getEditPartForModel(viewer.getPaletteRoot());
+			if (ep instanceof GraphicalEditPart gep) {
+				return adapter.cast(gep.getFigure());
 			}
 		}
 		return null;


### PR DESCRIPTION
As part of this clean-up a new helper method has been added for getting an EditPart for a model instance and for getting the LayerManager from a viewer.

@ptziegler this PR has still a problem, or better reveal a misuse of the EditPartRegistry by the palette. The `SliderPaletteEditPart` is registering an instance of `PaletteAnimator` at the EditPartRegsitry of the PaletteViewer. This `PaletteAnimator` is then later requested by `DrawerEditPart`s. The problem is that `PlaetteAnimator` is not an `EditPart`.  This totally violates the API description of `EditPartViewer`. Both `SliderPaletteEditPart` and `DrawerEditPart` are internal classes so we have a bit more freedom. Still I'm not sure how to best solve the issue. Currently I have two ideas on my mind:

1.  Move the PaletteAnimator to the PaletteViewer, add there a getter and a factory method. So that clients can provide own animators. This would for me be the cleanest solution. However clients may expect that PaletteAnimator to be in the EditPart Registry.
2. Therefore my other solution would be to let PaletteAnimator implement the EditPart interface. This would definitely be less clean but not break clients.  

So I'm unsure what to do. 
