### PR TITLE
Restrict the number of builds to keep with artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
   options {
     timeout(time: 240, unit: 'MINUTES')
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '2'))
     disableConcurrentBuilds(abortPrevious: true)
   }
 


### PR DESCRIPTION
This is required to avoid excessive disk usage.

This setting should be copied to the Jenkinsfiles in all project repos.