### PR TITLE
Fix: ToolTipHelper doesn't work properly on Linux

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ToolTipHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -120,6 +120,11 @@ public class ToolTipHelper extends PopUpHelper {
 					.getExpanded(getShellTrimSize());
 			setShellBounds(displayPoint.x, displayPoint.y, shellSize.width, shellSize.height);
 			show();
+			// Moving an invisible shell might not be supported by the operating system. Try
+			// again once it has become visible...
+			if (!getShell().getLocation().equals(displayPoint)) {
+				setShellBounds(displayPoint.x, displayPoint.y, shellSize.width, shellSize.height);
+			}
 			currentTipSource = hoverSource;
 			timer = new Timer(true);
 			timer.schedule(new TimerTask() {


### PR DESCRIPTION
The pop-up helper reuses the shell that is used to display the tooltip. When a new tooltip is shown, the (currently invisible) shell is moved from its old location and then made visible. This doesn't work in GTK and the shell remains at its old location.

After the shell has been made visible, it is checked whether the shell has been correctly moved and if necessary, the shell coordinates are updated again. Note that it is still necessary to set the bounds while the shell is invisible, in order to properly handle the first tooltip that is shown.

Resolves https://github.com/eclipse/gef-classic/issues/531