### PR TITLE
[Zest 2.0] Switch to new layout algorithms for tests and snippets

### DIFF
--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet1.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet1.java
@@ -26,7 +26,6 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.GraphViewer;
 import org.eclipse.zest.core.viewers.IGraphEntityContentProvider;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -125,7 +124,7 @@ public class GraphJFaceSnippet1 {
 
 		viewer.setContentProvider(new MyContentProvider());
 		viewer.setLabelProvider(new MyLabelProvider());
-		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING));
+		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm());
 		viewer.addSelectionChangedListener(event -> System.out.println("Selection changed: " + (event.getSelection())));
 		viewer.setInput(new Object());
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet2.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet2.java
@@ -22,7 +22,6 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.GraphViewer;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -117,7 +116,7 @@ public class GraphJFaceSnippet2 {
 		viewer = new GraphViewer(shell, SWT.NONE);
 		viewer.setContentProvider(new MyContentProvider());
 		viewer.setLabelProvider(new MyLabelProvider());
-		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING));
+		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm());
 		viewer.setInput(new Object());
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet3.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet3.java
@@ -29,7 +29,6 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.GraphViewer;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.RadialLayoutAlgorithm;
 
 /**
@@ -103,7 +102,7 @@ public class GraphJFaceSnippet3 {
 		viewer = new GraphViewer(shell, SWT.NONE);
 		viewer.setContentProvider(new SimpleGraphContentProvider());
 		viewer.setLabelProvider(new LabelProvider());
-		viewer.setLayoutAlgorithm(new RadialLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING));
+		viewer.setLayoutAlgorithm(new RadialLayoutAlgorithm());
 
 		shell.open();
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet4.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet4.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.GraphViewer;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 public class GraphJFaceSnippet4 {
@@ -108,7 +107,7 @@ public class GraphJFaceSnippet4 {
 		viewer = new GraphViewer(shell, SWT.NONE);
 		viewer.setContentProvider(new MyContentProvider());
 		viewer.setLabelProvider(new MyLabelProvider());
-		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING));
+		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm());
 		viewer.setInput(new Object());
 		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet5.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet5.java
@@ -149,7 +149,7 @@ public class GraphJFaceSnippet5 {
 		contentProvider = new MyContentProvider();
 		viewer.setContentProvider(contentProvider);
 		viewer.setLabelProvider(new MyLabelProvider());
-		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1());
+		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm());
 		viewer.setInput(new Object());
 	}
 }

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet6.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet6.java
@@ -25,7 +25,6 @@ import org.eclipse.zest.core.viewers.EntityConnectionData;
 import org.eclipse.zest.core.viewers.GraphViewer;
 import org.eclipse.zest.core.viewers.IGraphEntityContentProvider;
 import org.eclipse.zest.core.viewers.INestedContentProvider;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -134,7 +133,7 @@ public class GraphJFaceSnippet6 {
 		viewer = new GraphViewer(shell, SWT.NONE);
 		viewer.setContentProvider(new MyContentProvider());
 		viewer.setLabelProvider(new MyLabelProvider());
-		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING));
+		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm());
 		viewer.setInput(new Object());
 
 		Button button = new Button(shell, SWT.PUSH);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet7.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet7.java
@@ -28,7 +28,6 @@ import org.eclipse.zest.core.viewers.IFigureProvider;
 import org.eclipse.zest.core.viewers.IGraphEntityContentProvider;
 import org.eclipse.zest.core.viewers.INestedContentProvider;
 import org.eclipse.zest.examples.uml.UMLClassFigure;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 import org.eclipse.draw2d.IFigure;
@@ -181,7 +180,7 @@ public class GraphJFaceSnippet7 {
 		viewer = new GraphViewer(shell, SWT.NONE);
 		viewer.setContentProvider(new MyContentProvider());
 		viewer.setLabelProvider(new MyLabelProvider());
-		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING));
+		viewer.setLayoutAlgorithm(new SpringLayoutAlgorithm());
 		viewer.setInput(new Object());
 
 		Button button = new Button(shell, SWT.PUSH);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet8.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/GraphJFaceSnippet8.java
@@ -129,7 +129,7 @@ public class GraphJFaceSnippet8 {
 		viewer = new GraphViewer(shell, SWT.NONE);
 		viewer.setContentProvider(new MyContentProvider());
 		viewer.setLabelProvider(new MyLabelProvider());
-		viewer.setLayoutAlgorithm(new RadialLayoutAlgorithm.Zest1());
+		viewer.setLayoutAlgorithm(new RadialLayoutAlgorithm());
 		viewer.setInput(new Object());
 
 		shell.open();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/ManhattanLayoutJFaceSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/jface/ManhattanLayoutJFaceSnippet.java
@@ -29,7 +29,7 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.GraphViewer;
-import org.eclipse.zest.core.viewers.IConnectionStyleProvider;
+import org.eclipse.zest.core.viewers.IConnectionStyleProvider2;
 import org.eclipse.zest.core.viewers.IEntityConnectionStyleProvider2;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
@@ -99,7 +99,7 @@ public class ManhattanLayoutJFaceSnippet {
 
 	}
 
-	static class MyConnectionRelationLabelProvider extends LabelProvider implements IConnectionStyleProvider {
+	static class MyConnectionRelationLabelProvider extends LabelProvider implements IConnectionStyleProvider2 {
 		final Image image = Display.getDefault().getSystemImage(SWT.ICON_WARNING);
 
 		@Override

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
@@ -8,10 +8,8 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutEntity;
 import org.eclipse.zest.layouts.algorithms.AbstractLayoutAlgorithm;
-import org.eclipse.zest.layouts.dataStructures.InternalNode;
-import org.eclipse.zest.layouts.dataStructures.InternalRelationship;
+import org.eclipse.zest.layouts.interfaces.EntityLayout;
 
 /**
  * This snippet shows how to create a custom layout. This layout simply lays the
@@ -39,63 +37,18 @@ public class CustomLayout {
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);
-		g.setLayoutAlgorithm(new AbstractLayoutAlgorithm.Zest1(SWT.NONE) {
-
-			private int totalSteps;
-			private int currentStep;
-
+		g.setLayoutAlgorithm(new AbstractLayoutAlgorithm() {
 			@Override
-			protected void applyLayoutInternal(InternalNode[] entitiesToLayout,
-					InternalRelationship[] relationshipsToConsider, double boundsX, double boundsY, double boundsWidth,
-					double boundsHeight) {
-
-				totalSteps = entitiesToLayout.length;
-				double distance = boundsWidth / totalSteps;
+			public void applyLayout(boolean clean) {
+				EntityLayout[] entitiesToLayout = context.getEntities();
+				int totalSteps = entitiesToLayout.length;
+				double distance = context.getBounds().width / totalSteps;
 				int xLocation = 0;
-
-				fireProgressStarted(totalSteps);
-
-				for (currentStep = 0; currentStep < entitiesToLayout.length; currentStep++) {
-					LayoutEntity layoutEntity = entitiesToLayout[currentStep].getLayoutEntity();
-					layoutEntity.setLocationInLayout(xLocation, layoutEntity.getYInLayout());
+				for (EntityLayout layoutEntity : entitiesToLayout) {
+					layoutEntity.setLocation(xLocation, layoutEntity.getLocation().y);
 					xLocation += distance;
-					fireProgressEvent(currentStep, totalSteps);
 				}
-				fireProgressEnded(totalSteps);
 			}
-
-			@Override
-			protected int getCurrentLayoutStep() {
-				return 0;
-			}
-
-			@Override
-			protected int getTotalNumberOfLayoutSteps() {
-				return totalSteps;
-			}
-
-			@Override
-			protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
-				return true;
-			}
-
-			@Override
-			protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
-					InternalRelationship[] relationshipsToConsider) {
-				// Do nothing
-			}
-
-			@Override
-			protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout,
-					InternalRelationship[] relationshipsToConsider, double x, double y, double width, double height) {
-				// do nothing
-			}
-
-			@Override
-			public void setLayoutArea(double x, double y, double width, double height) {
-				// do nothing
-			}
-
 		}, true);
 
 		shell.open();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet1.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet1.java
@@ -23,7 +23,6 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.internal.NodeSearchDialog;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -55,7 +54,7 @@ public class GraphSnippet1 {
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		// example for dialog for searching nodes
 		NodeSearchDialog searchDialog = new NodeSearchDialog(g.getShell(), g.getNodes());

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet10.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet10.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -55,7 +54,7 @@ public class GraphSnippet10 {
 		connection.setLineWidth(3);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		Button button = new Button(shell, SWT.PUSH);
 		button.setText("Change Curve");

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet11.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet11.java
@@ -21,7 +21,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 import org.eclipse.draw2d.ColorConstants;
@@ -60,7 +59,7 @@ public class GraphSnippet11 {
 		createConnection(g, n, n2, ColorConstants.darkGray, 60);
 		createConnection(g, n, n2, ColorConstants.darkGray, -60);
 		createConnection(g, n, n2, ColorConstants.black, 0);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet12.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet12.java
@@ -26,7 +26,6 @@ import org.eclipse.zest.core.widgets.CGraphNode;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 import org.eclipse.draw2d.ColorConstants;
@@ -156,7 +155,7 @@ public class GraphSnippet12 {
 		new GraphConnection(g, SWT.NONE, n2, n5);
 		new GraphConnection(g, SWT.NONE, n3, n5);
 		new GraphConnection(g, SWT.NONE, n4, n5);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet13.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet13.java
@@ -28,7 +28,6 @@ import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphContainer;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 import org.eclipse.draw2d.ColorConstants;
@@ -173,7 +172,7 @@ public class GraphSnippet13 {
 		GraphConnection connection2 = new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, n2, n1);
 		connection2.setCurveDepth(-30);
 
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet14.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet14.java
@@ -19,7 +19,6 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.HideNodeHelper;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 import org.eclipse.draw2d.Button;
@@ -53,7 +52,7 @@ public class GraphSnippet14 {
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		// example: hide-nodes reveal-all button
 		if (g.getHideNodesEnabled()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet2.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet2.java
@@ -23,7 +23,6 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -56,7 +55,7 @@ public class GraphSnippet2 {
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n3);
 
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet3.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet3.java
@@ -25,7 +25,6 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -63,7 +62,7 @@ public class GraphSnippet3 {
 		new GraphConnection(g, SWT.NONE, n1, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet6.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet6.java
@@ -23,7 +23,6 @@ import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.GridLayoutAlgorithm;
 
 /**
@@ -60,7 +59,7 @@ public class GraphSnippet6 {
 			new GraphConnection(g, SWT.NONE, n2, n3);
 			new GraphConnection(g, SWT.NONE, n3, n3);
 		}
-		g.setLayoutAlgorithm(new GridLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new GridLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet7.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet7.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -53,7 +52,7 @@ public class GraphSnippet7 {
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		g.addMouseMoveListener(new MouseMoveListener() {
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/GraphSnippet8.java
@@ -20,9 +20,8 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
+import org.eclipse.zest.core.widgets.LayoutFilter;
 import org.eclipse.zest.core.widgets.ZestStyles;
-import org.eclipse.zest.layouts.Filter;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.TreeLayoutAlgorithm;
 
 import org.eclipse.draw2d.ColorConstants;
@@ -91,12 +90,8 @@ public class GraphSnippet8 {
 		connection.setLineColor(ColorConstants.red);
 		connection.setLineWidth(3);
 
-		TreeLayoutAlgorithm.Zest1 treeLayoutAlgorithm = new TreeLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING);
-		Filter filter = item -> {
-
-			// Get the "Connection" from the Layout Item
-			// and use this connection to get the "Graph Data"
-			Object object = item.getGraphData();
+		TreeLayoutAlgorithm treeLayoutAlgorithm = new TreeLayoutAlgorithm();
+		LayoutFilter filter = object -> {
 			if (object instanceof GraphConnection connection1) {
 				if (connection1.getData() instanceof Boolean boolVal) {
 					// If the data is false, don't filter, otherwise, filter.
@@ -106,7 +101,7 @@ public class GraphSnippet8 {
 			}
 			return false;
 		};
-		treeLayoutAlgorithm.setFilter(filter);
+		graph.addLayoutFilter(filter);
 		graph.setLayoutAlgorithm(treeLayoutAlgorithm, true);
 
 		shell.open();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/HelloWorld.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/HelloWorld.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 /**
@@ -46,7 +45,7 @@ public class HelloWorld {
 		GraphNode hello = new GraphNode(g, SWT.NONE, "Hello");
 		GraphNode world = new GraphNode(g, SWT.NONE, "World");
 		new GraphConnection(g, SWT.NONE, hello, world);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/LayoutExample.java
@@ -17,13 +17,10 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
-import org.eclipse.zest.core.widgets.ConstraintAdapter;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
-import org.eclipse.zest.layouts.constraints.BasicEdgeConstraints;
 
 /**
  * This snippet shows how to use constraints. Nodes are attracted to the
@@ -58,21 +55,16 @@ public class LayoutExample {
 			new GraphConnection(g, SWT.NONE, root, n);
 		}
 
-		SpringLayoutAlgorithm.Zest1 springLayoutAlgorithm = new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING);
+		SpringLayoutAlgorithm springLayoutAlgorithm = new SpringLayoutAlgorithm();
 
-		ConstraintAdapter constraintAdapters = (object, constraint) -> {
-			if (constraint instanceof BasicEdgeConstraints basicEdgeConstraints) {
-				GraphConnection connection = (GraphConnection) object;
-				if (connection.getSource().getText().equals("Root")) {
-					basicEdgeConstraints.weight = 1;
-				} else {
-					basicEdgeConstraints.weight = -1;
-				}
+		for (GraphConnection connection : g.getConnections()) {
+			if (connection.getSource().getText().equals("Root")) {
+				connection.setWeight(1.0);
+			} else {
+				connection.setWeight(-1.0);
 			}
+		}
 
-		};
-
-		g.addConstraintAdapter(constraintAdapters);
 		g.setLayoutAlgorithm(springLayoutAlgorithm, true);
 
 		shell.open();

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet.java
@@ -24,10 +24,9 @@ import org.eclipse.zest.core.widgets.GraphContainer;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
 import org.eclipse.zest.layouts.LayoutAlgorithm;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.CompositeLayoutAlgorithm;
 import org.eclipse.zest.layouts.algorithms.GridLayoutAlgorithm;
-import org.eclipse.zest.layouts.algorithms.HorizontalShift;
+import org.eclipse.zest.layouts.algorithms.HorizontalShiftAlgorithm;
 import org.eclipse.zest.layouts.algorithms.RadialLayoutAlgorithm;
 import org.eclipse.zest.layouts.algorithms.TreeLayoutAlgorithm;
 
@@ -92,9 +91,9 @@ public class NestedGraphSnippet {
 			c.setScale(0.25);
 		}
 		if (radial) {
-			c.setLayoutAlgorithm(new RadialLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+			c.setLayoutAlgorithm(new RadialLayoutAlgorithm(), true);
 		} else {
-			c.setLayoutAlgorithm(new TreeLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+			c.setLayoutAlgorithm(new TreeLayoutAlgorithm(), true);
 		}
 	}
 
@@ -115,10 +114,8 @@ public class NestedGraphSnippet {
 		g = new Graph(shell, SWT.NONE);
 		createContainer(g);
 
-		CompositeLayoutAlgorithm.Zest1 compositeLayoutAlgorithm = new CompositeLayoutAlgorithm.Zest1(
-				LayoutStyles.NO_LAYOUT_NODE_RESIZING,
-				new LayoutAlgorithm.Zest1[] { new GridLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING),
-						new HorizontalShift(LayoutStyles.NO_LAYOUT_NODE_RESIZING) });
+		CompositeLayoutAlgorithm compositeLayoutAlgorithm = new CompositeLayoutAlgorithm(
+				new LayoutAlgorithm[] { new GridLayoutAlgorithm(), new HorizontalShiftAlgorithm() });
 		// g.setLayoutAlgorithm(new
 		// GridLayoutAlgorithm(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
 		g.setLayoutAlgorithm(compositeLayoutAlgorithm, true);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet2.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/NestedGraphSnippet2.java
@@ -22,7 +22,6 @@ import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphContainer;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.GridLayoutAlgorithm;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
@@ -76,11 +75,11 @@ public class NestedGraphSnippet2 {
 		new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, object3, object4);
 		new GraphConnection(g, ZestStyles.CONNECTIONS_DIRECTED, object4, object5);
 
-		container1.setLayoutAlgorithm(new GridLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
-		container2.setLayoutAlgorithm(new GridLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
-		container3.setLayoutAlgorithm(new GridLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
-		container3.setLayoutAlgorithm(new GridLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		container1.setLayoutAlgorithm(new GridLayoutAlgorithm(), true);
+		container2.setLayoutAlgorithm(new GridLayoutAlgorithm(), true);
+		container3.setLayoutAlgorithm(new GridLayoutAlgorithm(), true);
+		container3.setLayoutAlgorithm(new GridLayoutAlgorithm(), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/PaintSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/PaintSnippet.java
@@ -27,7 +27,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 import org.eclipse.draw2d.SWTGraphics;
@@ -68,7 +67,7 @@ public class PaintSnippet {
 		new GraphConnection(g, SWT.NONE, n, n2);
 		new GraphConnection(g, SWT.NONE, n2, n3);
 		new GraphConnection(g, SWT.NONE, n3, n);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		b.addSelectionListener(new SelectionListener() {
 

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/ZoomSnippet.java
@@ -27,10 +27,9 @@ import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.ZestStyles;
 import org.eclipse.zest.layouts.LayoutAlgorithm;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.CompositeLayoutAlgorithm;
 import org.eclipse.zest.layouts.algorithms.GridLayoutAlgorithm;
-import org.eclipse.zest.layouts.algorithms.HorizontalShift;
+import org.eclipse.zest.layouts.algorithms.HorizontalShiftAlgorithm;
 import org.eclipse.zest.layouts.algorithms.RadialLayoutAlgorithm;
 import org.eclipse.zest.layouts.algorithms.TreeLayoutAlgorithm;
 
@@ -95,9 +94,9 @@ public class ZoomSnippet {
 			c.setScale(0.25);
 		}
 		if (radial) {
-			c.setLayoutAlgorithm(new RadialLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+			c.setLayoutAlgorithm(new RadialLayoutAlgorithm(), true);
 		} else {
-			c.setLayoutAlgorithm(new TreeLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+			c.setLayoutAlgorithm(new TreeLayoutAlgorithm(), true);
 		}
 	}
 
@@ -118,10 +117,8 @@ public class ZoomSnippet {
 		g = new Graph(shell, SWT.NONE);
 		createContainer(g);
 
-		CompositeLayoutAlgorithm.Zest1 compositeLayoutAlgorithm = new CompositeLayoutAlgorithm.Zest1(
-				LayoutStyles.NO_LAYOUT_NODE_RESIZING,
-				new LayoutAlgorithm.Zest1[] { new GridLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING),
-						new HorizontalShift(LayoutStyles.NO_LAYOUT_NODE_RESIZING) });
+		CompositeLayoutAlgorithm compositeLayoutAlgorithm = new CompositeLayoutAlgorithm(
+				new LayoutAlgorithm[] { new GridLayoutAlgorithm(), new HorizontalShiftAlgorithm() });
 		// g.setLayoutAlgorithm(new
 		// GridLayoutAlgorithm(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
 		g.setLayoutAlgorithm(compositeLayoutAlgorithm, true);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/UMLExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/UMLExample.java
@@ -27,7 +27,6 @@ import org.eclipse.zest.core.widgets.GraphContainer;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.IContainer;
 import org.eclipse.zest.core.widgets.ZestStyles;
-import org.eclipse.zest.layouts.LayoutStyles;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 
 import org.eclipse.draw2d.IFigure;
@@ -128,8 +127,8 @@ public class UMLExample {
 		new GraphConnection(g, SWT.NONE, n1, n2);
 		new GraphConnection(g, SWT.NONE, n, n1);
 
-		c.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
-		g.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
+		c.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
+		g.setLayoutAlgorithm(new SpringLayoutAlgorithm(), true);
 
 		shell.open();
 		while (!shell.isDisposed()) {

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphJFaceTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphJFaceTests.java
@@ -122,7 +122,6 @@ public class GraphJFaceTests extends AbstractGraphTest {
 		// Explicitly checking 30 nodes and 29 connections is just busy work...
 		assertEquals(graph.getNodes().size(), 30);
 		assertEquals(graph.getConnections().size(), 29);
-		assertNoOverlap(graph);
 	}
 
 	/**
@@ -230,7 +229,7 @@ public class GraphJFaceTests extends AbstractGraphTest {
 	 */
 	@Test
 	@Snippet(type = GraphJFaceSnippet8.class)
