### PR TITLE
Make DirectEditManager more robust when brought down multiple times #757

### DIFF
--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
@@ -11,7 +11,9 @@ package org.eclipse.gef.test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.swt.widgets.Composite;
@@ -22,32 +24,73 @@ import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
 import org.eclipse.ui.PlatformUI;
 
-import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.EditDomain;
 import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
+import org.eclipse.gef.test.utils.TestGraphicalEditPart;
 import org.eclipse.gef.tools.DirectEditManager;
 import org.eclipse.gef.ui.parts.AbstractEditPartViewer;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class DirectEditManagerTest {
+	private Shell shell;
+	private EditDomain editDomain;
+	private TestDirectEditManager editManager;
+	private List<Throwable> throwables;
 
-	@SuppressWarnings("static-method")
+	@BeforeEach
+	public void setUp() {
+		shell = PlatformUI.getWorkbench().getDisplay()
+				.syncCall(() -> PlatformUI.getWorkbench().getDisplay().getActiveShell());
+		editDomain = new EditDomain();
+		throwables = new ArrayList<>();
+		editManager = null;
+	}
+
 	@Test
 	public void testComboCellEditorChangeProcessed() {
-		Shell shell = PlatformUI.getWorkbench().getDisplay()
-				.syncCall(() -> PlatformUI.getWorkbench().getDisplay().getActiveShell());
-		EditDomain editDomain = new EditDomain();
-		TestDirectEditManager editManager = new TestDirectEditManager(createDummyEditPart(shell, editDomain));
 		AtomicBoolean comboChangeCommandSubmitted = new AtomicBoolean();
 		editDomain.getCommandStack().addCommandStackEventListener(event -> comboChangeCommandSubmitted.set(true));
+
+		testWith(new DirectGraphicalEditPart() {
+			@Override
+			public Command getCommand(Request request) {
+				return new Command() {
+				};
+			}
+		});
+
+		assertTrue(comboChangeCommandSubmitted.get());
+		assertTrue(throwables.isEmpty(), () -> "Internal exception occurred: " + throwables); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testComboCellEditorDisposedTwice() {
+		testWith(new DirectGraphicalEditPart() {
+			@Override
+			public Command getCommand(Request request) {
+				return new Command() {
+					@Override
+					public void execute() {
+						editManager.bringDown();
+					}
+				};
+			}
+		});
+
+		assertTrue(throwables.isEmpty(), () -> "Internal exception occurred: " + throwables); //$NON-NLS-1$
+	}
+
+	private void testWith(GraphicalEditPart editPart) {
+		editManager = new TestDirectEditManager(editPart);
 
 		PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
 			editManager.show();
@@ -56,11 +99,9 @@ public class DirectEditManagerTest {
 			// Make combo cell editor lose focus to apply its value
 			shell.setFocus();
 		});
-
-		assertTrue(comboChangeCommandSubmitted.get());
 	}
 
-	private static class TestDirectEditManager extends DirectEditManager {
+	private class TestDirectEditManager extends DirectEditManager {
 		public TestDirectEditManager(GraphicalEditPart source) {
 			super(source, ComboBoxCellEditor.class, cellEditor -> {
 			});
@@ -73,7 +114,22 @@ public class DirectEditManagerTest {
 
 		@Override
 		public CellEditor getCellEditor() {
-			return super.getCellEditor();
+			try {
+				return super.getCellEditor();
+			} catch (Throwable exception) {
+				throwables.add(exception);
+				throw exception;
+			}
+		}
+
+		@Override
+		public void bringDown() {
+			try {
+				super.bringDown();
+			} catch (Throwable exception) {
+				throwables.add(exception);
+				throw exception;
+			}
 		}
 
 		@Override
@@ -85,49 +141,32 @@ public class DirectEditManagerTest {
 		}
 	}
 
-	private static GraphicalEditPart createDummyEditPart(Control control, EditDomain editDomain) {
-		return new AbstractGraphicalEditPart() {
-			@Override
-			protected void createEditPolicies() {
-			}
+	private class DirectGraphicalEditPart extends TestGraphicalEditPart {
+		@Override
+		public EditPartViewer getViewer() {
+			return new AbstractEditPartViewer() {
+				@Override
+				public EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet,
+						Conditional conditional) {
+					return null;
+				}
 
-			@Override
-			public org.eclipse.gef.EditPartViewer getViewer() {
-				return new AbstractEditPartViewer() {
-					@Override
-					public EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet,
-							Conditional conditional) {
-						return null;
-					}
+				@Override
+				public Control createControl(Composite parent) {
+					return parent;
+				}
 
-					@Override
-					public Control createControl(Composite parent) {
-						return parent;
-					}
+				@Override
+				public Control getControl() {
+					return shell;
+				}
 
-					@Override
-					public Control getControl() {
-						return control;
-					}
-
-					@Override
-					public org.eclipse.gef.EditDomain getEditDomain() {
-						return editDomain;
-					}
-				};
-			}
-
-			@Override
-			public Command getCommand(Request request) {
-				return new Command() {
-				};
-			}
-
-			@Override
-			protected IFigure createFigure() {
-				return new Figure();
-			}
-		};
+				@Override
+				public EditDomain getEditDomain() {
+					return editDomain;
+				}
+			};
+		}
 	}
 
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DragEditPartsTrackerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2024 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,50 +27,14 @@ import org.eclipse.ui.IPropertyListener;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PartInitException;
 
-import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.IFigure;
-
 import org.eclipse.gef.DefaultEditDomain;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
+import org.eclipse.gef.test.utils.TestGraphicalEditPart;
 import org.eclipse.gef.tools.DragEditPartsTracker;
 
 import org.junit.jupiter.api.Test;
 
 public class DragEditPartsTrackerTest {
-
-	private static class TestGraphicalEditPart extends AbstractGraphicalEditPart {
-
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.gef.editparts.AbstractEditPart#register()
-		 */
-		@Override
-		protected void register() {
-			// do nothing
-		}
-
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
-		 */
-		@Override
-		protected IFigure createFigure() {
-			return new Figure();
-		}
-
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
-		 */
-		@Override
-		protected void createEditPolicies() {
-			// do nothing
-		}
-	}
 
 	private class DummyEditorPart implements org.eclipse.ui.IEditorPart {
 

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/ToolUtilitiesTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/ToolUtilitiesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2024 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,58 +15,13 @@ package org.eclipse.gef.test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.eclipse.draw2d.Figure;
-import org.eclipse.draw2d.IFigure;
-
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
+import org.eclipse.gef.test.utils.TestGraphicalEditPart;
 import org.eclipse.gef.tools.ToolUtilities;
 
 import org.junit.jupiter.api.Test;
 
 public class ToolUtilitiesTest {
-
-	private static class TestGraphicalEditPart extends AbstractGraphicalEditPart {
-
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#activate()
-		 */
-		public void addChild(EditPart ep) {
-			addChild(ep, 0);
-		}
-
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.gef.editparts.AbstractEditPart#register()
-		 */
-		@Override
-		protected void register() {
-			// do nothing
-		}
-
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
-		 */
-		@Override
-		protected IFigure createFigure() {
-			return new Figure();
-		}
-
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
-		 */
-		@Override
-		protected void createEditPolicies() {
-			// do nothing
-		}
-	}
 
 	@SuppressWarnings("static-method")
 	@Test

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/utils/TestGraphicalEditPart.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/utils/TestGraphicalEditPart.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gef.test.utils;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
+
+public class TestGraphicalEditPart extends AbstractGraphicalEditPart {
+
+	/**
+	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#activate()
+	 */
+	public void addChild(EditPart ep) {
+		addChild(ep, 0);
+	}
+
+	@Override
+	protected void register() {
+		// do nothing
+	}
+
+	@Override
+	protected IFigure createFigure() {
+		return new Figure();
+	}
+
+	@Override
+	protected void createEditPolicies() {
+		// do nothing
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/DirectEditManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/DirectEditManager.java
@@ -440,10 +440,14 @@ public abstract class DirectEditManager {
 	 * Unhooks listeners. Called from {@link #bringDown()}.
 	 */
 	protected void unhookListeners() {
-		getEditPart().getFigure().removeAncestorListener(ancestorListener);
-		getEditPart().removeEditPartListener(editPartListener);
-		ancestorListener = null;
-		editPartListener = null;
+		if (ancestorListener != null) {
+			getEditPart().getFigure().removeAncestorListener(ancestorListener);
+			ancestorListener = null;
+		}
+		if (editPartListener != null) {
+			getEditPart().removeEditPartListener(editPartListener);
+			editPartListener = null;
+		}
 
 		if (getCellEditor() == null) {
 			return;


### PR DESCRIPTION
When bringDown() is called while processing a "direct edit" command, an IllegalArgumentException is thrown because the edit-part listener is removed twice.

This is because the listener is null in the second round, which is not a valid parameter to pass to the underlying EventListenerList of the edit part.

An explicit null-check has been added to the DirectEditManager to avoid this issue.