### PR TITLE
Add Zest to baseline

### DIFF
--- a/org.eclipse.gef.baseline/gef-classic-3.25.0.target
+++ b/org.eclipse.gef.baseline/gef-classic-3.25.0.target
@@ -10,6 +10,7 @@
 			<repository location="https://download.eclipse.org/releases/2025-09"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.zest.feature.group" version="0.0.0"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
Both GEF and Draw2D plugins are (probably) added to the baseline via the SWTBot dependency. But Zest is not, leading to warnings in the workspace.