### PR TITLE
Remove unused API filters

### DIFF
--- a/org.eclipse.draw2d/.settings/.api_filters
+++ b/org.eclipse.draw2d/.settings/.api_filters
@@ -1,21 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.draw2d" version="2">
-    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwarePoint">
-        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
-                <message_argument value="org.eclipse.draw2d_3.20.0"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
-        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
-                <message_argument value="org.eclipse.draw2d_3.20.0"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/draw2d/AbstractImageFigure.java" type="org.eclipse.draw2d.AbstractImageFigure">
         <filter comment="AbstractImageFigure is the offical startpoint for IImageFigure therefore it is ok that it implements that interface" id="576725006">
             <message_arguments>

--- a/org.eclipse.zest.core/.settings/.api_filters
+++ b/org.eclipse.zest.core/.settings/.api_filters
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.zest.core" version="2">
-    <resource path="META-INF/MANIFEST.MF">
-        <filter id="927989779">
-            <message_arguments>
-                <message_argument value="1.16.0"/>
-                <message_argument value="org.eclipse.draw2d"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/zest/core/widgets/Graph.java" type="org.eclipse.zest.core.widgets.Graph">
         <filter id="576725006">
             <message_arguments>

--- a/org.eclipse.zest.layouts/.settings/.api_filters
+++ b/org.eclipse.zest.layouts/.settings/.api_filters
@@ -1,21 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.zest.layouts" version="2">
-    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwarePoint">
-        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
-                <message_argument value="org.eclipse.zest.layouts_2.0.200"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
-        <filter comment="https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349" id="305426566">
-            <message_arguments>
-                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
-                <message_argument value="org.eclipse.zest.layouts_2.0.200"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java" type="org.eclipse.zest.layouts.algorithms.AbstractLayoutAlgorithm">
         <filter id="576725006">
             <message_arguments>


### PR DESCRIPTION
Those filters were added because of the removal of the MonitorAwarePoint and MonitorAwareRectangle in SWT, which were re-exported by the Draw2D/GEF/Zest bundles. With the 2025-12 release, these filters are no longer relevant.