### PR TITLE
Override remove in PopupHelper.ScalableRootFigure #814

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
@@ -281,6 +281,12 @@ public abstract class PopUpHelper {
 			public void setScale(double scale) {
 				scalablePane.setScale(scale);
 			}
+
+			@Override
+			public void remove(IFigure figure) {
+				scalablePane.remove(figure);
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
As this class is managing its children differently all methods manipulating and accessing children from the outside need to be overriden. remove() was missing resulting in acceptions.

Fixes: https://github.com/eclipse-gef/gef-classic/issues/814