### PR TITLE
[Zest 2.0] Fix API warnings in GraphConnection class

### DIFF
--- a/org.eclipse.zest.core/.settings/.api_filters
+++ b/org.eclipse.zest.core/.settings/.api_filters
@@ -1,5 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.zest.core" version="2">
+    <resource path="src/org/eclipse/zest/core/widgets/GraphConnection.java" type="org.eclipse.zest.core.widgets.GraphConnection$GraphLayoutConnection">
+        <filter id="574619656">
+            <message_arguments>
+                <message_argument value="LayoutRelationship"/>
+                <message_argument value="GraphLayoutConnection"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="LayoutBendPoint"/>
+                <message_argument value="GraphLayoutConnection"/>
+                <message_argument value="getIsControlPoint()"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="LayoutBendPoint"/>
+                <message_argument value="GraphLayoutConnection"/>
+                <message_argument value="getX()"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="LayoutBendPoint"/>
+                <message_argument value="GraphLayoutConnection"/>
+                <message_argument value="getY()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/zest/core/widgets/GraphContainer.java" type="org.eclipse.zest.core.widgets.GraphContainer">
         <filter id="572522506">
             <message_arguments>


### PR DESCRIPTION
The class is referencing old Zest 1.0 methods for the sake of backwards compatibility. Given that those methods should no longer be used, they therefore produce a corresponding API warning.

Because usage is intentional with no Zest 2.0 counterpart, we simply suppress those warnings.