### PR TITLE
Try to stabilize Draw2D SWTBot test

### DIFF
--- a/org.eclipse.draw2d.examples/sandbox/gef/bugs/BugWithLocalCoordinateSystem.java
+++ b/org.eclipse.draw2d.examples/sandbox/gef/bugs/BugWithLocalCoordinateSystem.java
@@ -132,7 +132,6 @@ public class BugWithLocalCoordinateSystem {
 				display.sleep();
 			}
 		}
-		display.dispose();
 	}
 
 	/**


### PR DESCRIPTION
The test for the BugWithLocalCoordinateSystem snippet may dispose the Display instance also hosting the Eclipse IDE. This may cause unintended side-effects, as the IDE is also terminated by the shutdown routine of the test suite.