### PR TITLE
Fix memory-leak in FigureUtilities by disposing GC on font change

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -32,6 +32,7 @@ public class FigureUtilities {
 
 	private static final float RGB_VALUE_MULTIPLIER = 0.6f;
 	private static GC gc;
+	private static Shell shell;
 	private static Font appliedFont;
 	private static FontMetrics metrics;
 	private static Color ghostFillColor = new Color(null, 31, 31, 31);
@@ -59,7 +60,7 @@ public class FigureUtilities {
 	public static FontMetrics getFontMetrics(Font f) {
 		setFont(f);
 		if (metrics == null) {
-			metrics = getGC().getFontMetrics();
+			metrics = gc.getFontMetrics();
 		}
 		return metrics;
 	}
@@ -74,14 +75,20 @@ public class FigureUtilities {
 	@Deprecated
 	protected static GC getGC() {
 		if (gc == null) {
-			Shell shell = new Shell();
-			InternalDraw2dUtils.configureForAutoscalingMode(shell, event -> {
-				// ignored
-			});
-			gc = new GC(shell);
+			gc = new GC(getShell());
 			appliedFont = gc.getFont();
 		}
 		return gc;
+	}
+
+	private static Shell getShell() {
+		if (shell == null) {
+			shell = new Shell();
+			InternalDraw2dUtils.configureForAutoscalingMode(shell, event -> {
+				// ignored
+			});
+		}
+		return shell;
 	}
 
 	/**
@@ -95,7 +102,7 @@ public class FigureUtilities {
 	 */
 	protected static org.eclipse.swt.graphics.Point getTextDimension(String s, Font f) {
 		setFont(f);
-		return getGC().textExtent(s);
+		return gc.textExtent(s);
 	}
 
 	/**
@@ -123,7 +130,7 @@ public class FigureUtilities {
 	 */
 	protected static org.eclipse.swt.graphics.Point getStringDimension(String s, Font f) {
 		setFont(f);
-		return getGC().stringExtent(s);
+		return gc.stringExtent(s);
 	}
 
 	/**
@@ -341,10 +348,14 @@ public class FigureUtilities {
 	 * @since 2.0
 	 */
 	protected static void setFont(Font f) {
-		if (appliedFont == f || (f != null && f.equals(appliedFont))) {
+		if ((appliedFont == null && f == null && gc != null) || (f != null && f.equals(appliedFont))) {
 			return;
 		}
-		getGC().setFont(f);
+		if (gc != null && !gc.isDisposed()) {
+			gc.dispose();
+		}
+		gc = new GC(getShell());
+		gc.setFont(f);
 		appliedFont = f;
 		metrics = null;
 	}


### PR DESCRIPTION
FigureUtilities create a GC once for an application and then reuse it to calculate font/text dimensions. Due to the modification of GC to store Operations, every operation on FigureUtilities that sets the font on the GC (i.e., that calls setFont()) creates a SetFontOperation in the GC. Since that GC is never dispose, these operation accumulate throughout the application lifecycle and constituted a memory leak

The current change addresses this issue by creating a single shell for the lifetime of the application. Whenever a different font needs to be set, the old GC is properly disposed and replaced with a new one created from the shell. This ensures that no GC objects persist indefinitely, effectively preventing the memory leak. The now unused getGC() method which was protected has been removed from the codebase as part of this change.

**Steps to reproduce** in https://github.com/vi-eclipse/Eclipse-Platform/issues/443#issue-3402387481

1. Start an Eclipse product with GEF installed
2. Open and close any GEF diagram (such as an empty Logic or Shapes example)
3. Take a memory heapdump, e.g., with VisualVM
4. Open and close the same GEF diagram one or multiple times
5. Take another memory heapdump and compare with the original one

You see that the number of org.eclipse.swt.graphics.GC$SetFontOperation objects in the heap increased (and increases with every GEF diagram that is opened) without this change