### PR TITLE
Only configure auto-scaling for the canvas when supported by SWT

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -45,7 +45,8 @@ public class InternalDraw2dUtils {
 	private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED"; //$NON-NLS-1$
 
 	private static final boolean enableAutoScale = "win32".equals(SWT.getPlatform()) //$NON-NLS-1$
-			&& Boolean.parseBoolean(System.getProperty(DRAW2D_ENABLE_AUTOSCALE, Boolean.TRUE.toString()));
+			&& Boolean.parseBoolean(System.getProperty(DRAW2D_ENABLE_AUTOSCALE, Boolean.TRUE.toString()))
+			&& SWT.getVersion() >= 4971; // SWT 2025-12 release or higher
 
 	public static boolean isAutoScaleEnabled() {
 		return enableAutoScale;


### PR DESCRIPTION
The auto-scaling support in Draw2D relies on the existence of the SHELL_ZOOM key, in order to calculate the zoom factor of the widget, which was only added with the 2025-12 SWT release. Because auto-scaling is enabled by default, Draw2D always paints figures at 100% zoom when using an older Eclipse version, even if the monitor has a higher zoom level.

By checking whether this key is set, this feature is only available with the latest Eclipse release. With older versions, the native scaling functionality provided by SWT is used.

Closes https://github.com/eclipse-gef/gef-classic/issues/812