### PR TITLE
Adapt API filters for removal of monitor-aware SWT classes

### DIFF
--- a/org.eclipse.draw2d/.settings/.api_filters
+++ b/org.eclipse.draw2d/.settings/.api_filters
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.draw2d" version="2">
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.draw2d_3.20.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.draw2d_3.20.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/draw2d/AbstractImageFigure.java" type="org.eclipse.draw2d.AbstractImageFigure">
         <filter comment="AbstractImageFigure is the offical startpoint for IImageFigure therefore it is ok that it implements that interface" id="576725006">
             <message_arguments>


### PR DESCRIPTION
The MonitorAwareRectangle and MonitorAwarePoint classes have been made package-private by SWT[1]. Because Draw2D re-exports SWT, this is considered a breakage in API, which would require a major version increment.

This change suppresses those errors, as they are not relevant for Draw2D.

[1] https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349