### PR TITLE
Make DirectEditManager properly handle changed cell editor state

### DIFF
--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.gef.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.ComboBoxCellEditor;
+import org.eclipse.ui.PlatformUI;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+
+import org.eclipse.gef.EditDomain;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.Request;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
+import org.eclipse.gef.tools.DirectEditManager;
+import org.eclipse.gef.ui.parts.AbstractEditPartViewer;
+
+import org.junit.jupiter.api.Test;
+
+public class DirectEditManagerTest {
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testComboCellEditorChangeProcessed() {
+		Shell shell = PlatformUI.getWorkbench().getDisplay()
+				.syncCall(() -> PlatformUI.getWorkbench().getDisplay().getActiveShell());
+		EditDomain editDomain = new EditDomain();
+		TestDirectEditManager editManager = new TestDirectEditManager(createDummyEditPart(shell, editDomain));
+		AtomicBoolean comboChangeCommandSubmitted = new AtomicBoolean();
+		editDomain.getCommandStack().addCommandStackEventListener(event -> comboChangeCommandSubmitted.set(true));
+
+		PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
+			editManager.show();
+			// Change value of combo cell editor
+			editManager.getCellEditor().setValue(0);
+			// Make combo cell editor lose focus to apply its value
+			shell.setFocus();
+		});
+
+		assertTrue(comboChangeCommandSubmitted.get());
+	}
+
+	private static class TestDirectEditManager extends DirectEditManager {
+		public TestDirectEditManager(GraphicalEditPart source) {
+			super(source, ComboBoxCellEditor.class, cellEditor -> {
+			});
+		}
+
+		@Override
+		protected CellEditor createCellEditorOn(Composite composite) {
+			return new ComboBoxCellEditor(composite, new String[] { "test" }); //$NON-NLS-1$
+		}
+
+		@Override
+		public CellEditor getCellEditor() {
+			return super.getCellEditor();
+		}
+
+		@Override
+		public void showFeedback() {
+		}
+
+		@Override
+		protected void initCellEditor() {
+		}
+	}
+
+	private static GraphicalEditPart createDummyEditPart(Control control, EditDomain editDomain) {
+		return new AbstractGraphicalEditPart() {
+			@Override
+			protected void createEditPolicies() {
+			}
+
+			@Override
+			public org.eclipse.gef.EditPartViewer getViewer() {
+				return new AbstractEditPartViewer() {
+					@Override
+					public EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet,
+							Conditional conditional) {
+						return null;
+					}
+
+					@Override
+					public Control createControl(Composite parent) {
+						return parent;
+					}
+
+					@Override
+					public Control getControl() {
+						return control;
+					}
+
+					@Override
+					public org.eclipse.gef.EditDomain getEditDomain() {
+						return editDomain;
+					}
+				};
+			}
+
+			@Override
+			public Command getCommand(Request request) {
+				return new Command() {
+				};
+			}
+
+			@Override
+			protected IFigure createFigure() {
+				return new Figure();
+			}
+		};
+	}
+
+}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
@@ -31,7 +31,8 @@ import org.junit.platform.suite.api.Suite;
 	RulerLayoutTests.class,
 	GraphicalViewerTest.class,
 	PaletteColorProviderTest.class,
-	SWTBotTestSuite.class
+	SWTBotTestSuite.class,
+	DirectEditManagerTest.class
 })
 public class GEFTestSuite {
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DirectEditManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DirectEditManager.java
@@ -62,7 +62,7 @@ public abstract class DirectEditManager {
 	private IFigure cellEditorFrame;
 	private ICellEditorListener cellEditorListener;
 	private boolean showingFeedback;
-	private boolean dirty;
+	private boolean customDirtyState;
 	private DirectEditRequest request;
 	private CellEditorLocator locator;
 	private GraphicalEditPart source;
@@ -121,7 +121,7 @@ public abstract class DirectEditManager {
 			setCellEditor(null);
 		}
 		request = null;
-		dirty = false;
+		customDirtyState = false;
 	}
 
 	/**
@@ -260,7 +260,10 @@ public abstract class DirectEditManager {
 	}
 
 	protected void handleValueChanged() {
-		setDirty(true);
+		CellEditor cellEditor = getCellEditor();
+		if (cellEditor == null) {
+			setDirty(true);
+		}
 		showFeedback();
 		placeCellEditor();
 	}
@@ -332,7 +335,11 @@ public abstract class DirectEditManager {
 	 * @return <code>true</code> if the cell editor is dirty
 	 */
 	protected boolean isDirty() {
-		return dirty;
+		CellEditor cellEditor = getCellEditor();
+		if (cellEditor == null) {
+			return customDirtyState;
+		}
+		return cellEditor.isDirty();
 	}
 
 	private void placeCellEditorFrame() {
@@ -368,7 +375,7 @@ public abstract class DirectEditManager {
 	 * @param value the dirty property
 	 */
 	protected void setDirty(boolean value) {
-		dirty = value;
+		customDirtyState = value;
 	}
 
 	/**


### PR DESCRIPTION
The DirectEditManager maintains an own dirty state to identify if a command has to be executed on commit, i.e., when the underlying cell editor submits its change. However, a dirty state is already tracked by the underlying cell editor and the two are not necessarily consistent. The DirectEditManager only updates its dirty state on a `editorValueChanged` event from the cell editor, which is by definition only sent on textual input changes. In case a selection is made, such as in case of the ComboBoxCellEditor, no such `editorValueChanged` event is submitted but only the `applyEditorValue` event is triggered. In consequences, changes in ComboBoxCellEditors are currently not properly converted into according commands by the DirectEditManager.

This change adapts the DirectEditManager to consider the dirty state of the underlying cell editor in addition to a potentially set custom dirty state on the DirectEditManager itself.

### Additional notes
I am not even sure if/why the explicit `setDirty` method on `DirectEditManager` is necessary/useful at all. If it's not necessary, it might make sense to deprecate it to completely get rid of the `customDirtyState`.

In fact, the current implementation is even inconsistent, as the contract of `isDirty()` states that it returns whether the cell editor's value has changed and _not_ whether the dirty state of the `DirectEditManager` may have been set. So in general, it would probably be the cleanest solution to remove everything related to the custom dirty state in the `DirectEditManager` but for the sake of API conformance that does not seem to be possible.

The test is a bit messy, as quite some elements had to be mocked manually, but at least it serves a regression test (and demonstrator) for the underlying issue. It's comparable to what is done in `DragEditPartsTrackerTest`.