### PR TITLE
Added getSelectedEditParts to SelectionAction #155

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/actions/IncrementDecrementAction.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/actions/IncrementDecrementAction.java
@@ -60,29 +60,17 @@ public class IncrementDecrementAction extends org.eclipse.gef.ui.actions.Selecti
 	}
 
 	private boolean canPerformAction() {
-		if (getSelectedObjects().isEmpty()) {
+		List<EditPart> selectedEditParts = getSelectedEditParts();
+		if (selectedEditParts.isEmpty()) {
 			return false;
 		}
-		List parts = getSelectedObjects();
-		for (Object o : parts) {
-			if (!(o instanceof EditPart part)) {
-				return false;
-			}
-			if (!(part.getModel() instanceof LED)) {
-				return false;
-			}
-		}
-		return true;
+		return selectedEditParts.stream().allMatch(ep -> ep.getModel() instanceof LED);
 	}
 
 	private Command getCommand() {
-		List editparts = getSelectedObjects();
-		CompoundCommand cc = new CompoundCommand();
+		final CompoundCommand cc = new CompoundCommand();
 		cc.setDebugLabel("Increment/Decrement LEDs");//$NON-NLS-1$
-		for (Object editpart : editparts) {
-			EditPart part = (EditPart) editpart;
-			cc.add(part.getCommand(request));
-		}
+		getSelectedEditParts().stream().map(ep -> ep.getCommand(request)).forEach(cc::add);
 		return cc;
 	}
 

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -144,6 +144,20 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/gef/ui/actions/SelectionAction.java" type="org.eclipse.gef.ui.actions.SelectionAction">
+        <filter id="354463860">
+            <message_arguments>
+                <message_argument value="org.eclipse.gef.ui.actions.SelectionAction"/>
+                <message_argument value="SelectionAction(IWorkbenchPart)"/>
+            </message_arguments>
+        </filter>
+        <filter id="354463860">
+            <message_arguments>
+                <message_argument value="org.eclipse.gef.ui.actions.SelectionAction"/>
+                <message_argument value="SelectionAction(IWorkbenchPart, int)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/gef/ui/actions/UndoRetargetAction.java" type="org.eclipse.gef.ui.actions.UndoRetargetAction">
         <filter id="571473929">
             <message_arguments>

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.20.0.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/AlignmentAction.java
@@ -170,19 +170,19 @@ public final class AlignmentAction extends SelectionAction {
 		if (operationSet != null) {
 			return operationSet;
 		}
-		List editparts = new ArrayList(getSelectedObjects());
+		List<? extends EditPart> editparts = new ArrayList<>(getSelectedEditParts());
 		if (editparts.isEmpty() || !(editparts.get(0) instanceof GraphicalEditPart)) {
 			return Collections.emptyList();
 		}
-		Object primary = editparts.get(editparts.size() - 1);
+		EditPart primary = editparts.get(editparts.size() - 1);
 		editparts = ToolUtilities.getSelectionWithoutDependants(editparts);
 		ToolUtilities.filterEditPartsUnderstanding(editparts, request);
 		if (editparts.size() < 2 || !editparts.contains(primary)) {
 			return Collections.emptyList();
 		}
-		EditPart parent = ((EditPart) editparts.get(0)).getParent();
+		EditPart parent = editparts.get(0).getParent();
 		for (int i = 1; i < editparts.size(); i++) {
-			EditPart part = (EditPart) editparts.get(i);
+			EditPart part = editparts.get(i);
 			if (part.getParent() != parent) {
 				return Collections.emptyList();
 			}
@@ -241,6 +241,8 @@ public final class AlignmentAction extends SelectionAction {
 			setToolTipText(GEFMessages.AlignMiddleAction_Tooltip);
 			setImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE);
 			setDisabledImageDescriptor(InternalImages.DESC_VERT_ALIGN_MIDDLE_DIS);
+			break;
+		default:
 			break;
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DeleteAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DeleteAction.java
@@ -77,7 +77,7 @@ public class DeleteAction extends SelectionAction {
 	 */
 	@Override
 	protected boolean calculateEnabled() {
-		Command cmd = createDeleteCommand(getSelectedObjects());
+		Command cmd = createDeleteCommand(getSelectedEditParts());
 		if (cmd == null) {
 			return false;
 		}
@@ -85,32 +85,22 @@ public class DeleteAction extends SelectionAction {
 	}
 
 	/**
-	 * Create a command to remove the selected objects.
+	 * Create a command to remove the selected EditParts.
 	 *
-	 * @param objects The objects to be deleted.
+	 * @param objects The EditParts to be deleted.
 	 * @return The command to remove the selected objects.
 	 */
 	@SuppressWarnings("static-method")
-	public Command createDeleteCommand(List objects) {
+	public Command createDeleteCommand(List<EditPart> objects) {
 		if (objects.isEmpty()) {
 			return null;
 		}
-		if (!(objects.get(0) instanceof EditPart)) {
-			return null;
-		}
 
-		GroupRequest deleteReq = new GroupRequest(RequestConstants.REQ_DELETE);
+		final GroupRequest deleteReq = new GroupRequest(RequestConstants.REQ_DELETE);
 		deleteReq.setEditParts(objects);
 
-		CompoundCommand compoundCmd = new CompoundCommand(GEFMessages.DeleteAction_ActionDeleteCommandName);
-		for (Object object2 : objects) {
-			EditPart object = (EditPart) object2;
-			Command cmd = object.getCommand(deleteReq);
-			if (cmd != null) {
-				compoundCmd.add(cmd);
-			}
-		}
-
+		final CompoundCommand compoundCmd = new CompoundCommand(GEFMessages.DeleteAction_ActionDeleteCommandName);
+		objects.stream().map(ep -> ep.getCommand(deleteReq)).forEach(compoundCmd::add);
 		return compoundCmd;
 	}
 
@@ -134,7 +124,7 @@ public class DeleteAction extends SelectionAction {
 	 */
 	@Override
 	public void run() {
-		execute(createDeleteCommand(getSelectedObjects()));
+		execute(createDeleteCommand(getSelectedEditParts()));
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DirectEditAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/DirectEditAction.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.gef.ui.actions;
 
+import java.util.List;
+
 import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.ui.IEditorPart;
@@ -75,8 +77,9 @@ public class DirectEditAction extends SelectionAction {
 	 */
 	@Override
 	protected boolean calculateEnabled() {
-		if (getSelectedObjects().size() == 1 && (getSelectedObjects().get(0) instanceof EditPart part)) {
-			return part.understandsRequest(getDirectEditRequest());
+		List<EditPart> selectedEditParts = getSelectedEditParts();
+		if (selectedEditParts.size() == 1) {
+			return selectedEditParts.get(0).understandsRequest(getDirectEditRequest());
 		}
 		return false;
 	}
@@ -96,11 +99,8 @@ public class DirectEditAction extends SelectionAction {
 	@Override
 	public void run() {
 		try {
-			EditPart part = (EditPart) getSelectedObjects().get(0);
-			part.performRequest(getDirectEditRequest());
-		} catch (ClassCastException e) {
-			Display.getCurrent().beep();
-		} catch (IndexOutOfBoundsException e) {
+			getSelectedEditParts().get(0).performRequest(getDirectEditRequest());
+		} catch (ClassCastException | IndexOutOfBoundsException e) {
 			Display.getCurrent().beep();
 		}
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteTemplateAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteTemplateAction.java
@@ -66,19 +66,16 @@ public class PasteTemplateAction extends SelectionAction {
 	 */
 	protected Command createPasteCommand() {
 		Command result = null;
-		List selection = getSelectedObjects();
-		if (selection != null && selection.size() == 1) {
-			Object obj = selection.get(0);
-			if (obj instanceof GraphicalEditPart gep) {
-				Object template = getClipboardContents();
-				if (template != null) {
-					CreationFactory factory = getFactory(template);
-					if (factory != null) {
-						CreateRequest request = new CreateRequest();
-						request.setFactory(factory);
-						request.setLocation(getPasteLocation(gep));
-						result = gep.getCommand(request);
-					}
+		List<Object> selection = getSelectedObjects();
+		if (selection != null && selection.size() == 1 && selection.get(0) instanceof GraphicalEditPart gep) {
+			Object template = getClipboardContents();
+			if (template != null) {
+				CreationFactory factory = getFactory(template);
+				if (factory != null) {
+					CreateRequest request = new CreateRequest();
+					request.setFactory(factory);
+					request.setLocation(getPasteLocation(gep));
+					result = gep.getCommand(request);
 				}
 			}
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectionAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/SelectionAction.java
@@ -21,6 +21,8 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.ui.IWorkbenchPart;
 
+import org.eclipse.gef.EditPart;
+
 /**
  * Superclass for an action needing the current selection.
  */
@@ -39,7 +41,7 @@ public abstract class SelectionAction extends WorkbenchPartAction {
 	 * @param part  The workbench part associated with this action
 	 * @param style the style for this action
 	 */
-	public SelectionAction(IWorkbenchPart part, int style) {
+	protected SelectionAction(IWorkbenchPart part, int style) {
 		super(part, style);
 	}
 
@@ -49,7 +51,7 @@ public abstract class SelectionAction extends WorkbenchPartAction {
 	 *
 	 * @param part the workbench part
 	 */
-	public SelectionAction(IWorkbenchPart part) {
+	protected SelectionAction(IWorkbenchPart part) {
 		super(part);
 	}
 
@@ -67,11 +69,22 @@ public abstract class SelectionAction extends WorkbenchPartAction {
 	 *
 	 * @return A List containing the currently selected objects.
 	 */
-	protected List getSelectedObjects() {
+	protected List<Object> getSelectedObjects() {
 		if (!(getSelection() instanceof IStructuredSelection)) {
-			return Collections.EMPTY_LIST;
+			return Collections.emptyList();
 		}
 		return ((IStructuredSelection) getSelection()).toList();
+	}
+
+	/**
+	 * Returns a <code>List<EditPart></code> containing the currently selected
+	 * EditParts.
+	 *
+	 * @return A List containing the currently selected EditParts.
+	 * @since 3.20
+	 */
+	protected final List<EditPart> getSelectedEditParts() {
+		return getSelectedObjects().stream().filter(EditPart.class::isInstance).map(EditPart.class::cast).toList();
 	}
 
 	/**


### PR DESCRIPTION
The new method filters the selection given to the SelectionAction on EditParts. This can reduce the effort for implementing SelectionActions and at least makes them clearer.

Addresses: https://github.com/eclipse/gef-classic/issues/155