### PR TITLE
Preserve dynamic layout flag after changing viewer input

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
@@ -121,9 +121,10 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 
 	@Override
 	protected void inputChanged(Object input, Object oldInput) {
+		boolean dynamicLayoutEnabled = graph.isDynamicLayoutEnabled();
 		graph.setDynamicLayout(false);
 		super.inputChanged(input, oldInput);
-		graph.setDynamicLayout(true);
+		graph.setDynamicLayout(dynamicLayoutEnabled);
 		graph.applyLayout();
 	}
 


### PR DESCRIPTION
The state of the "dynamic layout" flag should be restored after the viewer input has changed, rather than always be set again. This flag can only be "false" if explicitly unset by the user. It should therefore remain disabled until explicitly enabled again.