### PR TITLE
Remove the exclusion check for the TreeViewer

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
@@ -35,6 +35,7 @@ import org.eclipse.jface.util.TransferDragSourceListener;
 import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.jface.viewers.StructuredSelection;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.EditPart;
@@ -147,7 +148,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 *      EditPartViewer.Conditional)
 	 */
 	@Override
-	public EditPart findObjectAtExcluding(Point pt, Collection exclude, Conditional condition) {
+	public EditPart findObjectAtExcluding(Point pt, Collection<IFigure> exclude, Conditional condition) {
 		if (getControl() == null) {
 			return null;
 		}
@@ -167,7 +168,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 			result = (EditPart) tree.getData();
 		}
 		while (result != null) {
-			if ((condition == null || condition.evaluate(result)) && !exclude.contains(result)) {
+			if ((condition == null || condition.evaluate(result))) {
 				return result;
 			}
 			result = result.getParent();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewerTransferDropListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@ package org.eclipse.gef.ui.parts;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.swt.dnd.DND;
@@ -141,6 +142,25 @@ class TreeViewerTransferDropListener extends AbstractTransferDropTargetListener 
 		ChangeBoundsRequest request = getTargetRequest();
 		request.setLocation(getDropLocation());
 		request.setType(getCommandName());
+	}
+
+	@Override
+	protected void updateTargetEditPart() {
+		setTargetEditPart(calculateTargetEditPart());
+	}
+
+	private EditPart calculateTargetEditPart() {
+		EditPart ep = getViewer().findObjectAtExcluding(getDropLocation(), Collections.emptyList(),
+				getTargetingConditional());
+		if (ep != null) {
+			ep = ep.getTargetEditPart(getTargetRequest());
+		}
+		return ep;
+	}
+
+	private EditPartViewer.Conditional getTargetingConditional() {
+		Collection<EditPart> excludes = getExclusionSet();
+		return editPart -> !excludes.contains(editPart) && editPart.getTargetEditPart(getTargetRequest()) != null;
 	}
 
 }


### PR DESCRIPTION
The collection of IFigures that is used in the findObjectAtExcluding() of the TreeViewer is compared against an EditPart. This check will always return "false" and is therefore obsolete.

Given that a TreeViewer is based on a Tree widget and not IFigure's, specifying an exclusion set is generally not supported.