### PR TITLE
Adapt API filters for removal of monitor-aware SWT classes

### DIFF
--- a/org.eclipse.zest.layouts/.settings/.api_filters
+++ b/org.eclipse.zest.layouts/.settings/.api_filters
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.zest.layouts" version="2">
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.zest.layouts_2.0.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.zest.layouts_2.0.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java" type="org.eclipse.zest.layouts.algorithms.AbstractLayoutAlgorithm">
         <filter id="576725006">
             <message_arguments>


### PR DESCRIPTION
This is a follow-up to 50e27e3f2f36a1c1d161a219e3088e8ba6d4f1ed, this time for the Zest plug-in. Because it also re-exports the SWT bundle, it is also affected by the removal of the "MonitorAware" SWT classes [1].

This change suppresses those errors, as they are not relevant for Zest.

[1] https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349