### PR TITLE
[Zest 2.0] Resolve Zest 1.0-related compiler warnings

### DIFF
--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutAlgorithm.java
@@ -29,6 +29,7 @@ import org.eclipse.zest.layouts.progress.ProgressListener;
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("rawtypes")
 public interface LayoutAlgorithm {
 
 	/**

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutEntity.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutEntity.java
@@ -28,6 +28,7 @@ import org.eclipse.zest.layouts.interfaces.NodeLayout;
  * @noreference This interface is not intended to be referenced by clients..
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("rawtypes")
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutEntity extends Comparable, LayoutItem {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutGraph.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutGraph.java
@@ -25,6 +25,7 @@ import java.util.List;
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("rawtypes")
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutGraph {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutIterationEvent.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutIterationEvent.java
@@ -27,6 +27,7 @@ import java.util.List;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("rawtypes")
 @Deprecated(since = "2.0", forRemoval = true)
 public class LayoutIterationEvent {
 	private List relationshipsToLayout, entitiesToLayout;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/NestedLayoutEntity.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/NestedLayoutEntity.java
@@ -26,6 +26,7 @@ import org.eclipse.zest.layouts.interfaces.SubgraphLayout;
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("rawtypes")
 @Deprecated(since = "2.0", forRemoval = true)
 public interface NestedLayoutEntity extends LayoutEntity {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
@@ -56,6 +56,7 @@ import org.eclipse.zest.layouts.progress.ProgressListener;
  * @noextend This class is not intended to be subclassed by clients.
  * @noreference This class is not intended to be referenced by clients.
  */
+@SuppressWarnings({ "rawtypes", "unchecked" })
 @Deprecated(since = "2.0", forRemoval = true)
 public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm.Zest1, Stoppable {
 
@@ -74,9 +75,9 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm.Zest1, 
 	private double widthToHeightRatio;
 
 	class InternalComparator implements Comparator<InternalNode> {
-		Comparator externalComparator = null;
+		Comparator<LayoutEntity> externalComparator = null;
 
-		public InternalComparator(Comparator externalComparator) {
+		public InternalComparator(Comparator<LayoutEntity> externalComparator) {
 			this.externalComparator = externalComparator;
 		}
 
@@ -475,6 +476,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm.Zest1, 
 	 *
 	 * @param relationshipsToConsider
 	 */
+	@SuppressWarnings("static-method")
 	protected void updateBendPoints(InternalRelationship[] relationshipsToConsider) {
 		for (InternalRelationship relationship : relationshipsToConsider) {
 			List bendPoints = relationship.getBendPoints();
@@ -830,6 +832,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm.Zest1, 
 	 * nodes or not. If the size is not included, the bounds will only be guaranteed
 	 * to include the center of each node.
 	 */
+	@SuppressWarnings("static-method")
 	protected DisplayIndependentRectangle getLayoutBounds(InternalNode[] entitiesToLayout, boolean includeNodeSize) {
 		double rightSide = Double.MIN_VALUE;
 		double bottomSide = Double.MIN_VALUE;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
@@ -42,6 +42,7 @@ public class GridLayoutAlgorithm implements LayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
+	@SuppressWarnings("unchecked")
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm {
 
@@ -192,6 +193,7 @@ public class GridLayoutAlgorithm implements LayoutAlgorithm {
 			}
 		}
 
+		@SuppressWarnings("static-method")
 		protected int[] calculateNumberOfRowsAndCols_square(int numChildren, double boundX, double boundY,
 				double boundWidth, double boundHeight) {
 			int rows = Math.max(1, (int) Math.sqrt(numChildren * boundHeight / boundWidth));
@@ -241,6 +243,7 @@ public class GridLayoutAlgorithm implements LayoutAlgorithm {
 			return result;
 		}
 
+		@SuppressWarnings("static-method")
 		protected int[] calculateNumberOfRowsAndCols_rectangular(int numChildren) {
 			int rows = Math.max(1, (int) Math.ceil(Math.sqrt(numChildren)));
 			int cols = Math.max(1, (int) Math.ceil(Math.sqrt(numChildren)));

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
@@ -44,6 +44,7 @@ public class RadialLayoutAlgorithm implements LayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends TreeLayoutAlgorithm.Zest1 {
 		private static final double MAX_DEGREES = Math.PI * 2;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
@@ -56,6 +56,7 @@ public class TreeLayoutAlgorithm implements LayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
@@ -13,6 +13,7 @@
 package org.eclipse.zest.layouts.dataStructures;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.zest.layouts.LayoutEntity;
 import org.eclipse.zest.layouts.constraints.BasicEntityConstraint;
@@ -26,11 +27,12 @@ import org.eclipse.zest.layouts.constraints.LayoutConstraint;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("rawtypes")
 @Deprecated(since = "2.0", forRemoval = true)
 public class InternalNode implements Comparable, LayoutEntity {
 
 	private LayoutEntity entity = null;
-	private HashMap attributeMap = new HashMap();
+	private final Map<Object, Object> attributeMap = new HashMap<>();
 	BasicEntityConstraint basicEntityConstraint = new BasicEntityConstraint();
 
 	public InternalNode(LayoutEntity entity) {
@@ -150,11 +152,13 @@ public class InternalNode implements Comparable, LayoutEntity {
 
 	// TODO: Fix all these preferred stuff!!!!! NOW!
 
+	@SuppressWarnings("static-method")
 	public boolean hasPreferredWidth() {
 		return false;
 		// return enity.getAttributeInLayout(LayoutEntity.ATTR_PREFERRED_WIDTH) != null;
 	}
 
+	@SuppressWarnings("static-method")
 	public double getPreferredWidth() {
 		return 0.0;
 //	    if (hasPreferredWidth()) {
@@ -164,12 +168,14 @@ public class InternalNode implements Comparable, LayoutEntity {
 //	    }
 	}
 
+	@SuppressWarnings("static-method")
 	public boolean hasPreferredHeight() {
 		return false;
 		// return entity.getAttributeInLayout(LayoutEntity.ATTR_PREFERRED_HEIGHT) !=
 		// null;
 	}
 
+	@SuppressWarnings("static-method")
 	public double getPreferredHeight() {
 		return 0.0;
 //	    if (hasPreferredHeight()) {

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
@@ -29,6 +29,7 @@ import org.eclipse.zest.layouts.constraints.LayoutConstraint;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("rawtypes")
 @Deprecated(since = "2.0", forRemoval = true)
 public class InternalRelationship implements LayoutRelationship {
 
@@ -36,7 +37,7 @@ public class InternalRelationship implements LayoutRelationship {
 	private InternalNode source;
 	private InternalNode destination;
 	private Object layoutInfo;
-	private List bendPoints = new LinkedList();
+	private List<BendPoint> bendPoints = new LinkedList<>();
 	BasicEdgeConstraints basicEdgeConstraints = new BasicEdgeConstraints();
 
 	public InternalRelationship(LayoutRelationship externalRelationship, InternalNode source,


### PR DESCRIPTION
Primarily related to the references of deprecated classes marked as for-removal as well as the usage of raw types in the Zest 1.0 API. Where possible, the warnings have been resolved properly as best as possibles. But whenever this touches public API, we simply suppress the warning.

Given that this API will be removed in an upcoming release, the focus should be on stability and to avoid any incompatibilities that might arise from using the actual rather than raw types.