### PR TITLE
[Zest 2.0] Cleanup compiler warning in Zest graph viewer

### DIFF
--- a/org.eclipse.zest.core/.settings/.api_filters
+++ b/org.eclipse.zest.core/.settings/.api_filters
@@ -1,36 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.zest.core" version="2">
-    <resource path="src/org/eclipse/zest/core/viewers/AbstractZoomableViewer.java" type="org.eclipse.zest.core.viewers.AbstractZoomableViewer">
-        <filter id="643842064">
-            <message_arguments>
-                <message_argument value="ZoomManager"/>
-                <message_argument value="AbstractZoomableViewer"/>
-                <message_argument value="getZoomManager()"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/zest/core/viewers/GraphViewer.java" type="org.eclipse.zest.core.viewers.GraphViewer">
-        <filter id="576720909">
-            <message_arguments>
-                <message_argument value="AbstractStructuredGraphViewer"/>
-                <message_argument value="GraphViewer"/>
-            </message_arguments>
-        </filter>
-        <filter id="643842064">
-            <message_arguments>
-                <message_argument value="IStylingGraphModelFactory"/>
-                <message_argument value="GraphViewer"/>
-                <message_argument value="getFactory()"/>
-            </message_arguments>
-        </filter>
-        <filter id="643842064">
-            <message_arguments>
-                <message_argument value="ZoomManager"/>
-                <message_argument value="GraphViewer"/>
-                <message_argument value="getZoomManager()"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/zest/core/widgets/GraphContainer.java" type="org.eclipse.zest.core.widgets.GraphContainer">
         <filter id="627060751">
             <message_arguments>

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/AbstractStructuredGraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/AbstractStructuredGraphViewer.java
@@ -53,6 +53,7 @@ import org.eclipse.draw2d.geometry.Point;
  * @since 1.13
  * @noextend This class is not intended to be subclassed by clients.
  */
+@SuppressWarnings("removal")
 public abstract class AbstractStructuredGraphViewer extends AbstractZoomableViewer {
 	/**
 	 * Contains top-level styles for the entire graph. Set in the constructor. *
@@ -671,7 +672,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 	 * @param point1 must not be null
 	 * @param point2 may be null - in that case, point1 is returned
 	 */
-	private Point getTopLeftBoundary(Point point1, Point point2) {
+	private static Point getTopLeftBoundary(Point point1, Point point2) {
 		if (point2 != null) {
 			return new Point(Math.min(point1.x, point2.x), Math.min(point1.y, point2.y));
 		}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
@@ -227,6 +227,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 
 	@Override
 	protected void setSelectionToWidget(@SuppressWarnings("rawtypes") List l, boolean reveal) {
+		@SuppressWarnings("unchecked")
 		GraphItem[] listOfItems = findItems(l);
 		graph.setSelection(listOfItems);
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStylingModelFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/AbstractStylingModelFactory.java
@@ -44,6 +44,7 @@ import org.eclipse.draw2d.IFigure;
  */
 // @tag zest.bug.160367-Refreshing.fix : update the factory to use the
 // IStylingGraphModelFactory
+@SuppressWarnings("removal")
 public abstract class AbstractStylingModelFactory implements IStylingGraphModelFactory {
 	private AbstractStructuredGraphViewer viewer;
 	private int connectionStyle;

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
@@ -40,6 +40,7 @@ import org.eclipse.draw2d.IFigure;
  * @author Del Myers
  */
 // @tag bug(151327-Styles) : created to help resolve this bug
+@SuppressWarnings("removal")
 public class GraphItemStyler {
 	public static void styleItem(GraphItem item, final IBaseLabelProvider labelProvider) {
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityFactory.java
@@ -30,6 +30,7 @@ import org.eclipse.zest.core.widgets.GraphNode;
  *
  * @author Ian Bull
  */
+@SuppressWarnings("removal")
 public class GraphModelEntityFactory extends AbstractStylingModelFactory {
 
 	AbstractStructuredGraphViewer viewer = null;

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.zest.core.widgets.GraphNode;
  * @author Ian Bull
  * @author Chris Callendar
  */
+@SuppressWarnings("removal")
 public class GraphModelFactory extends AbstractStylingModelFactory {
 
 	AbstractStructuredGraphViewer viewer = null;


### PR DESCRIPTION
A lot of methods have been marked as deprecated & for-removal due to the new Zest 2.0 API. Because those methods can't be deleted yet due to backwards compatibility, we simply suppress those warnings.