### PR TITLE
[Zest 2.0] Reference replacement classes in deprecated layout algorithms

### DIFF
--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
@@ -12,13 +12,16 @@
  *******************************************************************************/
 package org.eclipse.zest.layouts.algorithms;
 
+import org.eclipse.swt.SWT;
+
 import org.eclipse.zest.layouts.LayoutStyles;
 
 /**
  * @version 2.0
  * @author Casey Best and Rob Lintern
  * @deprecated No longer used in Zest 2.x. This class will be removed in a
- *             future release.
+ *             future release. Use {@link BoxLayoutAlgorithm} with
+ *             {@link SWT#HORIZONTAL} instead.
  * @noextend This class is not intended to be subclassed by clients.
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
@@ -25,7 +25,8 @@ import org.eclipse.zest.layouts.dataStructures.InternalRelationship;
  * @version 1.0
  * @author Rob Lintern
  * @deprecated No longer used in Zest 2.x. This class will be removed in a
- *             future release.
+ *             future release. Use {@link TreeLayoutAlgorithm} with
+ *             {@link TreeLayoutAlgorithm#LEFT_RIGHT} instead.
  * @noextend This class is not intended to be subclassed by clients.
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
@@ -12,13 +12,16 @@
  *******************************************************************************/
 package org.eclipse.zest.layouts.algorithms;
 
+import org.eclipse.swt.SWT;
+
 import org.eclipse.zest.layouts.LayoutStyles;
 
 /**
  * @version 2.0
  * @author Casey Best and Rob Lintern (version 1.0 by Rob Lintern)
  * @deprecated No longer used in Zest 2.x. This class will be removed in a
- *             future release.
+ *             future release. Use {@link BoxLayoutAlgorithm} with
+ *             {@link SWT#VERTICAL} instead.
  * @noextend This class is not intended to be subclassed by clients.
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.


### PR DESCRIPTION
The HorizontalTreeLayoutAlgorithm is already implemented by the base TreeLayoutAlgorithm class by using LEFT_RIGHT and the Horizontal-/VerticalLayoutAlgorithm is implemented by the BoxLayoutAlgorith with either SWT.HORIZONTAL or SWT.VERTICAL