### PR TITLE
[Zest 2.0] Cleanup compiler warnings in GraphContainer

### DIFF
--- a/org.eclipse.zest.core/.settings/.api_filters
+++ b/org.eclipse.zest.core/.settings/.api_filters
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.zest.core" version="2">
     <resource path="src/org/eclipse/zest/core/widgets/GraphContainer.java" type="org.eclipse.zest.core.widgets.GraphContainer">
+        <filter id="572522506">
+            <message_arguments>
+                <message_argument value="Zest1"/>
+                <message_argument value="GraphContainer"/>
+            </message_arguments>
+        </filter>
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IContainer2"/>
+                <message_argument value="GraphContainer"/>
+            </message_arguments>
+        </filter>
         <filter id="627060751">
             <message_arguments>
                 <message_argument value="ZestRootLayer"/>

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -109,7 +109,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	private final List<GraphNode> nodes;
 	protected List<GraphConnection> connections;
 	private List<GraphItem> selectedItems = null;
-	Set subgraphFigures;
+	Set<IFigure> subgraphFigures;
 	private HideNodeHelper hoverNode = null;
 	IFigure fisheyedFigure = null;
 	private final ArrayList fisheyeListeners = new ArrayList();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/IContainer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/IContainer.java
@@ -54,7 +54,7 @@ public interface IContainer {
 	 */
 	public void setLayoutAlgorithm(LayoutAlgorithm algorithm, boolean applyLayout);
 
-	public List getNodes();
+	public List<? extends GraphNode> getNodes();
 
 	/* protected void highlightNode(GraphNode node); */
 


### PR DESCRIPTION
There are several instances where raw types are used instead of the GraphNode and GraphConnection widgets. Several private method can be marked as static.

The warnings caused by usage of the deprecated Zest 1.0 API have been suppressed, as those are needed for backwards compatibility to e.g. apply layouts using the old layout algorithms.