### PR TITLE
[Zest 2.0] Resolve remaining i18n warnings in Zest Core

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/AbstractStructuredGraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/AbstractStructuredGraphViewer.java
@@ -114,7 +114,7 @@ public abstract class AbstractStructuredGraphViewer extends AbstractZoomableView
 		}
 
 		private String getObjectString(Object o) {
-			String s = o.getClass().getName() + "@" + Integer.toHexString(o.hashCode());
+			String s = o.getClass().getName() + '@' + Integer.toHexString(o.hashCode());
 			while (storedStrings.contains(s)) {
 				s = s + 'X';
 			}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/AbstractZoomableViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/AbstractZoomableViewer.java
@@ -39,7 +39,7 @@ public abstract class AbstractZoomableViewer extends StructuredViewer {
 	public void zoomTo(int x, int y, int width, int height) {
 		Rectangle r = new Rectangle(x, y, width, height);
 		if (r.isEmpty()) {
-			getZoomManager().setZoomAsText("100%");
+			getZoomManager().setZoomAsText("100%"); //$NON-NLS-1$
 		} else {
 			getZoomManager().zoomTo(r);
 		}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
@@ -195,7 +195,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 			super.setContentProvider(contentProvider);
 		} else {
 			throw new IllegalArgumentException(
-					"Invalid content provider, only IGraphContentProvider, IGraphEntityContentProvider, or IGraphEntityRelationshipContentProvider are supported.");
+					"Invalid content provider, only IGraphContentProvider, IGraphEntityContentProvider, or IGraphEntityRelationshipContentProvider are supported."); //$NON-NLS-1$
 		}
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphItemStyler.java
@@ -64,7 +64,7 @@ public class GraphItemStyler {
 			}
 			if (labelProvider instanceof ILabelProvider) {
 				String text = ((ILabelProvider) labelProvider).getText(node.getData());
-				node.setText((text != null) ? text : "");
+				node.setText((text != null) ? text : ""); //$NON-NLS-1$
 				node.setImage(((ILabelProvider) labelProvider).getImage(node.getData()));
 			}
 			if (labelProvider instanceof ISelfStyleProvider) {
@@ -80,7 +80,7 @@ public class GraphItemStyler {
 			}
 			if (labelProvider instanceof ILabelProvider) {
 				String text = ((ILabelProvider) labelProvider).getText(conn.getExternalConnection());
-				conn.setText((text != null) ? text : "");
+				conn.setText((text != null) ? text : ""); //$NON-NLS-1$
 				conn.setImage(((ILabelProvider) labelProvider).getImage(conn.getExternalConnection()));
 			}
 			if (labelProvider instanceof IEntityConnectionStyleProvider) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityRelationshipFactory.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/GraphModelEntityRelationshipFactory.java
@@ -35,7 +35,7 @@ public class GraphModelEntityRelationshipFactory extends AbstractStylingModelFac
 	public GraphModelEntityRelationshipFactory(AbstractStructuredGraphViewer viewer) {
 		super(viewer);
 		if (!(viewer.getContentProvider() instanceof IGraphEntityRelationshipContentProvider)) {
-			throw new IllegalArgumentException("Expected IGraphEntityRelationshipContentProvider");
+			throw new IllegalArgumentException("Expected IGraphEntityRelationshipContentProvider"); //$NON-NLS-1$
 		}
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/SharedMessages.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/SharedMessages.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.zest.core.viewers.internal;
 
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
 /**
  * This class contains UI strings (translated, if available) that clients can
  * use.
@@ -20,18 +23,39 @@ package org.eclipse.zest.core.viewers.internal;
  */
 //TODO zest 2.x: Move to org.eclipse.zest.core.widgets.internal
 public class SharedMessages {
+	private static final String BUNDLE_NAME = SharedMessages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+	private SharedMessages() {
+	}
+
+	private static String getString(String key) {
+		try {
+			return RESOURCE_BUNDLE.getString(key);
+		} catch (MissingResourceException e) {
+			return '!' + key + '!';
+		}
+	}
 
 	/**
 	 * The string "Page".
 	 */
-	public static String FitAllAction_Label = "Page"; // GEFMessages.FitAllAction_Label;
+	public static String FitAllAction_Label = getString("SharedMessages.FillAllAction_Label"); // GEFMessages.FitAllAction_Label; //$NON-NLS-1$
 	/**
 	 * The string "Width".
 	 */
-	public static String FitWidthAction_Label = "Width"; // GEFMessages.FitWidthAction_Label;
+	public static String FitWidthAction_Label = getString("SharedMessages.FillWidthAction_Label"); // GEFMessages.FitWidthAction_Label; //$NON-NLS-1$
 	/**
 	 * The string "Height".
 	 */
-	public static String FitHeightAction_Label = "Height"; // GEFMessages.FitHeightAction_Label;
+	public static String FitHeightAction_Label = getString("SharedMessages.FillHeightAction_Label"); // GEFMessages.FitHeightAction_Label; //$NON-NLS-1$
 
+	public static String NodeSearchDialog_Title = getString("NodeSearchDialog.Title"); //$NON-NLS-1$
+	public static String NodeSearchDialog_Find = getString("NodeSearchDialog.Find"); //$NON-NLS-1$
+	public static String NodeSearchDialog_Options = getString("NodeSearchDialog.Options"); //$NON-NLS-1$
+	public static String NodeSearchDialog_WholeWord = getString("NodeSearchDialog.WholeWord"); //$NON-NLS-1$
+	public static String NodeSearchDialog_CaseSensitive = getString("NodeSearchDialog.CaseSensitive"); //$NON-NLS-1$
+	public static String NodeSearchDialog_Next = getString("NodeSearchDialog.Next"); //$NON-NLS-1$
+	public static String NodeSearchDialog_Previous = getString("NodeSearchDialog.Previous"); //$NON-NLS-1$
+	public static String NodeSearchDialog_Close = getString("NodeSearchDialog.Close"); //$NON-NLS-1$
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/messages.properties
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/internal/messages.properties
@@ -1,0 +1,11 @@
+NodeSearchDialog.CaseSensitive=Case sensitive
+NodeSearchDialog.Close=Close
+NodeSearchDialog.Find=Find:
+NodeSearchDialog.Next=Next
+NodeSearchDialog.Options=Options:
+NodeSearchDialog.Previous=Previous
+NodeSearchDialog.Title=Find
+NodeSearchDialog.WholeWord=Whole Word
+SharedMessages.FillAllAction_Label=Page
+SharedMessages.FillHeightAction_Label=Height
+SharedMessages.FillWidthAction_Label=Width

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/DAGExpandCollapseManager.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/DAGExpandCollapseManager.java
@@ -64,7 +64,7 @@ public class DAGExpandCollapseManager implements ExpandCollapseManager {
 	public void initExpansion(final LayoutContext context2) {
 		if (!(context2 instanceof InternalLayoutContext)) {
 			throw new RuntimeException(
-					"This manager works only with org.eclipse.zest.core.widgets.InternalLayoutContext");
+					"This manager works only with org.eclipse.zest.core.widgets.InternalLayoutContext"); //$NON-NLS-1$
 		}
 		context = (InternalLayoutContext) context2;
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/DefaultSubgraph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/DefaultSubgraph.java
@@ -217,7 +217,7 @@ public class DefaultSubgraph implements SubgraphLayout {
 
 	protected DefaultSubgraph(LayoutContext context2) {
 		if (!(context2 instanceof InternalLayoutContext)) {
-			throw new RuntimeException("This subgraph can be only created with LayoutContext provided by Zest Graph");
+			throw new RuntimeException("This subgraph can be only created with LayoutContext provided by Zest Graph"); //$NON-NLS-1$
 		}
 		this.context = (InternalLayoutContext) context2;
 	}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -404,7 +404,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 */
 	@Override
 	public String toString() {
-		return "GraphModel {" + nodes.size() + " nodes, " + connections.size() + " connections}";
+		return "GraphModel {%d nodes, %d connections}".formatted(nodes.size(), connections.size()); //$NON-NLS-1$
 	}
 
 	/*
@@ -835,7 +835,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 				IContainer currentContainer = container;
 				while (currentContainer instanceof GraphContainer current) {
 					labelBuilder.insert(0, current.getText());
-					labelBuilder.insert(0, "/");
+					labelBuilder.insert(0, '/');
 					currentContainer = current.getParent();
 				}
 				labelBuilder.insert(0, oldShellLabel);
@@ -1291,7 +1291,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			figure = ((GraphNode) item).getModelFigure();
 			figure2ItemMap.put(figure, item);
 		} else {
-			throw new RuntimeException("Unknown item type: " + item.getItemType());
+			throw new RuntimeException("Unknown item type: " + item.getItemType()); //$NON-NLS-1$
 		}
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -253,11 +253,11 @@ public class GraphConnection extends GraphItem {
 	 */
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer("GraphModelConnection: ");
-		buffer.append(sourceNode != null ? sourceNode.getText() : "null");
-		buffer.append(isDirected() ? " --> " : " --- ");
-		buffer.append(destinationNode != null ? destinationNode.getText() : "null");
-		buffer.append("  (weight=").append(getWeightInLayout()).append(")");
+		StringBuffer buffer = new StringBuffer("GraphModelConnection: "); //$NON-NLS-1$
+		buffer.append(sourceNode != null ? sourceNode.getText() : "null"); //$NON-NLS-1$
+		buffer.append(isDirected() ? " --> " : " --- "); //$NON-NLS-1$ //$NON-NLS-2$
+		buffer.append(destinationNode != null ? destinationNode.getText() : "null"); //$NON-NLS-1$
+		buffer.append("  (weight=").append(getWeightInLayout()).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
 		return buffer.toString();
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphContainer.java
@@ -91,7 +91,7 @@ public class GraphContainer extends GraphNode implements IContainer2 {
 	 * @param style
 	 */
 	public GraphContainer(IContainer graph, int style) {
-		this(graph, style, "");
+		this(graph, style, ""); //$NON-NLS-1$
 
 	}
 
@@ -754,7 +754,7 @@ public class GraphContainer extends GraphNode implements IContainer2 {
 		scrollPane.setScrollBarVisibility(ScrollPane.AUTOMATIC);
 
 		// scalledLayer = new ScalableFreeformLayeredPane();
-		scalledLayer = new AspectRatioFreeformLayer("debug label");
+		scalledLayer = new AspectRatioFreeformLayer("debug label"); //$NON-NLS-1$
 		scalledLayer.addLayoutListener(LayoutAnimator.getDefault());
 		// scalledLayer.setScale(computeChildScale());
 		scalledLayer.setScale(computeWidthScale(), computeHeightScale());

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -116,7 +116,7 @@ public class GraphNode extends GraphItem {
 	 */
 	@Deprecated(since = "1.12", forRemoval = true)
 	public GraphNode(IContainer graphModel, int style, Object data) {
-		this(graphModel, style, "" /* text */, null /* image */, data);
+		this(graphModel, style, "" /* text */, null /* image */, data); //$NON-NLS-1$
 	}
 
 	/**
@@ -220,7 +220,7 @@ public class GraphNode extends GraphItem {
 	 */
 	@Override
 	public String toString() {
-		return "GraphModelNode: " + getText();
+		return "GraphModelNode: " + getText(); //$NON-NLS-1$
 	}
 
 	/**
@@ -632,7 +632,7 @@ public class GraphNode extends GraphItem {
 	@Override
 	public void setText(String string) {
 		if (string == null) {
-			string = "";
+			string = ""; //$NON-NLS-1$
 		}
 		super.setText(string);
 
@@ -909,7 +909,7 @@ public class GraphNode extends GraphItem {
 		GraphLabel label = new GraphLabel(node.getText(), node.getImage(), cacheLabel);
 		label.setFont(this.font);
 		if (checkStyle(ZestStyles.NODES_HIDE_TEXT)) {
-			label.setText("");
+			label.setText(""); //$NON-NLS-1$
 		}
 		updateFigureForModel(label);
 		label.addFigureListener(new FigureListener() {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/HideNodeHelper.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/HideNodeHelper.java
@@ -33,10 +33,10 @@ public class HideNodeHelper extends ContainerFigure {
 
 	private GraphNode node;
 
-	private Button hideButton = new Button("-");
-	private Button revealButton = new Button("+");
+	private Button hideButton = new Button("-"); //$NON-NLS-1$
+	private Button revealButton = new Button("+"); //$NON-NLS-1$
 	private int hiddenNodeCount = 0;
-	private GraphLabel hiddenNodesLabel = new GraphLabel("0", false);
+	private GraphLabel hiddenNodesLabel = new GraphLabel("0", false); //$NON-NLS-1$
 
 	private HideNodeListener thisHideNodeListener;
 	private List<HideNodeListener> hideNodeListeners = new ArrayList<>();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalLayoutContext.java
@@ -382,7 +382,7 @@ class InternalLayoutContext implements LayoutContext {
 
 	void checkChangesAllowed() {
 		if (!backgorundLayoutEnabled && !externalLayoutInvocation) {
-			throw new RuntimeException("Layout not allowed to perform changes in layout context!");
+			throw new RuntimeException("Layout not allowed to perform changes in layout context!"); //$NON-NLS-1$
 		}
 	}
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalNodeLayout.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalNodeLayout.java
@@ -109,7 +109,7 @@ class InternalNodeLayout implements NodeLayout {
 	@Override
 	public void prune(SubgraphLayout subgraph) {
 		if (subgraph != null && !(subgraph instanceof DefaultSubgraph)) {
-			throw new RuntimeException("InternalNodeLayout can be pruned only to instance of DefaultSubgraph.");
+			throw new RuntimeException("InternalNodeLayout can be pruned only to instance of DefaultSubgraph."); //$NON-NLS-1$
 		}
 		ownerLayoutContext.checkChangesAllowed();
 		if (subgraph == this.subgraph) {
@@ -322,7 +322,7 @@ class InternalNodeLayout implements NodeLayout {
 
 	@Override
 	public String toString() {
-		return node.toString() + "(layout)";
+		return node.toString() + "(layout)"; //$NON-NLS-1$
 	}
 
 	void dispose() {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/PrunedSuccessorsSubgraph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/PrunedSuccessorsSubgraph.java
@@ -227,7 +227,7 @@ class PrunedSuccessorsSubgraph extends DefaultSubgraph {
 					numberOfHiddenSuccessors++;
 				}
 			}
-			String labelText = numberOfHiddenSuccessors > 0 ? "" + numberOfHiddenSuccessors : "";
+			String labelText = numberOfHiddenSuccessors > 0 ? Integer.toString(numberOfHiddenSuccessors) : ""; //$NON-NLS-1$
 			if (!labelText.equals(label.getText())) {
 				label.setText(labelText);
 			}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/custom/LabelSubgraph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/custom/LabelSubgraph.java
@@ -61,7 +61,7 @@ public class LabelSubgraph extends FigureSubgraph {
 
 	@Override
 	protected void updateFigure() {
-		((Label) figure).setText("" + nodes.size());
+		((Label) figure).setText("" + nodes.size()); //$NON-NLS-1$
 	}
 
 	public LabelSubgraph(NodeLayout[] nodes, LayoutContext context, Color foregroundColor, Color backgroundColor) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/custom/TriangleSubgraph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/custom/TriangleSubgraph.java
@@ -229,7 +229,7 @@ public class TriangleSubgraph extends FigureSubgraph {
 		}
 		if ((direction != TOP_DOWN) && (direction != BOTTOM_UP) && (direction != LEFT_RIGHT)
 				&& (direction != RIGHT_LEFT)) {
-			throw new IllegalArgumentException("invalid direction");
+			throw new IllegalArgumentException("invalid direction"); //$NON-NLS-1$
 		}
 		parameters.direction = direction;
 		updateFigure();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AspectRatioFreeformLayer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/AspectRatioFreeformLayer.java
@@ -70,7 +70,7 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 	@Override
 	public double getScale() {
 		// TODO Auto-generated method stub
-		throw new RuntimeException("Operation not supported");
+		throw new UnsupportedOperationException("Operation not supported"); //$NON-NLS-1$
 		// return this.widthScale;
 
 		// throw new RuntimeException("Operation Not supported");
@@ -135,9 +135,9 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		} else if (t instanceof Point p) {
 			p.scale(1 / widthScale, 1 / heigthScale);
 		} else if (t instanceof PointList) {
-			throw new RuntimeException("PointList not supported in AspectRatioScale");
+			throw new UnsupportedOperationException("PointList not supported in AspectRatioScale"); //$NON-NLS-1$
 		} else {
-			throw new RuntimeException(t.toString() + " not supported in AspectRatioScale");
+			throw new UnsupportedOperationException(t.toString() + " not supported in AspectRatioScale"); //$NON-NLS-1$
 		}
 
 		// t.performScale(1/widthScale);
@@ -168,9 +168,9 @@ public class AspectRatioFreeformLayer extends FreeformLayer implements ScalableF
 		} else if (t instanceof Point p) {
 			p.scale(widthScale, heigthScale);
 		} else if (t instanceof PointList) {
-			throw new RuntimeException("PointList not supported in AspectRatioScale");
+			throw new UnsupportedOperationException("PointList not supported in AspectRatioScale"); //$NON-NLS-1$
 		} else {
-			throw new RuntimeException(t.toString() + " not supported in AspectRatioScale");
+			throw new UnsupportedOperationException(t.toString() + " not supported in AspectRatioScale"); //$NON-NLS-1$
 		}
 
 		super.translateToParent(t);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
@@ -107,11 +107,11 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 	private ToolbarLayout layout;
 
 	public ExpandGraphLabel(GraphContainer container, boolean cacheLabel) {
-		this(container, "", null, cacheLabel);
+		this(container, "", null, cacheLabel); //$NON-NLS-1$
 	}
 
 	public ExpandGraphLabel(GraphContainer container, Image i, boolean cacheLabel) {
-		this(container, "", i, cacheLabel);
+		this(container, "", i, cacheLabel); //$NON-NLS-1$
 	}
 
 	public ExpandGraphLabel(GraphContainer container, String text, boolean cacheLabel) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
@@ -50,7 +50,7 @@ public class GraphLabel extends CachedLabel implements IStyleableFigure {
 	 *                   faster, but the text is not as clear
 	 */
 	public GraphLabel(boolean cacheLabel) {
-		this("", cacheLabel);
+		this("", cacheLabel); //$NON-NLS-1$
 	}
 
 	/**
@@ -72,7 +72,7 @@ public class GraphLabel extends CachedLabel implements IStyleableFigure {
 	 *                   faster, but the
 	 */
 	public GraphLabel(Image i, boolean cacheLabel) {
-		this("", i, cacheLabel);
+		this("", i, cacheLabel); //$NON-NLS-1$
 	}
 
 	/**

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/NodeSearchDialog.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/NodeSearchDialog.java
@@ -14,6 +14,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
+import org.eclipse.zest.core.viewers.internal.SharedMessages;
 import org.eclipse.zest.core.widgets.GraphNode;
 
 public class NodeSearchDialog {
@@ -41,13 +42,13 @@ public class NodeSearchDialog {
 
 	private void createDialog(Shell parentShell) {
 		dialog = new Shell(parentShell, SWT.DIALOG_TRIM | SWT.MAX | SWT.RESIZE);
-		dialog.setText("Find");
+		dialog.setText(SharedMessages.NodeSearchDialog_Title);
 		GridLayout layout = new GridLayout(2, false);
 		dialog.setLayout(layout);
 
 		// 1st row
 		final Label label = new Label(dialog, SWT.NONE);
-		label.setText("Find:");
+		label.setText(SharedMessages.NodeSearchDialog_Find);
 
 		text = new Text(dialog, SWT.BORDER);
 		text.addFocusListener(new FocusAdapter() {
@@ -71,20 +72,20 @@ public class NodeSearchDialog {
 
 		// 2nd row
 		final Label optionsLabel = new Label(dialog, SWT.NONE);
-		optionsLabel.setText("Options:");
+		optionsLabel.setText(SharedMessages.NodeSearchDialog_Options);
 		new Label(dialog, SWT.NULL);
 
 		// 3rd row
 		wholeWordButton = new Button(dialog, SWT.CHECK);
 		wholeWordButton.addListener(SWT.Selection, e -> searchForNodes());
 		final Label wholeWordLabel = new Label(dialog, SWT.NONE);
-		wholeWordLabel.setText("Whole Word");
+		wholeWordLabel.setText(SharedMessages.NodeSearchDialog_WholeWord);
 
 		// 4th row
 		caseSensButton = new Button(dialog, SWT.CHECK);
 		caseSensButton.addListener(SWT.Selection, e -> searchForNodes());
 		final Label caseSensitiveLabel = new Label(dialog, SWT.NONE);
-		caseSensitiveLabel.setText("Case sensitive");
+		caseSensitiveLabel.setText(SharedMessages.NodeSearchDialog_CaseSensitive);
 
 		// 5th row
 		new Label(dialog, SWT.NULL);
@@ -93,12 +94,12 @@ public class NodeSearchDialog {
 		comp.setLayout(new GridLayout(2, false));
 
 		nextButton = new Button(comp, SWT.PUSH);
-		nextButton.setText("Next");
+		nextButton.setText(SharedMessages.NodeSearchDialog_Next);
 		nextButton.setEnabled(false);
 		nextButton.addListener(SWT.Selection, e -> changeNode(true));
 
 		prevButton = new Button(comp, SWT.PUSH);
-		prevButton.setText("Previous");
+		prevButton.setText(SharedMessages.NodeSearchDialog_Previous);
 		prevButton.setEnabled(false);
 		prevButton.addListener(SWT.Selection, e -> changeNode(false));
 
@@ -109,7 +110,7 @@ public class NodeSearchDialog {
 		comp.setLayoutData(new GridData(SWT.RIGHT, SWT.BOTTOM, true, true));
 
 		Button closeButton = new Button(comp, SWT.PUSH);
-		closeButton.setText("Close");
+		closeButton.setText(SharedMessages.NodeSearchDialog_Close);
 		closeButton.addListener(SWT.Selection, e -> dialog.close());
 
 		dialog.addDisposeListener(e -> isDisposed = true);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/XYScaledGraphics.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/XYScaledGraphics.java
@@ -614,7 +614,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	@Override
 	public void scale(double amount) {
 		// setScale(zoom * amount);
-		throw new RuntimeException("Operation not supported, use scale(x, y)");
+		throw new UnsupportedOperationException("Operation not supported, use scale(x, y)"); //$NON-NLS-1$
 	}
 
 	/**
@@ -730,7 +730,7 @@ public class XYScaledGraphics extends ScaledGraphics {
 	}
 
 	void setScale(double value) {
-		throw new RuntimeException("Operation not supported, use setScale(x,y)");
+		throw new UnsupportedOperationException("Operation not supported, use setScale(x,y)"); //$NON-NLS-1$
 
 		/*
 		 * if (zoom == value) return; this.zoom = value;

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ZestRootLayer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ZestRootLayer.java
@@ -200,7 +200,7 @@ public class ZestRootLayer extends FreeformLayer {
 	public void addDecoration(IFigure decorated, IFigure decorating) {
 		int position = this.getChildren().indexOf(decorated);
 		if (position == -1) {
-			throw new RuntimeException("Can't add decoration for a figuer that is not on this ZestRootLayer");
+			throw new RuntimeException("Can't add decoration for a figuer that is not on this ZestRootLayer"); //$NON-NLS-1$
 		}
 		itemsInLayer[getLayer(position)]++;
 		isLayerKnown = true;


### PR DESCRIPTION
Classes such as the NodeSearchDialog use translatable strings while other classes which use them as internal values simply suppress the warning.