### PR TITLE
Simplify configuration for Draw2D auto-scaling mode

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -75,7 +75,9 @@ public class FigureUtilities {
 	protected static GC getGC() {
 		if (gc == null) {
 			Shell shell = new Shell();
-			InternalDraw2dUtils.configureForAutoscalingMode(shell);
+			InternalDraw2dUtils.configureForAutoscalingMode(shell, event -> {
+				// ignored
+			});
 			gc = new GC(shell);
 			if (InternalDraw2dUtils.disableAutoscale) {
 				gc.setAdvanced(true);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
@@ -223,31 +223,6 @@ public abstract class PopUpHelper {
 	private class PopupHelperLightweightSystem extends LightweightSystem {
 
 		/**
-		 * Data that can be set to scale this widget at 100%.
-		 */
-		private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED"; //$NON-NLS-1$
-
-		/**
-		 * Internal flag for fetching the shell zoom
-		 */
-		private static final String DATA_SHELL_ZOOM = "SHELL_ZOOM"; //$NON-NLS-1$
-
-		/**
-		 * Returns the zoom of the monitor this widget is assigned to.
-		 *
-		 * @return 1.0 at 100%, 1.25 at 125% etc.
-		 */
-		private static double getMonitorZoomScale(Control c) {
-			int shellZooom;
-			try {
-				shellZooom = (int) c.getData(DATA_SHELL_ZOOM);
-			} catch (ClassCastException | NullPointerException e) {
-				shellZooom = 100;
-			}
-			return shellZooom / 100.0;
-		}
-
-		/**
 		 * The scalable pane that is injected between the root figure and the contents
 		 * of this viewport.
 		 */
@@ -274,9 +249,7 @@ public abstract class PopUpHelper {
 				return;
 			}
 
-			c.setData(DATA_AUTOSCALE_DISABLED, true);
-			c.addListener(SWT.ZoomChanged, e -> setScale(e.detail / 100.0));
-			setScale(getMonitorZoomScale(c));
+			InternalDraw2dUtils.configureForAutoscalingMode(c, this::setScale);
 
 			super.setControl(c);
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.internal;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 
@@ -34,6 +36,11 @@ public class InternalDraw2dUtils {
 	 */
 	private static final String DATA_SHELL_ZOOM = "SHELL_ZOOM"; //$NON-NLS-1$
 
+	/**
+	 * Data that can be set to scale this widget at 100%.
+	 */
+	private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED"; //$NON-NLS-1$
+
 	public static boolean disableAutoscale;
 
 	static {
@@ -41,22 +48,22 @@ public class InternalDraw2dUtils {
 				&& Boolean.parseBoolean(System.getProperty(DRAW2D_DISABLE_AUTOSCALE));
 	}
 
-	public static void configureForAutoscalingMode(Control control) {
-		if (control != null && disableAutoscale) {
-			control.setData("AUTOSCALE_DISABLED", true); //$NON-NLS-1$
+	public static void configureForAutoscalingMode(Control control, Consumer<Double> zoomConsumer) {
+		if (control == null || !disableAutoscale) {
+			return;
 		}
+		control.setData(InternalDraw2dUtils.DATA_AUTOSCALE_DISABLED, true);
+		control.addListener(SWT.ZoomChanged, e -> zoomConsumer.accept(e.detail / 100.0));
+		zoomConsumer.accept(InternalDraw2dUtils.calculateScale(control));
 	}
 
-	public static double calculateScale(Control control) {
-		if (!InternalDraw2dUtils.disableAutoscale || control == null) {
-			return 1.0;
-		}
-		int shellZooom;
+	private static double calculateScale(Control control) {
+		int shellZoom;
 		try {
-			shellZooom = (int) control.getData(InternalDraw2dUtils.DATA_SHELL_ZOOM);
+			shellZoom = (int) control.getData(InternalDraw2dUtils.DATA_SHELL_ZOOM);
 		} catch (ClassCastException | NullPointerException e) {
-			shellZooom = 100;
+			shellZoom = 100;
 		}
-		return shellZooom / 100.0;
+		return shellZoom / 100.0;
 	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DragSource;
 import org.eclipse.swt.dnd.DropTarget;
@@ -488,10 +487,9 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 			control.setMenu(contextMenu.createContextMenu(getControl()));
 		}
 		if (InternalDraw2dUtils.disableAutoscale) {
-			control.addListener(SWT.ZoomChanged,
-					e -> setProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY, e.detail / 100.0));
+			InternalDraw2dUtils.configureForAutoscalingMode(control,
+					scale -> setProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY, scale));
 		}
-		setProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY, InternalDraw2dUtils.calculateScale(control));
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ScrollingGraphicalViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/ScrollingGraphicalViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,7 +21,6 @@ import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
@@ -54,7 +53,6 @@ public class ScrollingGraphicalViewer extends GraphicalViewerImpl {
 	@Override
 	public final Control createControl(Composite parent) {
 		FigureCanvas control = new FigureCanvas(parent, getLightweightSystem());
-		InternalDraw2dUtils.configureForAutoscalingMode(control);
 		setControl(control);
 		hookRootFigure();
 		return getControl();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -241,9 +241,7 @@ public class Graph extends FigureCanvas implements IContainer2 {
 		this.rotateListener = new RotateGestureListener();
 
 		if (InternalDraw2dUtils.disableAutoscale) {
-			InternalDraw2dUtils.configureForAutoscalingMode(this);
-			addListener(SWT.ZoomChanged, event -> rootlayer.setScale(event.detail / 100.0));
-			rootlayer.setScale(InternalDraw2dUtils.calculateScale(this));
+			InternalDraw2dUtils.configureForAutoscalingMode(this, rootlayer::setScale);
 		}
 
 		this.addPaintListener(event -> {


### PR DESCRIPTION
Enabling the Draw2D auto-scaling mode currently requires three steps:

1) Disable the native SWT auto-scaling
2) Hook a ZoomChanged listener to the underlying canvas
3) Update the zoom of the ScalableFigure

All of these steps are currently possible via individual methods in the InternalDraw2dUtils. With this change, those methods are combined into a single method, greatly reducing the amount of changes required in the calling classes.