### PR TITLE
[Zest 2.0] Mark stub-implementation of ProgressListener as for-removal

### DIFF
--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
@@ -29,8 +29,14 @@ public interface ProgressListener {
 	/**
 	 * An empty implementation of {@list ProgressListener} for convenience.
 	 *
+	 * @deprecated No longer used in Zest 2.x. This interface will be removed in a
+	 *             future release.
+	 * @noextend This interface is not intended to be extended by clients.
+	 * @noreference This interface is not intended to be referenced by clients.
+	 * @noimplement This interface is not intended to be implemented by clients.
 	 * @since 1.5
 	 */
+	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Stub implements ProgressListener {
 		@Override
 		public void progressStarted(ProgressEvent e) {


### PR DESCRIPTION
The ProgressListener has been marked as deprecated and is no longer supported in Zest 2.0. Meaning the stub implementation also needs to be marked as such, in order to propagate the removal warning.