### PR TITLE
Use DrawableTextUtilities for Label and TextFlow figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
   This feature was originally request in [Bug 172463](https://bugs.eclipse.org/bugs/show_bug.cgi?id=172463)   
 - Implemented `SWTGraphics.getAbsoluteScale()`
   This feature was originally requested in [Bug 267462](https://bugs.eclipse.org/bugs/show_bug.cgi?id=267462)
+- The `getTextUtilities()` method has been moved from the `Label` and `TextFlow` class to the `Figure` class. By
+  default, this method returns a `DrawableFigureCanvas` rather than `TextUtilities.INSTANCE`, which is an object created
+  for the `FigureCanvas`, containing the given figure.
 
 ## GEF
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -914,6 +914,20 @@ public class Figure implements IFigure {
 	@Override
 	public final Dimension getSize() {
 		return getBounds().getSize();
+	}
+
+	/**
+	 * Gets the {@link TextUtilities} instance to be used in measurement
+	 * calculations.
+	 *
+	 * @return a {@link TextUtilities} instance
+	 * @since 3.22
+	 */
+	public TextUtilities getTextUtilities() {
+		if (getParent() instanceof Figure parent) {
+			return parent.getTextUtilities();
+		}
+		return TextUtilities.INSTANCE;
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -672,18 +672,6 @@ public class Label extends Figure implements PositionConstants {
 		textPlacement = where;
 		revalidate();
 		repaint();
-	}
-
-	/**
-	 * Gets the <code>TextUtilities</code> instance to be used in measurement
-	 * calculations.
-	 *
-	 * @return a <code>TextUtilities</code> instance
-	 * @since 3.4
-	 */
-	@SuppressWarnings("static-method")
-	public TextUtilities getTextUtilities() {
-		return TextUtilities.INSTANCE;
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LightweightSystem.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LightweightSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,6 +41,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.pde.api.tools.annotations.NoOverride;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.DrawableTextUtilities;
 
 /**
  * The LightweightSystem is the link between SWT and Draw2d. It is the component
@@ -63,6 +64,7 @@ public class LightweightSystem {
 	private EventDispatcher dispatcher;
 	private UpdateManager manager = new DeferredUpdateManager();
 	private int ignoreResize;
+	private TextUtilities textUtilities;
 
 	/**
 	 * Constructs a LightweightSystem on Canvas <i>c</i>.
@@ -231,6 +233,7 @@ public class LightweightSystem {
 			return;
 		}
 		canvas = c;
+		textUtilities = new DrawableTextUtilities(canvas);
 		if ((c.getStyle() & SWT.DOUBLE_BUFFERED) != 0) {
 			getUpdateManager().setGraphicsSource(new NativeGraphicsSource(canvas));
 		} else {
@@ -327,6 +330,15 @@ public class LightweightSystem {
 				return canvas.getForeground();
 			}
 			return null;
+		}
+
+		/** @see Figure#getTextUtilities() */
+		@Override
+		public TextUtilities getTextUtilities() {
+			if (textUtilities != null) {
+				return textUtilities;
+			}
+			return TextUtilities.INSTANCE;
 		}
 
 		/** @see IFigure#getUpdateManager() */

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableTextUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableTextUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Yatta and others.
+ * Copyright (c) 2025, 2026 Yatta and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,6 +19,7 @@ import org.eclipse.swt.widgets.Control;
 
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.text.FlowUtilities;
 
 /**
  * Provides miscellaneous text operations calculated with the zoom context of
@@ -27,9 +28,11 @@ import org.eclipse.draw2d.geometry.Dimension;
 public class DrawableTextUtilities extends TextUtilities {
 
 	private final DrawableFigureUtilities figureUtilities;
+	private final FlowUtilities flowUtilities;
 
 	public DrawableTextUtilities(Control source) {
 		figureUtilities = new DrawableFigureUtilities(source);
+		flowUtilities = new DrawableFlowUtilities();
 	}
 
 	/**
@@ -78,5 +81,21 @@ public class DrawableTextUtilities extends TextUtilities {
 	@Override
 	public int getDescent(Font font) {
 		return figureUtilities.getFontMetrics(font).getDescent();
+	}
+
+	/**
+	 * Gets the {@link FlowUtilities} using this instance for text calculations.
+	 *
+	 * @return a {@link FlowUtilities} instance
+	 */
+	public FlowUtilities getFlowUtilities() {
+		return flowUtilities;
+	}
+
+	private class DrawableFlowUtilities extends FlowUtilities {
+		@Override
+		protected TextUtilities getTextUtilities() {
+			return DrawableTextUtilities.this;
+		}
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,10 +22,10 @@ import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.DrawableTextUtilities;
 
 /**
  * An inline flow figure that renders a string of text across one or more lines.
@@ -724,21 +724,11 @@ public class TextFlow extends InlineFlow {
 	 * @return a <code>FlowUtilities</code> instance
 	 * @since 3.4
 	 */
-	@SuppressWarnings("static-method")
 	protected FlowUtilities getFlowUtilities() {
+		if (getTextUtilities() instanceof DrawableTextUtilities textUtilities) {
+			return textUtilities.getFlowUtilities();
+		}
 		return FlowUtilities.INSTANCE;
-	}
-
-	/**
-	 * Gets the <code>TextUtilities</code> instance to be used in measurement
-	 * calculations.
-	 *
-	 * @return a <code>TextUtilities</code> instance
-	 * @since 3.4
-	 */
-	@SuppressWarnings("static-method")
-	protected TextUtilities getTextUtilities() {
-		return TextUtilities.INSTANCE;
 	}
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -82,10 +82,8 @@ import org.eclipse.draw2d.LightweightSystem;
 import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.ScalableLightweightSystem;
-import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.Triangle;
 import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.internal.DrawableTextUtilities;
 import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.GraphicalViewer;
@@ -1121,7 +1119,6 @@ public class FlyoutPaletteComposite extends Composite {
 	private class TitleLabel extends Label {
 		protected static final Border BORDER = new MarginBorder(4, 3, 4, 3);
 		protected static final Border TOOL_TIP_BORDER = new MarginBorder(0, 2, 0, 2);
-		private TextUtilities textUtilities;
 
 		public TitleLabel(boolean isHorizontal) {
 			super(GEFMessages.Palette_Label, InternalImages.get(InternalImages.IMG_PALETTE));
@@ -1131,14 +1128,6 @@ public class FlyoutPaletteComposite extends Composite {
 			tooltip.setBorder(TOOL_TIP_BORDER);
 			setToolTip(tooltip);
 			setForegroundColor(ColorConstants.listForeground);
-		}
-
-		@Override
-		public TextUtilities getTextUtilities() {
-			if (textUtilities == null) {
-				textUtilities = new DrawableTextUtilities(paletteContainer);
-			}
-			return textUtilities;
 		}
 
 		@Override


### PR DESCRIPTION
This adds a new getTextUtilities() method to the IFigure interface. The method is overriden by the RootFigure and returns an object of type DrawableTextUtilities, which is created for the canvas hooked to the LWS.

When using this method, users are guaranteed that the font sizes returned calculated by this instance match the zoom level of the monitor they are painted on.