-	public void testGraphJFaceSnippet8() {
+	public void testGraphJFaceSnippet8() throws ReflectiveOperationException {
 		assertNode(graph.getNodes().get(0), "First");
 		assertNode(graph.getNodes().get(1), "Second");
 		assertNode(graph.getNodes().get(2), "Third");
@@ -247,10 +246,10 @@ public class GraphJFaceTests extends AbstractGraphTest {
 		assertConnection(connection3, "First", "First");
 		assertConnection(connection4, "First", "Second");
 
-		assertArc(connection1, 34 /* ° */);
-		assertArc(connection2, 34 /* ° */);
-		assertArc(connection3, Double.NaN /* ° */);
-		assertArc(connection4, 0 /* ° */);
+		assertCurve(connection1, 20);
+		assertCurve(connection2, 20);
+		assertCurve(connection3, 40);
+		assertCurve(connection4, 0);
 
 		assertNoOverlap(graph);
 	}

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
@@ -67,9 +67,7 @@ import org.eclipse.zest.examples.swt.NestedGraphSnippet2;
 import org.eclipse.zest.examples.swt.PaintSnippet;
 import org.eclipse.zest.examples.swt.ZoomSnippet;
 import org.eclipse.zest.layouts.Filter;
-import org.eclipse.zest.layouts.LayoutStyles;
-import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
-import org.eclipse.zest.layouts.dataStructures.InternalRelationship;
+import org.eclipse.zest.layouts.interfaces.ConnectionLayout;
 import org.eclipse.zest.tests.utils.Snippet;
 
 import org.eclipse.draw2d.ColorConstants;
@@ -344,7 +342,7 @@ public class GraphSWTTests extends AbstractGraphTest {
 	 * connections.
 	 */
 	@Test
-	@Snippet(type = GraphSnippet7.class)
+	@Snippet(type = GraphSnippet7.class, random = true)
 	public void testGraphSnippet7() {
 		for (GraphNode node : graph.getNodes()) {
 			IFigure nodeFigure = node.getNodeFigure();
@@ -367,7 +365,7 @@ public class GraphSWTTests extends AbstractGraphTest {
 		assertEquals(graph.getConnections().size(), 13);
 		assertNoOverlap(graph);
 
-		InternalRelationship[] connections = getInternalRelationships();
+		ConnectionLayout[] connections = graph.getLayoutContext().getConnections();
 		assertEquals(connections.length, 8);
 
 		for (GraphConnection connection : graph.getConnections()) {
@@ -377,7 +375,7 @@ public class GraphSWTTests extends AbstractGraphTest {
 		graph.applyLayout();
 		waitEventLoop(0);
 
-		connections = getInternalRelationships();
+		connections = graph.getLayoutContext().getConnections();
 		assertEquals(connections.length, 0);
 	}
 
@@ -403,8 +401,8 @@ public class GraphSWTTests extends AbstractGraphTest {
 	 * press.
 	 */
 	@Test
-	@Snippet(type = GraphSnippet10.class)
-	public void testGraphSnippet10() {
+	@Snippet(type = GraphSnippet10.class, random = true)
+	public void testGraphSnippet10() throws ReflectiveOperationException {
 		assertNode(graph.getNodes().get(0), "Paper");
 		assertNode(graph.getNodes().get(1), "Rock");
 		assertNode(graph.getNodes().get(2), "Scissors");
@@ -425,7 +423,7 @@ public class GraphSWTTests extends AbstractGraphTest {
 				robot.select(button);
 			}
 			// Old connection is removed and a new one is added
-			assertArc(graph.getConnections().get(2), i * 10 /* ° */);
+			assertCurve(graph.getConnections().get(2), i * 10);
 		}
 	}
 
@@ -433,8 +431,8 @@ public class GraphSWTTests extends AbstractGraphTest {
 	 * Tests a graph with curved connections.
 	 */
 	@Test
-	@Snippet(type = GraphSnippet11.class)
-	public void testGraphSnippet11() {
+	@Snippet(type = GraphSnippet11.class, random = true)
+	public void testGraphSnippet11() throws ReflectiveOperationException {
 		assertNode(graph.getNodes().get(0), "Node 1");
 		assertNode(graph.getNodes().get(1), "Node 2");
 		assertEquals(graph.getNodes().size(), 2);
@@ -444,13 +442,13 @@ public class GraphSWTTests extends AbstractGraphTest {
 			assertConnection(connection, "Node 1", "Node 2");
 		}
 
-		assertArc(graph.getConnections().get(0), 15 /* ° */);
-		assertArc(graph.getConnections().get(1), 15 /* ° */);
-		assertArc(graph.getConnections().get(2), 29 /* ° */);
-		assertArc(graph.getConnections().get(3), 29 /* ° */);
-		assertArc(graph.getConnections().get(4), 40 /* ° */);
-		assertArc(graph.getConnections().get(5), 40 /* ° */);
-		assertArc(graph.getConnections().get(6), 0 /* ° */);
+		assertCurve(graph.getConnections().get(0), 20);
+		assertCurve(graph.getConnections().get(1), -20);
+		assertCurve(graph.getConnections().get(2), 40);
+		assertCurve(graph.getConnections().get(3), -40);
+		assertCurve(graph.getConnections().get(4), 60);
+		assertCurve(graph.getConnections().get(5), -60);
+		assertCurve(graph.getConnections().get(6), 0);
 
 		assertNoOverlap(graph);
 	}
@@ -576,9 +574,6 @@ public class GraphSWTTests extends AbstractGraphTest {
 	@Test
 	@Snippet(type = LayoutExample.class)
 	public void testLayoutExample() {
-		graph.setLayoutAlgorithm(new SpringLayoutAlgorithm.Zest1(LayoutStyles.NO_LAYOUT_NODE_RESIZING), true);
-		waitEventLoop(0);
-
 		double sumLengthInner = 0;
 		int countInner = 0;
 		double sumLengthOuter = 0;
@@ -615,8 +610,6 @@ public class GraphSWTTests extends AbstractGraphTest {
 
 		GraphContainer container = (GraphContainer) graph.getNodes().get(0);
 		container.open(false);
-
-		graph.applyLayout();
 		waitEventLoop(0);
 
 		assertNode(container.getNodes().get(0), "SomeClass.java");
@@ -643,23 +636,17 @@ public class GraphSWTTests extends AbstractGraphTest {
 		assertNode(graph.getNodes().get(2), "Machine 3");
 		assertEquals(graph.getNodes().size(), 3);
 
-		GraphContainer container1 = (GraphContainer) graph.getNodes().get(0);
-		container1.open(false);
-
-		graph.applyLayout();
+		GraphContainer container3 = (GraphContainer) graph.getNodes().get(2);
+		container3.open(false);
 		waitEventLoop(0);
 
-		assertNode(container1.getNodes().get(0), "Host 1");
-		assertNode(container1.getNodes().get(1), "Host 2");
-		assertEquals(container1.getNodes().size(), 2);
+		assertNode(container3.getNodes().get(0), "Host 4");
+		assertEquals(container3.getNodes().size(), 1);
 
-		GraphContainer container2 = (GraphContainer) container1.getNodes().get(1);
+		GraphContainer container2 = (GraphContainer) container3.getNodes().get(0);
 		container2.open(false);
 
-		graph.applyLayout();
-		waitEventLoop(0);
-
-		assertNode(container2.getNodes().get(0), "JSP Object 3");
+		assertNode(container2.getNodes().get(0), "JSP Object 5");
 		assertEquals(container2.getNodes().size(), 1);
 
 		GraphNode node = container2.getNodes().get(0);
@@ -672,17 +659,17 @@ public class GraphSWTTests extends AbstractGraphTest {
 		assertEquals(graph.getSelection(), List.of(node));
 
 		GraphLabel nodeLabel = (GraphLabel) graph.getFigureAt(nodeLocation.x, nodeLocation.y);
-		assertEquals(nodeLabel.getText(), "JSP Object 3");
+		assertEquals(nodeLabel.getText(), "JSP Object 5");
 
-		assertNoOverlap(container1);
 		assertNoOverlap(container2);
+		assertNoOverlap(container3);
 	}
 
 	/**
 	 * Tests whether nodes are painted correctly.
 	 */
 	@Test
-	@Snippet(type = PaintSnippet.class)
+	@Snippet(type = PaintSnippet.class, random = true)
 	public void testPaintSnippet() {
 		assertEquals(graph.getNodes().size(), 3);
 

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/utils/Snippet.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/utils/Snippet.java
@@ -37,4 +37,10 @@ public @interface Snippet {
 	 * @return The name of the static field containing the {@link Graph}.
 	 */
 	String field() default "g";
+
+	/**
+	 * @return Return {@code true} when nodes should be placed randomly (if
+	 *         supported by the layout).
+	 */
+	boolean random() default false;
 }


### PR DESCRIPTION
This change has been delayed until the very end to avoid accidentally breaking the Zest 1.x legacy mode.