### PR TITLE
[Zest 2.0] Fix: Deprecation warnings in GraphNode constructor

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -107,12 +107,12 @@ public class GraphNode extends GraphItem {
 	private boolean hasCustomTooltip;
 
 	public GraphNode(IContainer graphModel, int style) {
-		this(graphModel, style, null);
+		this(graphModel, style, (Object) null);
 	}
 
 	/**
-	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int)} and
-	 *             {@link #setData(Object)}
+	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int, IFigure)}
+	 *             instead.
 	 */
 	@Deprecated(since = "1.12", forRemoval = true)
 	public GraphNode(IContainer graphModel, int style, Object data) {
@@ -120,8 +120,15 @@ public class GraphNode extends GraphItem {
 	}
 
 	/**
+	 * @since 1.13
+	 */
+	public GraphNode(IContainer graphModel, int style, IFigure data) {
+		this(graphModel, style, "" /* text */, null /* image */, data); //$NON-NLS-1$
+	}
+
+	/**
 	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int)} and
-	 *             {@link #setData(Object)}
+	 *             {@link #setText(String)}
 	 */
 	@Deprecated(since = "1.12", forRemoval = true)
 	public GraphNode(IContainer graphModel, int style, String text) {
@@ -129,8 +136,8 @@ public class GraphNode extends GraphItem {
 	}
 
 	/**
-	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int)},
-	 *             {@link #setText(String)} and {@link #setData(Object)}
+	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int, IFigure)}
+	 *             and {@link #setText(String)}
 	 */
 	@Deprecated(since = "1.12", forRemoval = true)
 	public GraphNode(IContainer graphModel, int style, String text, Object data) {
@@ -147,9 +154,8 @@ public class GraphNode extends GraphItem {
 	}
 
 	/**
-	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int)},
-	 *             {@link #setText(String)}, {@link #setImage(Image)} and
-	 *             {@link #setData(Object)}
+	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int, IFigure)},
+	 *             {@link #setText(String)} and {@link #setImage(Image)}.
 	 */
 	@Deprecated(since = "1.12", forRemoval = true)
 	public GraphNode(IContainer graphModel, int style, String text, Image image, Object data) {


### PR DESCRIPTION
The constructors where one could pass the data object has been marked for removal as part of the Zest 2.0 migration, with the suggestion to call setData() afterwards.

However, this might not be possible for e.g. the CGraphNode, where the data object is returned by a call to createFigureForModel(), which then leads to an exception if this field hasn't been initialized yet.

To remedy this situation, the constructors expecting a raw object as data remain deprecated and instead a new constructor has been created, where this object has to be of type IFigure.