### PR TITLE
Introduce getDistanceSquared for deprecated getDistance2 #21

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PointTests.java
@@ -186,9 +186,9 @@ public class PointTests extends BaseTestCase {
 
 	@SuppressWarnings("static-method")
 	@Test
-	public void testGetDistance2Point() {
-		assertEquals(25, new Point(4, 7).getDistance2(new Point(1, 3)));
-		assertEquals(25, new Point(-1, -2).getDistance2(new Point(-5, 1)));
+	public void testGetDistanceSquaredPoint() {
+		assertEquals(25, new Point(4, 7).getDistanceSquared(new Point(1, 3)));
+		assertEquals(25, new Point(-1, -2).getDistanceSquared(new Point(-5, 1)));
 	}
 
 	@SuppressWarnings("static-method")

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.18.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
@@ -198,10 +198,23 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 * @return distance<sup>2</sup>
 	 * @since 2.0
 	 * @noreference This method is not intended to be referenced by clients.
-	 * @deprecated Use {@link #getDistance(Point)} and square the result instead.
+	 * @deprecated Use {@link #getDistanceSquared(Point)}.
 	 */
 	@Deprecated(since = "3.7", forRemoval = true)
 	public int getDistance2(Point p) {
+		return getDistanceSquared(p);
+	}
+
+	/**
+	 * Calculates the distance squared between this Point and the one specified. If
+	 * the distance squared is larger than the maximum integer value, then
+	 * <code>Integer.MAX_VALUE</code> will be returned.
+	 *
+	 * @param p The reference Point
+	 * @return distance<sup>2</sup>
+	 * @since 3.18
+	 */
+	public int getDistanceSquared(Point p) {
 		long i = p.x() - x;
 		long j = p.y() - y;
 		long result = i * i + j * j;

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/NodeFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/NodeFigure.java
@@ -34,7 +34,7 @@ public class NodeFigure extends Figure {
 
 		for (ConnectionAnchor c : getSourceConnectionAnchors()) {
 			Point p2 = c.getLocation(null);
-			long d = p.getDistance2(p2);
+			long d = p.getDistanceSquared(p2);
 			if (d < min) {
 				min = d;
 				closest = c;
@@ -42,7 +42,7 @@ public class NodeFigure extends Figure {
 		}
 		for (ConnectionAnchor c : getTargetConnectionAnchors()) {
 			Point p2 = c.getLocation(null);
-			long d = p.getDistance2(p2);
+			long d = p.getDistanceSquared(p2);
 			if (d < min) {
 				min = d;
 				closest = c;
@@ -70,7 +70,7 @@ public class NodeFigure extends Figure {
 
 		for (ConnectionAnchor c : getSourceConnectionAnchors()) {
 			Point p2 = c.getLocation(null);
-			long d = p.getDistance2(p2);
+			long d = p.getDistanceSquared(p2);
 			if (d < min) {
 				min = d;
 				closest = c;
@@ -89,7 +89,7 @@ public class NodeFigure extends Figure {
 
 		for (ConnectionAnchor c : getTargetConnectionAnchors()) {
 			Point p2 = c.getLocation(null);
-			long d = p.getDistance2(p2);
+			long d = p.getDistanceSquared(p2);
 			if (d < min) {
 				min = d;
 				closest = c;

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/BendpointEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/BendpointEditPolicy.java
@@ -315,9 +315,9 @@ public abstract class BendpointEditPolicy extends SelectionHandlesEditPolicy imp
 		// points include the bend points as well as start and end, which we may
 		// leave out when searching for the bend point index
 		for (int i = 1; i < points.size() - 1; i++) {
-			if (smallestDistance == -1 || points.getPoint(i).getDistance2(bp) < smallestDistance) {
+			if (smallestDistance == -1 || points.getPoint(i).getDistanceSquared(bp) < smallestDistance) {
 				bpIndex = i;
-				smallestDistance = points.getPoint(i).getDistance2(bp);
+				smallestDistance = points.getPoint(i).getDistanceSquared(bp);
 				if (smallestDistance == 0) {
 					break;
 				}


### PR DESCRIPTION
Having the squared distance between two points can be used often for simple sorting of points. It is more efficient then calculating the real distance. However the old getDistanc2's name was not very intuitive. With this change we have an appropriate replacement.

Addresses https://github.com/eclipse/gef-classic/issues/21