### PR TITLE
Fix bogus calculation of graph node location

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalNodeLayout.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/InternalNodeLayout.java
@@ -295,7 +295,7 @@ class InternalNodeLayout implements NodeLayout {
 		} else {
 			node.setSize(-1, -1);
 			if (location != null) {
-				node.setLocation(location.x - getSize().width / 2, location.y - size.height / 2);
+				node.setLocation(location.x, location.y);
 			}
 			if (size != null) {
 				Dimension currentSize = node.getSize();

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
@@ -147,6 +147,14 @@ public class GraphSWTTests extends AbstractGraphTest {
 		assertEquals(node1.getLocation().y, node3.getLocation().y);
 
 		waitEventLoop(5);
+
+		for (GraphNode node : graph.getNodes()) {
+			Point p = node.getLocation();
+			Rectangle bounds = graph.getBounds();
+			assertTrue("Node outside of bounds", p.x >= 0 && p.x <= bounds.width);
+			assertTrue("Node outside of bounds", p.y >= 0 && p.y <= bounds.height);
+		}
+
 		assertNoOverlap(graph);
 	}
 


### PR DESCRIPTION
The location of the graph node should match whatever has been calculated in the layout algorithm and should not include the node size.