### PR TITLE
Fix regression in Tooltip parent Shell on Linux Wayland

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
@@ -84,7 +84,7 @@ public abstract class PopUpHelper {
 	 * @since 2.0
 	 */
 	protected Shell createShell() {
-		return new Shell(control.getDisplay(), shellStyle);
+		return new Shell(control.getShell(), shellStyle);
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTEventDispatcher.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTEventDispatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -336,7 +336,7 @@ public class SWTEventDispatcher extends EventDispatcher {
 	 * @return the ToolTipHelper
 	 */
 	protected ToolTipHelper getToolTipHelper() {
-		if (toolTipHelper == null) {
+		if (toolTipHelper == null || toolTipHelper.getShell().isDisposed()) {
 			toolTipHelper = new ToolTipHelper(control);
 		}
 		return toolTipHelper;


### PR DESCRIPTION
This reverts 843e56c0df42aec34a487b97483a0b6c866fff95 and instead checks for a disposed Shell in SWTEventDispatcher#getToolTipHelper()

See https://github.com/eclipse/gef-classic/issues/555