### PR TITLE
Make refresh rate of DeferredUpdateManager & TargetingTool configurable

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/DeferredUpdateManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/DeferredUpdateManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,6 +58,7 @@ public class DeferredUpdateManager extends UpdateManager {
 	private boolean updating;
 	private boolean validating;
 	private RunnableChain afterUpdate;
+	private int refreshRate = -1;
 
 	private static class RunnableChain {
 		RunnableChain next;
@@ -263,7 +264,11 @@ public class DeferredUpdateManager extends UpdateManager {
 		if (display == null) {
 			throw new SWTException(SWT.ERROR_THREAD_INVALID_ACCESS);
 		}
-		display.asyncExec(new UpdateRequest());
+		if (refreshRate <= 0) {
+			display.asyncExec(new UpdateRequest());
+		} else {
+			display.timerExec(refreshRate, new UpdateRequest());
+		}
 	}
 
 	/**
@@ -346,6 +351,24 @@ public class DeferredUpdateManager extends UpdateManager {
 	@Override
 	public void setRoot(IFigure figure) {
 		root = figure;
+	}
+
+	/**
+	 * Sets the rate with paint requests are executed. If set to either {@code 0} or
+	 * a negative value, requests are executed as fast as possible (default
+	 * behavior). Otherwise the requests are executed at {@code 1/refreshRate}mHz.
+	 *
+	 * Example:
+	 *
+	 * <pre>
+	 * setRefreshRate(500); // Paints every 500ms
+	 * </pre>
+	 *
+	 * @param refreshRate The rate with which paint requests are executed.
+	 * @since 3.17
+	 */
+	public void setRefreshRate(int refreshRate) {
+		this.refreshRate = refreshRate;
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/TargetingTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/TargetingTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -59,6 +59,7 @@ public abstract class TargetingTool extends AbstractTool {
 	private Request targetRequest;
 	private EditPart targetEditPart;
 	private AutoexposeHelper exposeHelper;
+	private int refreshRate = -1;
 
 	/**
 	 * Creates the target request that will be used with the target editpart. This
@@ -101,7 +102,11 @@ public abstract class TargetingTool extends AbstractTool {
 		}
 		if (exposeHelper.step(getLocation())) {
 			handleAutoexpose();
-			Display.getCurrent().asyncExec(new QueuedAutoexpose());
+			if (refreshRate <= 0) {
+				Display.getCurrent().asyncExec(new QueuedAutoexpose());
+			} else {
+				Display.getCurrent().timerExec(refreshRate, new QueuedAutoexpose());
+			}
 		} else {
 			setAutoexposeHelper(null);
 		}
@@ -476,4 +481,22 @@ public abstract class TargetingTool extends AbstractTool {
 		return exposeHelper;
 	}
 
+	/**
+	 * Sets the rate with which the auto-expose helper is evaluated. If set to
+	 * either {@code 0} or a negative value, the evaluation is done as fast as
+	 * possible (default behavior). Otherwise the evaluation is done at
+	 * {@code 1/refreshRate}mHz.
+	 *
+	 * Example:
+	 *
+	 * <pre>
+	 * setRefreshRate(500); // Validate every 500ms
+	 * </pre>
+	 *
+	 * @param refreshRate The rate with which the auto-expose helper is validated.
+	 * @since 3.19
+	 */
+	public void setRefreshRate(int refreshRate) {
+		this.refreshRate = refreshRate;
+	}
 }


### PR DESCRIPTION
This adds a new setRefreshRate() for both classes, which defines how often paint requests are executed/the auto-exposer helper is evaluated.

Both tasks are currently executed as fast possible, which may lead to to a very high CPU cost with very little gain. By setting a high rate, users may artificially throttle the speed at which those operations are performed, at the cost of responsiveness.

Relates to:
https://github.com/eclipse/gef-classic/issues/430
https://github.com/eclipse/gef-classic/issues/492