### PR TITLE
[Zest 2.0] Fix: WidgetIsDisposedException  when applying graph layout

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -1355,6 +1355,9 @@ public class Graph extends FigureCanvas implements IContainer2 {
 		synchronized (this) {
 			if (scheduledLayoutRunnable == null) {
 				Display.getDefault().asyncExec(scheduledLayoutRunnable = () -> {
+					if (Graph.this.isDisposed()) {
+						return;
+					}
 					int layoutStyle = 0;
 
 					if ((nodeStyle & ZestStyles.NODES_NO_LAYOUT_RESIZE) > 0) {


### PR DESCRIPTION
Because the layout algorithm is executed asynchronously, it may happen that the layout is performed AFTER the graph has been disposed. Explicitly check the state of the graph to avoid this issue.

This issue can easily be reproduced by opening and closing one of the snippets.