### PR TITLE
Introduce dedicated autoScaleLayer

### DIFF
--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.21.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d;
+
+/**
+ * @since 3.21
+ */
+public class AutoscaleFreeformViewport extends FreeformViewport implements ScalableFigure {
+
+	public AutoscaleFreeformViewport() {
+		super.setContents(new ScalableFreeformLayeredPane(false));
+	}
+
+	private ScalableFreeformLayeredPane getAutoScaleLayerPane() {
+		return (ScalableFreeformLayeredPane) super.getContents();
+	}
+
+	@Override
+	public IFigure getContents() {
+		ScalableFreeformLayeredPane autoScaleLayerPane = getAutoScaleLayerPane();
+		return (!autoScaleLayerPane.getChildren().isEmpty()) ? autoScaleLayerPane.getChildren().get(0) : null;
+	}
+
+	@Override
+	public double getScale() {
+		return getAutoScaleLayerPane().getScale();
+	}
+
+	@Override
+	public void setContents(IFigure figure) {
+		ScalableFreeformLayeredPane autoScaleLayerPane = getAutoScaleLayerPane();
+		if (!autoScaleLayerPane.getChildren().isEmpty()) {
+			IFigure oldContent = autoScaleLayerPane.getChildren().get(0);
+			autoScaleLayerPane.remove(oldContent);
+		}
+		autoScaleLayerPane.add(figure);
+	}
+
+	@Override
+	public void setScale(double scale) {
+		getAutoScaleLayerPane().setScale(scale);
+	}
+
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
@@ -24,10 +24,10 @@ public class FreeformViewport extends Viewport {
 	class FreeformViewportLayout extends ViewportLayout {
 		@Override
 		protected Dimension calculatePreferredSize(IFigure parent, int wHint, int hHint) {
-			getContents().validate();
+			view.validate();
 			wHint = Math.max(0, wHint);
 			hHint = Math.max(0, hHint);
-			return ((FreeformFigure) getContents()).getFreeformExtent().getExpanded(getInsets()).union(0, 0)
+			return ((FreeformFigure) view).getFreeformExtent().getExpanded(getInsets()).union(0, 0)
 					.union(wHint - 1, hHint - 1).getSize();
 		}
 
@@ -66,13 +66,12 @@ public class FreeformViewport extends Viewport {
 	 */
 	@Override
 	protected void readjustScrollBars() {
-		if (getContents() == null) {
+		if (view == null) {
 			return;
 		}
-		if (!(getContents() instanceof FreeformFigure)) {
+		if (!(view instanceof FreeformFigure ff)) {
 			return;
 		}
-		FreeformFigure ff = (FreeformFigure) getContents();
 		Rectangle clientArea = getClientArea();
 		Rectangle bounds = ff.getFreeformExtent().getCopy();
 		bounds.union(0, 0, clientArea.width, clientArea.height);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Viewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Viewport.java
@@ -27,7 +27,10 @@ public class Viewport extends Figure implements PropertyChangeListener {
 
 	/** ID for the view location property */
 	public static final String PROPERTY_VIEW_LOCATION = "viewLocation"; //$NON-NLS-1$
-	private IFigure view;
+	/**
+	 * @since 3.21
+	 */
+	protected IFigure view;
 
 	private boolean useTranslate = false;
 	private boolean trackWidth = false;
@@ -206,11 +209,11 @@ public class Viewport extends Figure implements PropertyChangeListener {
 	 * @since 2.0
 	 */
 	protected void readjustScrollBars() {
-		if (getContents() == null) {
+		if (view == null) {
 			return;
 		}
-		getVerticalRangeModel().setAll(0, getClientArea().height, getContents().getBounds().height);
-		getHorizontalRangeModel().setAll(0, getClientArea().width, getContents().getBounds().width);
+		getVerticalRangeModel().setAll(0, getClientArea().height, view.getBounds().height);
+		getHorizontalRangeModel().setAll(0, getClientArea().width, view.getBounds().width);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
@@ -14,13 +14,13 @@ package org.eclipse.gef.editparts;
 
 import java.beans.PropertyChangeListener;
 
+import org.eclipse.draw2d.AutoscaleFreeformViewport;
 import org.eclipse.draw2d.ConnectionLayer;
 import org.eclipse.draw2d.FreeformLayer;
 import org.eclipse.draw2d.FreeformLayeredPane;
 import org.eclipse.draw2d.FreeformViewport;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.LayeredPane;
-import org.eclipse.draw2d.ScalableFreeformLayeredPane;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 
@@ -88,7 +88,7 @@ import org.eclipse.gef.tools.MarqueeDragTracker;
  */
 public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements LayerConstants, LayerManager {
 
-	private ScalableFreeformLayeredPane innerLayers;
+	private LayeredPane innerLayers;
 	private LayeredPane printableLayers;
 	private final PropertyChangeListener gridListener = evt -> {
 		String property = evt.getPropertyName();
@@ -104,8 +104,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	@Override
 	protected IFigure createFigure() {
 		FreeformViewport viewport = createViewport();
-		innerLayers = new ScalableFreeformLayeredPane();
-		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerLayers));
+		innerLayers = new FreeformLayeredPane();
 		createLayers(innerLayers);
 		viewport.setContents(innerLayers);
 		return viewport;
@@ -158,9 +157,10 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	 *
 	 * @since 3.24
 	 */
-	@SuppressWarnings("static-method") // allow subclasses to override
 	protected FreeformViewport createViewport() {
-		return new FreeformViewport();
+		AutoscaleFreeformViewport viewPort = new AutoscaleFreeformViewport();
+		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(viewPort));
+		return viewPort;
 	}
 
 	/**


### PR DESCRIPTION
If clients want to wrap the inner layers in other figures the fixed autoscaleeditpart listener is to limiting.

For example in 4diac IDE we are adding two more figures arround the inner layers so that we get an incremental expanding canvas similar to DrawIO. As the property listener is hard wired to the inner layer when moving 4diac IDE windows to different screens the wrong figure was scale adjusted. And as such broke our drawings. Here an example:

<img width="2926" height="1875" alt="image" src="https://github.com/user-attachments/assets/6044a4ea-dd28-48c8-8e71-62b3eeff688f" />

As you can see there are lines going outside the drawing area where normally elements are at the border.

With this PR I added a dedicated layer for just handling the autoscale. This would allow me to hook my two additional figures between the autoscale and the inner layer. 

@akoch-yatta  will this break the design? Does this have other issues?




