### PR TITLE
[Zest 2.0] Fix: Use SWT constants for horizontal and vertical alignment

### DIFF
--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/BoxLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/BoxLayoutAlgorithm.java
@@ -12,6 +12,8 @@
  ******************************************************************************/
 package org.eclipse.zest.layouts.algorithms;
 
+import org.eclipse.swt.SWT;
+
 /**
  * Layout algorithm that places all elements in one column or one row, depending
  * on set orientation.
@@ -20,11 +22,7 @@ package org.eclipse.zest.layouts.algorithms;
  */
 public class BoxLayoutAlgorithm extends GridLayoutAlgorithm {
 
-	public static final int HORIZONTAL = 1;
-
-	public static final int VERTICAL = 2;
-
-	private int orientation = HORIZONTAL;
+	private int orientation = SWT.HORIZONTAL;
 
 	public BoxLayoutAlgorithm() {
 	}
@@ -38,7 +36,7 @@ public class BoxLayoutAlgorithm extends GridLayoutAlgorithm {
 	}
 
 	public void setOrientation(int orientation) {
-		if ((orientation != HORIZONTAL) && (orientation != VERTICAL)) {
+		if ((orientation != SWT.HORIZONTAL) && (orientation != SWT.VERTICAL)) {
 			throw new RuntimeException("Invalid orientation: " + orientation); //$NON-NLS-1$
 		}
 		this.orientation = orientation;
@@ -47,7 +45,7 @@ public class BoxLayoutAlgorithm extends GridLayoutAlgorithm {
 	@Override
 	protected int[] calculateNumberOfRowsAndCols(int numChildren, double boundX, double boundY, double boundWidth,
 			double boundHeight) {
-		if (orientation == HORIZONTAL) {
+		if (orientation == SWT.HORIZONTAL) {
 			return new int[] { numChildren, 1 };
 		}
 		return new int[] { 1, numChildren };

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
@@ -150,17 +150,7 @@ public class DirectedGraphLayoutAlgorithm implements LayoutAlgorithm {
 		}
 	}
 
-	/**
-	 * @since 2.0
-	 */
-	public static final int HORIZONTAL = 1;
-
-	/**
-	 * @since 2.0
-	 */
-	public static final int VERTICAL = 2;
-
-	private int orientation = VERTICAL;
+	private int orientation = SWT.VERTICAL;
 
 	private LayoutContext context;
 
@@ -171,7 +161,7 @@ public class DirectedGraphLayoutAlgorithm implements LayoutAlgorithm {
 	}
 
 	public DirectedGraphLayoutAlgorithm(int orientation) {
-		if (orientation == VERTICAL) {
+		if (orientation == SWT.VERTICAL) {
 			this.orientation = orientation;
 		}
 	}
@@ -187,7 +177,7 @@ public class DirectedGraphLayoutAlgorithm implements LayoutAlgorithm {
 	 * @since 2.0
 	 */
 	public void setOrientation(int orientation) {
-		if (orientation == HORIZONTAL || orientation == VERTICAL) {
+		if (orientation == SWT.HORIZONTAL || orientation == SWT.VERTICAL) {
 			this.orientation = orientation;
 		}
 	}
@@ -221,7 +211,7 @@ public class DirectedGraphLayoutAlgorithm implements LayoutAlgorithm {
 		for (Object node2 : graph.nodes) {
 			Node node = (Node) node2;
 			EntityLayout entity = (EntityLayout) node.data;
-			if (orientation == VERTICAL) {
+			if (orientation == SWT.VERTICAL) {
 				entity.setLocation(node.x, node.y);
 			} else {
 				entity.setLocation(node.y, node.x);

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SugiyamaLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SugiyamaLayoutAlgorithm.java
@@ -22,6 +22,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.swt.SWT;
+
 import org.eclipse.zest.layouts.LayoutAlgorithm;
 import org.eclipse.zest.layouts.dataStructures.DisplayIndependentRectangle;
 import org.eclipse.zest.layouts.interfaces.LayoutContext;
@@ -51,10 +53,6 @@ import org.eclipse.draw2d.geometry.Dimension;
  */
 @SuppressWarnings("javadoc")
 public class SugiyamaLayoutAlgorithm implements LayoutAlgorithm {
-
-	// Tree direction constants
-	public final static int HORIZONTAL = 1;
-	public final static int VERTICAL = 2;
 
 	// Internal constants
 	private static final int MAX_LAYERS = 10;
@@ -160,10 +158,10 @@ public class SugiyamaLayoutAlgorithm implements LayoutAlgorithm {
 	 *            {@link LayoutContext#getBounds()} if not set
 	 */
 	public SugiyamaLayoutAlgorithm(int dir, Dimension dim) {
-		if (dir == HORIZONTAL) {
-			direction = HORIZONTAL;
+		if (dir == SWT.HORIZONTAL) {
+			direction = SWT.HORIZONTAL;
 		} else {
-			direction = VERTICAL;
+			direction = SWT.VERTICAL;
 		}
 		dimension = dim;
 	}
@@ -173,7 +171,7 @@ public class SugiyamaLayoutAlgorithm implements LayoutAlgorithm {
 	}
 
 	public SugiyamaLayoutAlgorithm() {
-		this(VERTICAL, null);
+		this(SWT.VERTICAL, null);
 	}
 
 	/*
@@ -392,7 +390,7 @@ public class SugiyamaLayoutAlgorithm implements LayoutAlgorithm {
 		}
 		double dx = boundary.width / layers.size();
 		double dy = boundary.height / (last + 1);
-		if (direction == HORIZONTAL) {
+		if (direction == SWT.HORIZONTAL) {
 			for (NodeLayout node : context.getNodes()) {
 				NodeWrapper nw = map.get(node);
 				node.setLocation((nw.layer + 0.5d) * dx, (nw.index + 0.5d) * dy);


### PR DESCRIPTION
The SWT class provides perfectly fine constants. There is no need for us to re-define those constants when we can simply reuse them.