### PR TITLE
Create and add SVG variants for Match/Alignment icons

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalImages.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalImages.java
@@ -102,20 +102,20 @@ public class InternalImages {
 		DESC_ZOOM_IN = createDescriptor("icons/zoom_in.svg"); //$NON-NLS-1$
 		DESC_ZOOM_OUT = createDescriptor("icons/zoom_out.svg"); //$NON-NLS-1$
 
-		DESC_MATCH_SIZE = createDescriptor("icons/matchsize.png"); //$NON-NLS-1$
-		DESC_MATCH_WIDTH = createDescriptor("icons/matchwidth.png"); //$NON-NLS-1$
-		DESC_MATCH_HEIGHT = createDescriptor("icons/matchheight.png"); //$NON-NLS-1$
+		DESC_MATCH_SIZE = createDescriptor("icons/matchsize.svg"); //$NON-NLS-1$
+		DESC_MATCH_WIDTH = createDescriptor("icons/matchwidth.svg"); //$NON-NLS-1$
+		DESC_MATCH_HEIGHT = createDescriptor("icons/matchheight.svg"); //$NON-NLS-1$
 
 		DESC_MATCH_SIZE_DIS = createDescriptor("icons/matchsize_d.png"); //$NON-NLS-1$
 		DESC_MATCH_WIDTH_DIS = createDescriptor("icons/matchwidth_d.png"); //$NON-NLS-1$
 		DESC_MATCH_HEIGHT_DIS = createDescriptor("icons/matchheight_d.png"); //$NON-NLS-1$
 
-		DESC_VERT_ALIGN_BOTTOM = createDescriptor("icons/alignbottom.png"); //$NON-NLS-1$
-		DESC_HORZ_ALIGN_CENTER = createDescriptor("icons/aligncenter.png"); //$NON-NLS-1$
-		DESC_HORZ_ALIGN_LEFT = createDescriptor("icons/alignleft.png"); //$NON-NLS-1$
-		DESC_VERT_ALIGN_MIDDLE = createDescriptor("icons/alignmid.png"); //$NON-NLS-1$
-		DESC_HORZ_ALIGN_RIGHT = createDescriptor("icons/alignright.png"); //$NON-NLS-1$
-		DESC_VERT_ALIGN_TOP = createDescriptor("icons/aligntop.png"); //$NON-NLS-1$
+		DESC_VERT_ALIGN_BOTTOM = createDescriptor("icons/alignbottom.svg"); //$NON-NLS-1$
+		DESC_HORZ_ALIGN_CENTER = createDescriptor("icons/aligncenter.svg"); //$NON-NLS-1$
+		DESC_HORZ_ALIGN_LEFT = createDescriptor("icons/alignleft.svg"); //$NON-NLS-1$
+		DESC_VERT_ALIGN_MIDDLE = createDescriptor("icons/alignmid.svg"); //$NON-NLS-1$
+		DESC_HORZ_ALIGN_RIGHT = createDescriptor("icons/alignright.svg"); //$NON-NLS-1$
+		DESC_VERT_ALIGN_TOP = createDescriptor("icons/aligntop.svg"); //$NON-NLS-1$
 
 		DESC_VERT_ALIGN_BOTTOM_DIS = createDescriptor("icons/alignbottom_d.png"); //$NON-NLS-1$
 		DESC_HORZ_ALIGN_CENTER_DIS = createDescriptor("icons/aligncenter_d.png"); //$NON-NLS-1$

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignbottom.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignbottom.svg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient5549">
+      <stop
+         style="stop-color:#59df73;stop-opacity:1;"
+         offset="0"
+         id="stop5545" />
+      <stop
+         style="stop-color:#519554;stop-opacity:1;"
+         offset="1"
+         id="stop5547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4087">
+      <stop
+         style="stop-color:#599159;stop-opacity:1;"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#446e44;stop-opacity:1;"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2625">
+      <stop
+         style="stop-color:#b6d0d5;stop-opacity:1;"
+         offset="0"
+         id="stop2621" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop2623" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1163">
+      <stop
+         style="stop-color:#5971b4;stop-opacity:1;"
+         offset="0"
+         id="stop1159" />
+      <stop
+         style="stop-color:#545490;stop-opacity:1;"
+         offset="1"
+         id="stop1161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#ffffde;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bc8511;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#a16f26;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1163"
+       id="linearGradient3453"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,4.9999995,0.66666629)" />
+    <linearGradient
+       xlink:href="#linearGradient2625"
+       id="linearGradient5299"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,4.9999995,0.66666629)" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0039797"
+       y1="3.0192807"
+       x2="9.9774294"
+       y2="11.999311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6"
+       y1="2.0248184"
+       x2="11.021058"
+       y2="12.99624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient5549"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,10.999999,2.6666666)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient4087"
+       id="linearGradient568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,10.999999,2.6666666)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-6.2960915e-7,9.6666664)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-6.2960915e-7,9.6666664)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g28468"
+       transform="translate(8.9547977,0.10292871)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -1.4547977,9.8970713 v -3"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,9.8970713 H 0.04520224 L -1.4547977,11.897072 Z"
+         id="path16955" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,9.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,11.897072 Z"
+         id="path22179" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g19442"
+       transform="translate(8.9547977,0.10292871)"
+       style="display:inline">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 4.5452023,9.8970713 v -1"
+         id="path12879-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 3.0452023,9.8970713 H 6.0452022 L 4.5452023,11.897072 Z"
+         id="path16955-2" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3.0452023,9.8970713 h 0.5 l 1,1.3333337 0.9999999,-1.3333337 h 0.5 L 4.5452023,11.897072 Z"
+         id="path22179-6" />
+      <rect
+         style="display:inline;fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435-0"
+         width="1"
+         height="1"
+         x="4.0452023"
+         y="7.8970714" />
+    </g>
+    <g
+       id="g16903">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="4"
+         x="5.4999995"
+         y="1.4999995" />
+      <rect
+         style="fill:url(#linearGradient566);fill-opacity:1;stroke:url(#linearGradient568);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-2"
+         width="4"
+         height="4"
+         x="11.499999"
+         y="3.4999995" />
+      <rect
+         style="fill:url(#linearGradient599);fill-opacity:1;stroke:url(#linearGradient601);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-6"
+         width="4"
+         height="4"
+         x="0.49999949"
+         y="10.499999" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline"
+       transform="translate(-0.08075099,0.0403755)">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1"
+         width="1"
+         height="1"
+         x="7.0807509"
+         y="13.959624" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-8"
+         width="1"
+         height="1"
+         x="9.0807514"
+         y="13.959624" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-7"
+         width="1"
+         height="1"
+         x="11.080751"
+         y="13.959624" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-9"
+         width="1"
+         height="1"
+         x="13.080751"
+         y="13.959624" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/aligncenter.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/aligncenter.svg
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient5549">
+      <stop
+         style="stop-color:#59df73;stop-opacity:1;"
+         offset="0"
+         id="stop5545" />
+      <stop
+         style="stop-color:#519554;stop-opacity:1;"
+         offset="1"
+         id="stop5547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4087">
+      <stop
+         style="stop-color:#599159;stop-opacity:1;"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#446e44;stop-opacity:1;"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2625">
+      <stop
+         style="stop-color:#b6d0d5;stop-opacity:1;"
+         offset="0"
+         id="stop2621" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop2623" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1163">
+      <stop
+         style="stop-color:#5971b4;stop-opacity:1;"
+         offset="0"
+         id="stop1159" />
+      <stop
+         style="stop-color:#545490;stop-opacity:1;"
+         offset="1"
+         id="stop1161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#ffffde;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bc8511;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#a16f26;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1163"
+       id="linearGradient3453"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-1.4879819e-6,5.6666674)" />
+    <linearGradient
+       xlink:href="#linearGradient2625"
+       id="linearGradient5299"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-1.4879819e-6,5.6666674)" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0039797"
+       y1="3.0192807"
+       x2="9.9774294"
+       y2="11.999311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6"
+       y1="2.0248184"
+       x2="11.021058"
+       y2="12.99624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient5549"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999998,9.6666683)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient4087"
+       id="linearGradient568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999998,9.6666683)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,4.9999994,-0.33333327)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,4.9999994,-0.33333327)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g28468"
+       transform="rotate(-90,3.0740654,8.9711368)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -1.4547977,8.897072 V 6.8970713"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,8.8970713 H 0.04520224 L -1.4547977,10.897072 Z"
+         id="path16955" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,8.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,10.897072 Z"
+         id="path22179" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g28468-3"
+       transform="rotate(90,5.9711373,14.925935)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -1.4547977,8.897072 V 6.8970713"
+         id="path12879-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,8.8970713 H 0.04520224 L -1.4547977,10.897072 Z"
+         id="path16955-7" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,8.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,10.897072 Z"
+         id="path22179-5" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435-3"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g16903">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="4"
+         x="0.49999949"
+         y="6.4999995" />
+      <rect
+         style="fill:url(#linearGradient566);fill-opacity:1;stroke:url(#linearGradient568);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-2"
+         width="4"
+         height="4"
+         x="10.499999"
+         y="10.499999" />
+      <rect
+         style="fill:url(#linearGradient599);fill-opacity:1;stroke:url(#linearGradient601);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-6"
+         width="4"
+         height="4"
+         x="5.4999995"
+         y="0.49999949" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline"
+       transform="rotate(90,14.22064,-7.1808966)">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1"
+         width="1"
+         height="1"
+         x="28.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-8"
+         width="1"
+         height="1"
+         x="30.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-7"
+         width="1"
+         height="1"
+         x="32.401539"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-9"
+         width="1"
+         height="1"
+         x="34.401539"
+         y="-0.9602567" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignleft.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignleft.svg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient5549">
+      <stop
+         style="stop-color:#59df73;stop-opacity:1;"
+         offset="0"
+         id="stop5545" />
+      <stop
+         style="stop-color:#519554;stop-opacity:1;"
+         offset="1"
+         id="stop5547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4087">
+      <stop
+         style="stop-color:#599159;stop-opacity:1;"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#446e44;stop-opacity:1;"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2625">
+      <stop
+         style="stop-color:#b6d0d5;stop-opacity:1;"
+         offset="0"
+         id="stop2621" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop2623" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1163">
+      <stop
+         style="stop-color:#5971b4;stop-opacity:1;"
+         offset="0"
+         id="stop1159" />
+      <stop
+         style="stop-color:#545490;stop-opacity:1;"
+         offset="1"
+         id="stop1161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#ffffde;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bc8511;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#a16f26;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1163"
+       id="linearGradient3453"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,7.9999995,10.666667)" />
+    <linearGradient
+       xlink:href="#linearGradient2625"
+       id="linearGradient5299"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,7.9999995,10.666667)" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0039797"
+       y1="3.0192807"
+       x2="9.9774294"
+       y2="11.999311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6"
+       y1="2.0248184"
+       x2="11.021058"
+       y2="12.99624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient5549"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999994,4.666667)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient4087"
+       id="linearGradient568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999994,4.666667)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,0.99999937,-0.33333318)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,0.99999937,-0.33333318)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g28468"
+       transform="rotate(90,3.471137,12.425935)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -1.4547977,9.8970713 v -3"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,9.8970713 H 0.04520224 L -1.4547977,11.897072 Z"
+         id="path16955" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,9.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,11.897072 Z"
+         id="path22179" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g19442"
+       transform="rotate(90,3.471137,12.425935)"
+       style="display:inline">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 4.5452023,9.8970713 v -1"
+         id="path12879-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 3.0452023,9.8970713 H 6.0452022 L 4.5452023,11.897072 Z"
+         id="path16955-2" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3.0452023,9.8970713 h 0.5 l 1,1.3333337 0.9999999,-1.3333337 h 0.5 L 4.5452023,11.897072 Z"
+         id="path22179-6" />
+      <rect
+         style="display:inline;fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435-0"
+         width="1"
+         height="1"
+         x="4.0452023"
+         y="7.8970714" />
+    </g>
+    <g
+       id="g16903">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="4"
+         x="8.499999"
+         y="11.499999" />
+      <rect
+         style="fill:url(#linearGradient566);fill-opacity:1;stroke:url(#linearGradient568);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-2"
+         width="4"
+         height="4"
+         x="10.499999"
+         y="5.4999995" />
+      <rect
+         style="fill:url(#linearGradient599);fill-opacity:1;stroke:url(#linearGradient601);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-6"
+         width="4"
+         height="4"
+         x="1.4999995"
+         y="0.49999949" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline"
+       transform="rotate(90,11.22064,-10.180896)">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1"
+         width="1"
+         height="1"
+         x="28.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-8"
+         width="1"
+         height="1"
+         x="30.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-7"
+         width="1"
+         height="1"
+         x="32.401539"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-9"
+         width="1"
+         height="1"
+         x="34.401539"
+         y="-0.9602567" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignmid.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignmid.svg
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient5549">
+      <stop
+         style="stop-color:#59df73;stop-opacity:1;"
+         offset="0"
+         id="stop5545" />
+      <stop
+         style="stop-color:#519554;stop-opacity:1;"
+         offset="1"
+         id="stop5547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4087">
+      <stop
+         style="stop-color:#599159;stop-opacity:1;"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#446e44;stop-opacity:1;"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2625">
+      <stop
+         style="stop-color:#b6d0d5;stop-opacity:1;"
+         offset="0"
+         id="stop2621" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop2623" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1163">
+      <stop
+         style="stop-color:#5971b4;stop-opacity:1;"
+         offset="0"
+         id="stop1159" />
+      <stop
+         style="stop-color:#545490;stop-opacity:1;"
+         offset="1"
+         id="stop1161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#ffffde;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bc8511;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#a16f26;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1163"
+       id="linearGradient3453"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,5.9999993,-0.33333323)" />
+    <linearGradient
+       xlink:href="#linearGradient2625"
+       id="linearGradient5299"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,5.9999993,-0.33333323)" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0039797"
+       y1="3.0192807"
+       x2="9.9774294"
+       y2="11.999311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6"
+       y1="2.0248184"
+       x2="11.021058"
+       y2="12.99624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient5549"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999998,9.6666683)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient4087"
+       id="linearGradient568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999998,9.6666683)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-6.2960915e-7,4.6666668)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-6.2960915e-7,4.6666668)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g28468"
+       transform="rotate(180,3.0226011,10.448536)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -1.4547977,8.897072 V 6.8970713"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,8.8970713 H 0.04520224 L -1.4547977,10.897072 Z"
+         id="path16955" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,8.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,10.897072 Z"
+         id="path22179" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g28468-3"
+       transform="translate(14.954798,-5.8970714)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -1.4547977,8.897072 V 6.8970713"
+         id="path12879-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,8.8970713 H 0.04520224 L -1.4547977,10.897072 Z"
+         id="path16955-7" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,8.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,10.897072 Z"
+         id="path22179-5" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435-3"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g16903">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="4"
+         x="6.4999995"
+         y="0.49999949" />
+      <rect
+         style="fill:url(#linearGradient566);fill-opacity:1;stroke:url(#linearGradient568);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-2"
+         width="4"
+         height="4"
+         x="10.499999"
+         y="10.499999" />
+      <rect
+         style="fill:url(#linearGradient599);fill-opacity:1;stroke:url(#linearGradient601);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-6"
+         width="4"
+         height="4"
+         x="0.49999949"
+         y="5.4999995" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline"
+       transform="translate(-21.401537,7.9602567)">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1"
+         width="1"
+         height="1"
+         x="28.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-8"
+         width="1"
+         height="1"
+         x="30.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-7"
+         width="1"
+         height="1"
+         x="32.401539"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-9"
+         width="1"
+         height="1"
+         x="34.401539"
+         y="-0.9602567" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignright.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/alignright.svg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient5549">
+      <stop
+         style="stop-color:#59df73;stop-opacity:1;"
+         offset="0"
+         id="stop5545" />
+      <stop
+         style="stop-color:#519554;stop-opacity:1;"
+         offset="1"
+         id="stop5547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4087">
+      <stop
+         style="stop-color:#599159;stop-opacity:1;"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#446e44;stop-opacity:1;"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2625">
+      <stop
+         style="stop-color:#b6d0d5;stop-opacity:1;"
+         offset="0"
+         id="stop2621" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop2623" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1163">
+      <stop
+         style="stop-color:#5971b4;stop-opacity:1;"
+         offset="0"
+         id="stop1159" />
+      <stop
+         style="stop-color:#545490;stop-opacity:1;"
+         offset="1"
+         id="stop1161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#ffffde;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bc8511;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#a16f26;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1163"
+       id="linearGradient3453"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,2.9999995,10.666667)" />
+    <linearGradient
+       xlink:href="#linearGradient2625"
+       id="linearGradient5299"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,2.9999995,10.666667)" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0039797"
+       y1="3.0192807"
+       x2="9.9774294"
+       y2="11.999311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6"
+       y1="2.0248184"
+       x2="11.021058"
+       y2="12.99624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient5549"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,0.99999945,4.666667)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient4087"
+       id="linearGradient568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,0.99999945,4.666667)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999995,-0.33333317)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,9.9999995,-0.33333317)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g28468"
+       transform="rotate(-90,3.0740654,2.9711368)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -1.4547977,9.8970713 v -3"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,9.8970713 H 0.04520224 L -1.4547977,11.897072 Z"
+         id="path16955" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,9.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,11.897072 Z"
+         id="path22179" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g19442"
+       transform="rotate(-90,9.0740654,8.9711368)"
+       style="display:inline">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 4.5452023,9.8970713 v -1"
+         id="path12879-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 3.0452023,9.8970713 H 6.0452022 L 4.5452023,11.897072 Z"
+         id="path16955-2" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3.0452023,9.8970713 h 0.5 l 1,1.3333337 0.9999999,-1.3333337 h 0.5 L 4.5452023,11.897072 Z"
+         id="path22179-6" />
+      <rect
+         style="display:inline;fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435-0"
+         width="1"
+         height="1"
+         x="4.0452023"
+         y="7.8970714" />
+    </g>
+    <g
+       id="g16903">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="4"
+         x="3.4999995"
+         y="11.499999" />
+      <rect
+         style="fill:url(#linearGradient566);fill-opacity:1;stroke:url(#linearGradient568);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-2"
+         width="4"
+         height="4"
+         x="1.4999995"
+         y="5.4999995" />
+      <rect
+         style="fill:url(#linearGradient599);fill-opacity:1;stroke:url(#linearGradient601);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-6"
+         width="4"
+         height="4"
+         x="10.499999"
+         y="0.49999949" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline"
+       transform="rotate(90,17.72064,-3.6808968)">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1"
+         width="1"
+         height="1"
+         x="28.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-8"
+         width="1"
+         height="1"
+         x="30.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-7"
+         width="1"
+         height="1"
+         x="32.401539"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-9"
+         width="1"
+         height="1"
+         x="34.401539"
+         y="-0.9602567" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/aligntop.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/aligntop.svg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient5549">
+      <stop
+         style="stop-color:#59df73;stop-opacity:1;"
+         offset="0"
+         id="stop5545" />
+      <stop
+         style="stop-color:#519554;stop-opacity:1;"
+         offset="1"
+         id="stop5547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4087">
+      <stop
+         style="stop-color:#599159;stop-opacity:1;"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#446e44;stop-opacity:1;"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2625">
+      <stop
+         style="stop-color:#b6d0d5;stop-opacity:1;"
+         offset="0"
+         id="stop2621" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop2623" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1163">
+      <stop
+         style="stop-color:#5971b4;stop-opacity:1;"
+         offset="0"
+         id="stop1159" />
+      <stop
+         style="stop-color:#545490;stop-opacity:1;"
+         offset="1"
+         id="stop1161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#ffffde;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bc8511;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#a16f26;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1163"
+       id="linearGradient3453"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,4.9999995,9.6666663)" />
+    <linearGradient
+       xlink:href="#linearGradient2625"
+       id="linearGradient5299"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,4.9999995,9.6666663)" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0039797"
+       y1="3.0192807"
+       x2="9.9774294"
+       y2="11.999311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6"
+       y1="2.0248184"
+       x2="11.021058"
+       y2="12.99624"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.4,0,1.5)" />
+    <linearGradient
+       xlink:href="#linearGradient5549"
+       id="linearGradient566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,10.999999,7.6666666)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient4087"
+       id="linearGradient568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,10.999999,7.6666666)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-6.2960915e-7,0.66666685)"
+       x1="1.0164249"
+       y1="4.047514"
+       x2="4.0008202"
+       y2="13.004149" />
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.33333328,-6.2960915e-7,0.66666685)"
+       x1="0.0025460757"
+       y1="1.0482799"
+       x2="4.9871917"
+       y2="16.014412" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g28468"
+       transform="rotate(180,3.0226011,7.948536)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -1.4547977,9.8970713 v -3"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M -2.9547977,9.8970713 H 0.04520224 L -1.4547977,11.897072 Z"
+         id="path16955" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.9547977,9.8970713 h 0.5 l 1,1.3333337 0.99999995,-1.3333337 h 0.5 L -1.4547977,11.897072 Z"
+         id="path22179" />
+      <rect
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435"
+         width="1"
+         height="1"
+         x="-1.9547977"
+         y="5.8970714" />
+    </g>
+    <g
+       id="g19442"
+       transform="rotate(180,9.0226011,7.948536)"
+       style="display:inline">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 4.5452023,9.8970713 v -1"
+         id="path12879-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 3.0452023,9.8970713 H 6.0452022 L 4.5452023,11.897072 Z"
+         id="path16955-2" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3.0452023,9.8970713 h 0.5 l 1,1.3333337 0.9999999,-1.3333337 h 0.5 L 4.5452023,11.897072 Z"
+         id="path22179-6" />
+      <rect
+         style="display:inline;fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round"
+         id="rect14435-0"
+         width="1"
+         height="1"
+         x="4.0452023"
+         y="7.8970714" />
+    </g>
+    <g
+       id="g16903">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="4"
+         x="5.4999995"
+         y="10.499999" />
+      <rect
+         style="fill:url(#linearGradient566);fill-opacity:1;stroke:url(#linearGradient568);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-2"
+         width="4"
+         height="4"
+         x="11.499999"
+         y="8.499999" />
+      <rect
+         style="fill:url(#linearGradient599);fill-opacity:1;stroke:url(#linearGradient601);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-6"
+         width="4"
+         height="4"
+         x="0.49999949"
+         y="1.4999995" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline"
+       transform="translate(-21.401537,1.9602567)">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1"
+         width="1"
+         height="1"
+         x="28.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-8"
+         width="1"
+         height="1"
+         x="30.401537"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-7"
+         width="1"
+         height="1"
+         x="32.401539"
+         y="-0.9602567" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-1-9"
+         width="1"
+         height="1"
+         x="34.401539"
+         y="-0.9602567" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/matchheight.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/matchheight.svg
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#fffeda;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bd8610;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#9f6d27;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient3453"
+       x1="0.0025460757"
+       y1="2.0598419"
+       x2="4.9968257"
+       y2="14.973948"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient5299"
+       x1="0.94898742"
+       y1="3.0070503"
+       x2="3.9815521"
+       y2="13.957908"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0039797"
+       y1="3.0192807"
+       x2="9.9774294"
+       y2="11.999311"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6"
+       y1="2.0248184"
+       x2="11.021058"
+       y2="12.99624"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g28468">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 13.5,12 V 5"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 12,5 h 3 L 13.5,3 Z"
+         id="path16953" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 12,12 h 3 l -1.5,2 z"
+         id="path16955" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 12,5 h 0.5 L 13.5,3.6666666 14.5,5 H 15 L 13.5,3 Z"
+         id="path19135" />
+      <path
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 12,12 h 0.5 l 1,1.333333 L 14.5,12 H 15 l -1.5,2 z"
+         id="path22179" />
+    </g>
+    <g
+       id="g16903">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="12.000002"
+         x="0.5"
+         y="2.5" />
+      <rect
+         style="fill:url(#linearGradient7485);fill-opacity:1;stroke:url(#linearGradient10399);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-3"
+         width="4"
+         height="10"
+         x="6.5"
+         y="2.5" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0"
+         width="1"
+         height="1"
+         x="6"
+         y="14" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-6"
+         width="1"
+         height="1"
+         x="8"
+         y="14" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-56"
+         width="1"
+         height="1"
+         x="12"
+         y="2" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-2"
+         width="1"
+         height="1"
+         x="14"
+         y="2" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-7"
+         width="1"
+         height="1"
+         x="10"
+         y="14" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-5"
+         width="1"
+         height="1"
+         x="12"
+         y="14" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-3"
+         width="1"
+         height="1"
+         x="14"
+         y="14" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/matchsize.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/matchsize.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a72b6;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545591;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bdd5d6;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5a72b6;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#fffeda;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78e;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bd8610;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#9f6d27;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient3453"
+       x1="0.3447974"
+       y1="15.043054"
+       x2="4.7078943"
+       y2="1.9215353"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5000003,0,0,0.83333347,0.25000087,-13.583336)" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient5299"
+       x1="0.74610454"
+       y1="13.882817"
+       x2="4.326128"
+       y2="3.0970552"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5000003,0,0,0.83333347,0.25000087,-13.583336)" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="6.8178272"
+       y1="11.706614"
+       x2="10.198667"
+       y2="3.2586193"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.75,0,0,0.7,-9.875,-10.249999)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient30106"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.75,0,0,0.7,-9.875,-10.249999)"
+       x1="6.2280598"
+       y1="13.184231"
+       x2="10.768633"
+       y2="1.782492" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g34722">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:0.999999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="10.000001"
+         height="10.000003"
+         x="1.500001"
+         y="-11.500003"
+         transform="rotate(90)" />
+      <rect
+         style="fill:url(#linearGradient7485);fill-opacity:1;stroke:url(#linearGradient30106);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-3"
+         width="7"
+         height="7"
+         x="1.5"
+         y="-8.5"
+         transform="rotate(90)" />
+    </g>
+    <g
+       id="g34718"
+       style="display:inline">
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-5"
+         width="1"
+         height="1"
+         x="13"
+         y="-2"
+         transform="rotate(90)" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-3"
+         width="1"
+         height="1"
+         x="15"
+         y="-2"
+         transform="rotate(90)" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-5-7"
+         width="1"
+         height="1"
+         x="13"
+         y="-12"
+         transform="rotate(90)" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-3-5"
+         width="1"
+         height="1"
+         x="15"
+         y="-12"
+         transform="rotate(90)" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 4,14.500001 H 9"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 9,13.000001 v 3 l 2,-1.5 z"
+         id="path16953" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 4,13.000001 v 3 l -2,-1.5 z"
+         id="path16955" />
+      <path
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 9,13.000001 v 0.5 l 1.333333,1 -1.333333,1 v 0.5 l 2,-1.5 z"
+         id="path19135" />
+      <path
+         style="display:inline;fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 4,13.000001 v 0.5 l -1.333333,1 1.333333,1 v 0.5 l -2,-1.5 z"
+         id="path22179" />
+    </g>
+    <g
+       id="g34711"
+       style="display:inline">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0"
+         width="1"
+         height="1"
+         x="1"
+         y="-14"
+         transform="rotate(90)" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-9"
+         width="1"
+         height="1"
+         x="1"
+         y="-16"
+         transform="rotate(90)" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-2"
+         width="1"
+         height="1"
+         x="11"
+         y="-14"
+         transform="rotate(90)" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0-9-2"
+         width="1"
+         height="1"
+         x="11"
+         y="-16"
+         transform="rotate(90)" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 14.5,4 2e-6,5"
+         id="path12879-9" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.000002,9 h -3 l 1.5,2 z"
+         id="path16953-2" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.000002,4 h -3 l 1.5,-2 z"
+         id="path16955-0" />
+      <path
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.000002,9 h -0.5 l -1,1.333333 -1,-1.333333 h -0.5 l 1.5,2 z"
+         id="path19135-2" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.000002,4 h -0.5 l -1,-1.333333 -1,1.333333 h -0.5 l 1.5,-2 z"
+         id="path22179-3" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/matchwidth.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/matchwidth.svg
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg5"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient10397">
+      <stop
+         style="stop-color:#5a70b4;stop-opacity:1;"
+         offset="0"
+         id="stop10393" />
+      <stop
+         style="stop-color:#545590;stop-opacity:1;"
+         offset="1"
+         id="stop10395" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7483">
+      <stop
+         style="stop-color:#bad3d5;stop-opacity:1;"
+         offset="0"
+         id="stop7479" />
+      <stop
+         style="stop-color:#5380bd;stop-opacity:1;"
+         offset="1"
+         id="stop7481" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5297">
+      <stop
+         style="stop-color:#fffeda;stop-opacity:1;"
+         offset="0"
+         id="stop5293" />
+      <stop
+         style="stop-color:#ffe78c;stop-opacity:1;"
+         offset="1"
+         id="stop5295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3451">
+      <stop
+         style="stop-color:#bd8610;stop-opacity:1;"
+         offset="0"
+         id="stop3447" />
+      <stop
+         style="stop-color:#9f6d27;stop-opacity:1;"
+         offset="1"
+         id="stop3449" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3451"
+       id="linearGradient3453"
+       x1="0.047864959"
+       y1="15.005937"
+       x2="5.0119319"
+       y2="2.0127466"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient5297"
+       id="linearGradient5299"
+       x1="0.97920001"
+       y1="14.004433"
+       x2="3.9815521"
+       y2="3.0058439"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient7483"
+       id="linearGradient7485"
+       x1="7.0492988"
+       y1="12.007526"
+       x2="10.022748"
+       y2="2.9808536"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.000001)" />
+    <linearGradient
+       xlink:href="#linearGradient10397"
+       id="linearGradient10399"
+       x1="6.0151062"
+       y1="13.022201"
+       x2="10.990846"
+       y2="2.0139635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.000001)" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g16903"
+       transform="rotate(90,7.5,8.500001)">
+      <rect
+         style="fill:url(#linearGradient5299);fill-opacity:1;stroke:url(#linearGradient3453);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234"
+         width="4"
+         height="12.000002"
+         x="0.5"
+         y="2.5" />
+      <rect
+         style="fill:url(#linearGradient7485);fill-opacity:1;stroke:url(#linearGradient10399);stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect234-3"
+         width="4"
+         height="10"
+         x="6.5"
+         y="4.500001" />
+    </g>
+    <g
+       id="g16892"
+       style="display:inline"
+       transform="rotate(90,7.5,8.500001)">
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-0"
+         width="1"
+         height="1"
+         x="6"
+         y="2.000001" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-6"
+         width="1"
+         height="1"
+         x="8"
+         y="2.000001" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-56"
+         width="1"
+         height="1"
+         x="12"
+         y="2" />
+      <rect
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-2"
+         width="1"
+         height="1"
+         x="14"
+         y="2" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-7"
+         width="1"
+         height="1"
+         x="10"
+         y="2.000001" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-5"
+         width="1"
+         height="1"
+         x="12"
+         y="14" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         id="rect11853-3"
+         width="1"
+         height="1"
+         x="14"
+         y="14" />
+    </g>
+    <g
+       id="g28194">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 4.000001,14.500001 h 7"
+         id="path12879" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 11.000001,13.000001 v 3 l 2,-1.5 z"
+         id="path16953" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 4.000001,13.000001 v 3 l -2,-1.5 z"
+         id="path16955" />
+      <path
+         style="fill:#5a9ecd;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 11.000001,13.000001 v 0.5 l 1.333333,1 -1.333333,1 v 0.5 l 2,-1.5 z"
+         id="path19135" />
+      <path
+         style="fill:#b57d31;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 4.000001,13.000001 v 0.5 l -1.333333,1 1.333333,1 v 0.5 l -2,-1.5 z"
+         id="path22179" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This contributes following SVG icons:
- matchsize.svg
- matchwidth.svg
- matchheight.svg
- alignbottom.svg
- aligncenter.svg
- alignleft.svg
- alignmid.svg
- alignright.svg
- aligntop.svg

Note: Because newer versions of SWT are able to automatically generate the "disabled", no SVGs are created for those.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/732