### PR TITLE
[Zest 2.0] Ignore node size when calculating position in layout

### DIFF
--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AlgorithmHelper.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AlgorithmHelper.java
@@ -56,9 +56,8 @@ public class AlgorithmHelper {
 					entity.setSize(size.width, size.height);
 				}
 
-				location.x = destinationBounds.x + size.width / 2 + percentX * (destinationBounds.width - size.width);
-				location.y = destinationBounds.y + size.height / 2
-						+ percentY * (destinationBounds.height - size.height);
+				location.x = destinationBounds.x + percentX * (destinationBounds.width - size.width);
+				location.y = destinationBounds.y + percentY * (destinationBounds.height - size.height);
 				entity.setLocation(location.x, location.y);
 
 			} else if (resize && entity.isResizable()) {

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
@@ -385,9 +385,8 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 						node.setSize(Math.max(childrenWidth, MIN_ENTITY_SIZE),
 								Math.max(childrenHeight, MIN_ENTITY_SIZE));
 					}
-					DisplayIndependentDimension size = node.getSize();
-					double xmove = bounds.x + j * colWidth + offsetX + size.width / 2;
-					double ymove = bounds.y + i * rowHeight + offsetY + size.height / 2;
+					double xmove = bounds.x + j * colWidth + offsetX;
+					double ymove = bounds.y + i * rowHeight + offsetY;
 					if (node.isMovable()) {
 						node.setLocation(xmove, ymove);
 					}


### PR DESCRIPTION
The location of a node describes its top-left pixel, rather than its center. When using layout algorithms that are based on the grid layout, this causes the offset to be half the space between the rows and columns plus the half the width and height of the nodes.
Latter is undesirable and may cause nodes to be partially moved outside the client area.

The same issue can be observed in the other layout algorithms (Spring/Tree/Radial) when fitting the nodes into the client area, because the same mistake is repeated in the AlgorithmHelper class.