### PR TITLE
Add type to getModelChildren #155

### DIFF
--- a/org.eclipse.gef.examples.digraph1/src/org/eclipse/gef/examples/digraph1/editpart/Digraph1GraphEditPart.java
+++ b/org.eclipse.gef.examples.digraph1/src/org/eclipse/gef/examples/digraph1/editpart/Digraph1GraphEditPart.java
@@ -51,13 +51,17 @@ public class Digraph1GraphEditPart extends AbstractGraphicalEditPart {
 		return freeformLayer;
 	}
 
+	@Override
+	public Digraph1Graph getModel() {
+		return (Digraph1Graph) super.getModel();
+	}
+
 	/*
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#getModelChildren()
 	 */
 	@Override
 	protected List<Digraph1Node> getModelChildren() {
-		List<Digraph1Node> nodes = ((Digraph1Graph) getModel()).getNodes();
-		return nodes;
+		return getModel().getNodes();
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicContainerEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicContainerEditPart.java
@@ -31,7 +31,7 @@ public abstract class LogicContainerEditPart extends LogicEditPart {
 		return new AccessibleGraphicalEditPart() {
 			@Override
 			public void getName(AccessibleEvent e) {
-				e.result = getLogicDiagram().toString();
+				e.result = getModel().toString();
 			}
 		};
 	}
@@ -50,8 +50,9 @@ public abstract class LogicContainerEditPart extends LogicEditPart {
 	 *
 	 * @return LogicDiagram of this.
 	 */
-	protected LogicDiagram getLogicDiagram() {
-		return (LogicDiagram) getModel();
+	@Override
+	public LogicDiagram getModel() {
+		return (LogicDiagram) super.getModel();
 	}
 
 	/**
@@ -61,7 +62,7 @@ public abstract class LogicContainerEditPart extends LogicEditPart {
 	 */
 	@Override
 	protected List<LogicElement> getModelChildren() {
-		return getLogicDiagram().getChildren();
+		return getModel().getChildren();
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicContainerTreeEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicContainerTreeEditPart.java
@@ -52,8 +52,9 @@ public class LogicContainerTreeEditPart extends LogicTreeEditPart {
 	 *
 	 * @return Model of this.
 	 */
-	protected LogicDiagram getLogicDiagram() {
-		return (LogicDiagram) getModel();
+	@Override
+	public LogicDiagram getModel() {
+		return (LogicDiagram) super.getModel();
 	}
 
 	/**
@@ -64,7 +65,7 @@ public class LogicContainerTreeEditPart extends LogicTreeEditPart {
 	 */
 	@Override
 	protected List<LogicElement> getModelChildren() {
-		return getLogicDiagram().getChildren();
+		return getModel().getChildren();
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicDiagramEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicDiagramEditPart.java
@@ -198,11 +198,11 @@ public class LogicDiagramEditPart extends LogicContainerEditPart implements Laye
 			cLayer.setAntialias(SWT.ON);
 		}
 
-		if (getLogicDiagram().getConnectionRouter().equals(LogicDiagram.ROUTER_MANUAL)) {
+		if (getModel().getConnectionRouter().equals(LogicDiagram.ROUTER_MANUAL)) {
 			AutomaticRouter router = new FanRouter();
 			router.setNextRouter(new BendpointConnectionRouter());
 			cLayer.setConnectionRouter(router);
-		} else if (getLogicDiagram().getConnectionRouter().equals(LogicDiagram.ROUTER_MANHATTAN)) {
+		} else if (getModel().getConnectionRouter().equals(LogicDiagram.ROUTER_MANHATTAN)) {
 			cLayer.setConnectionRouter(new ManhattanConnectionRouter());
 		} else {
 			cLayer.setConnectionRouter(new ShortestPathConnectionRouter(getFigure()));

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeEditPart.java
@@ -85,8 +85,8 @@ public class LogicTreeEditPart extends org.eclipse.gef.editparts.AbstractTreeEdi
 	 * @return <code>null</code>
 	 */
 	@Override
-	protected List getModelChildren() {
-		return Collections.EMPTY_LIST;
+	protected List<LogicElement> getModelChildren() {
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractEditPart.java
@@ -94,7 +94,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * <code>null</code> values encountered.
 	 */
 	protected static class EditPolicyIterator {
-		private Object[] list;
+		private final Object[] list;
 		private int offset = 0;
 		private final int length;
 
@@ -109,6 +109,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 		 * @deprecated this constructor should not be used
 		 * @param list the list of policies.
 		 */
+		@Deprecated
 		public EditPolicyIterator(List list) {
 			this(list.toArray());
 		}
@@ -166,7 +167,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 
 		activateEditPolicies();
 
-		getChildren().forEach(c -> c.activate());
+		getChildren().forEach(EditPart::activate);
 
 		fireActivated();
 	}
@@ -254,7 +255,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	public void addNotify() {
 		register();
 		createEditPolicies();
-		getChildren().forEach(c -> c.addNotify());
+		getChildren().forEach(EditPart::addNotify);
 		refresh();
 	}
 
@@ -293,7 +294,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 */
 	@Override
 	public void deactivate() {
-		getChildren().forEach(c -> c.deactivate());
+		getChildren().forEach(EditPart::deactivate);
 		deactivateEditPolicies();
 		setFlag(FLAG_ACTIVE, false);
 		fireDeactivated();
@@ -313,6 +314,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * @param message a debug message
 	 * @deprecated in 3.1
 	 */
+	@Deprecated
 	protected final void debug(String message) {
 	}
 
@@ -323,6 +325,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 * @param message Message to be passed
 	 * @deprecated in 3.1
 	 */
+	@Deprecated
 	protected final void debugFeedback(String message) {
 	}
 
@@ -574,8 +577,9 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 	 *
 	 * @return the List of children
 	 */
-	protected List getModelChildren() {
-		return Collections.EMPTY_LIST;
+	@SuppressWarnings("static-method")
+	protected List<? extends Object> getModelChildren() {
+		return Collections.emptyList();
 	}
 
 	/**
@@ -766,7 +770,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 			}
 		}
 
-		List modelObjects = getModelChildren();
+		List<? extends Object> modelObjects = getModelChildren();
 		List<? extends EditPart> curChildren = getChildren();
 		int i;
 		for (i = 0; i < modelObjects.size(); i++) {
@@ -952,7 +956,7 @@ public abstract class AbstractEditPart implements EditPart, RequestConstants, IA
 			getViewer().setFocus(null);
 		}
 
-		getChildren().forEach(c -> c.removeNotify());
+		getChildren().forEach(EditPart::removeNotify);
 		unregister();
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerEditPart.java
@@ -44,7 +44,7 @@ public class RulerEditPart extends AbstractGraphicalEditPart {
 	private AccessibleEditPart accPart;
 	private RulerProvider rulerProvider;
 	private boolean horizontal;
-	private RulerChangeListener listener = new RulerChangeListener.Stub() {
+	private final RulerChangeListener listener = new RulerChangeListener.Stub() {
 		@Override
 		public void notifyGuideReparented(Object guide) {
 			handleGuideReparented(guide);
@@ -177,7 +177,7 @@ public class RulerEditPart extends AbstractGraphicalEditPart {
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#getModelChildren()
 	 */
 	@Override
-	protected List getModelChildren() {
+	protected List<? extends Object> getModelChildren() {
 		return getRulerProvider().getGuides();
 	}
 
@@ -198,9 +198,8 @@ public class RulerEditPart extends AbstractGraphicalEditPart {
 	public EditPart getTargetEditPart(Request request) {
 		if (request.getType().equals(REQ_MOVE)) {
 			return this;
-		} else {
-			return super.getTargetEditPart(request);
 		}
+		return super.getTargetEditPart(request);
 	}
 
 	public ZoomManager getZoomManager() {

--- a/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/rulers/RulerProvider.java
@@ -225,8 +225,8 @@ public abstract class RulerProvider {
 	 *
 	 * @return an empty list
 	 */
-	public List getGuides() {
-		return Collections.EMPTY_LIST;
+	public List<? extends Object> getGuides() {
+		return Collections.emptyList();
 	}
 
 	/**


### PR DESCRIPTION
To reduce the number of warnings a bit more getModelChildren has now a type. Has little impact on the code.

https://github.com/eclipse/gef-classic/issues/155