### PR TITLE
[Zest 2.0] Fix: Layout inside GraphContainers is not applied correctly.

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
@@ -614,7 +614,7 @@ public class GraphContainer extends GraphNode implements IContainer2 {
 				zest1.applyLayout(nodesToLayout, connectionsToLayout, 25, 25, d.width - 50, d.height - 50, false,
 						false);
 			} else {
-				layoutAlgorithm.applyLayout(false);
+				layoutAlgorithm.applyLayout(true);
 				layoutContext.flushChanges(false);
 			}
 			Animation.run(ANIMATION_TIME);


### PR DESCRIPTION
This can be observed when using the ZoomSnippet with the Zest 2.0 layouts; The nodes inside the containers arent't aligned according to the RadialLayoutAlgorithm but instead all placed in the top-left corner.

This is because we call applyLayout(false), which is a no-op operation for this algorithm.

One can reproduce this issue by checking the ZoomSnippet, where the nodes inside the containers are not position correctly, after expanding the container.