### PR TITLE
Combine ScalableRootFigure and ScalableLayeredPane #818

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IScalablePane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IScalablePane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Johannes Kepler University Linz and others.
+ * Copyright (c) 2022, 2025 Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,15 @@
 
 package org.eclipse.draw2d;
 
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.eclipse.swt.SWT;
+
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.geometry.Translatable;
 
 /**
  * Interface for scaleable panes which provides the default functionality for
@@ -36,7 +44,7 @@ public interface IScalablePane extends ScalableFigure {
 
 	public static final class IScalablePaneHelper {
 
-		static Graphics prepareScaledGraphics(final Graphics graphics, IScalablePane figurePane) {
+		private static Graphics prepareScaledGraphics(final Graphics graphics, IScalablePane figurePane) {
 			Graphics graphicsToUse = (figurePane.useScaledGraphics()) ? new ScaledGraphics(graphics) : graphics;
 			if (!figurePane.optimizeClip()) {
 				graphicsToUse.clipRect(figurePane.getBounds().getShrinked(figurePane.getInsets()));
@@ -46,13 +54,63 @@ public interface IScalablePane extends ScalableFigure {
 			return graphicsToUse;
 		}
 
-		static void cleanupScaledGraphics(final Graphics graphics, final Graphics graphicsUsed) {
+		private static void cleanupScaledGraphics(final Graphics graphics, final Graphics graphicsUsed) {
 			graphicsUsed.popState();
 
 			if (graphicsUsed != graphics) {
 				graphicsUsed.dispose();
 			}
 			graphics.restoreState();
+		}
+
+		static Rectangle getClientArea(IScalablePane figurePane, Function<Rectangle, Rectangle> superMethod,
+				Rectangle rect) {
+			return figurePane.getScaledRect(superMethod.apply(rect));
+		}
+
+		static Dimension getMinimumSize(IScalablePane figurePane, BiFunction<Integer, Integer, Dimension> superMethod,
+				int wHint, int hHint) {
+			Dimension d = superMethod.apply(getScaledHint(figurePane, wHint), getScaledHint(figurePane, hHint));
+			int w = figurePane.getInsets().getWidth();
+			int h = figurePane.getInsets().getHeight();
+			return d.getExpanded(-w, -h).scale(figurePane.getScale()).expand(w, h);
+		}
+
+		static Dimension getPreferredSize(IScalablePane figurePane, BiFunction<Integer, Integer, Dimension> superMethod,
+				int wHint, int hHint) {
+			Dimension d = superMethod.apply(getScaledHint(figurePane, wHint), getScaledHint(figurePane, hHint));
+			int w = figurePane.getInsets().getWidth();
+			int h = figurePane.getInsets().getHeight();
+			return d.getExpanded(-w, -h).scale(figurePane.getScale()).expand(w, h);
+		}
+
+		private static int getScaledHint(IScalablePane figurePane, int hint) {
+			return hint != SWT.DEFAULT ? (int) (hint / figurePane.getScale()) : SWT.DEFAULT;
+		}
+
+		static void paintClientArea(IScalablePane figurePane, Consumer<Graphics> superMethod, Graphics graphics) {
+			if (figurePane.getChildren().isEmpty()) {
+				return;
+			}
+
+			if (figurePane.getScale() == 1.0) {
+				superMethod.accept(graphics);
+			} else {
+				Graphics graphicsToUse = prepareScaledGraphics(graphics, figurePane);
+				// Even though paintChildren() is defined in the Figure class, this cast is
+				// still safe because this method is package-private and only called from
+				// IFigures extending Figure.
+				((Figure) figurePane).paintChildren(graphicsToUse);
+				cleanupScaledGraphics(graphics, graphicsToUse);
+			}
+		}
+
+		static void translateToParent(IScalablePane figurePane, Translatable t) {
+			t.performScale(figurePane.getScale());
+		}
+
+		static void translateFromParent(IScalablePane figurePane, Translatable t) {
+			t.performScale(1 / figurePane.getScale());
 		}
 
 		private IScalablePaneHelper() {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PopUpHelper.java
@@ -12,12 +12,9 @@
  *******************************************************************************/
 package org.eclipse.draw2d;
 
-import java.util.List;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
@@ -76,8 +73,9 @@ public abstract class PopUpHelper {
 	 * @return the newly created LightweightSystem
 	 * @since 2.0
 	 */
+	@SuppressWarnings("static-method")
 	protected LightweightSystem createLightweightSystem() {
-		return InternalDraw2dUtils.isAutoScaleEnabled() ? new PopupHelperLightweightSystem() : new LightweightSystem();
+		return InternalDraw2dUtils.isAutoScaleEnabled() ? new ScalableLightweightSystem() : new LightweightSystem();
 	}
 
 	/**
@@ -220,73 +218,5 @@ public abstract class PopUpHelper {
 	protected void show() {
 		getShell().setVisible(true);
 		tipShowing = true;
-	}
-
-	private class PopupHelperLightweightSystem extends LightweightSystem {
-
-		@Override
-		public void setControl(Canvas c) {
-			if (c == null) {
-				return;
-			}
-
-			InternalDraw2dUtils.configureForAutoscalingMode(c, getRootFigure()::setScale);
-
-			super.setControl(c);
-		}
-
-		@Override
-		protected RootFigure createRootFigure() {
-			RootFigure f = new ScalableRootFigure();
-			f.addNotify();
-			f.setOpaque(true);
-			f.setLayoutManager(new StackLayout());
-			return f;
-		}
-
-		@Override
-		public ScalableFigure getRootFigure() {
-			return (ScalableFigure) super.getRootFigure();
-		}
-
-		private class ScalableRootFigure extends RootFigure implements ScalableFigure {
-			/**
-			 * The scalable pane that is injected between the root figure and the contents
-			 * of this viewport.
-			 */
-			private final ScalableLayeredPane scalablePane;
-
-			private ScalableRootFigure() {
-				scalablePane = new ScalableLayeredPane(true);
-				scalablePane.setLayoutManager(new StackLayout());
-				super.add(scalablePane, null, 0);
-			}
-
-			@Override
-			public void add(IFigure figure, Object constraint, int index) {
-				scalablePane.add(figure, constraint, index);
-			}
-
-			@Override
-			public List<? extends IFigure> getChildren() {
-				return scalablePane.getChildren();
-			}
-
-			@Override
-			public double getScale() {
-				return scalablePane.getScale();
-			}
-
-			@Override
-			public void setScale(double scale) {
-				scalablePane.setScale(scale);
-			}
-
-			@Override
-			public void remove(IFigure figure) {
-				scalablePane.remove(figure);
-			}
-
-		}
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,7 +41,7 @@ public class ScalableFreeformLayeredPane extends FreeformLayeredPane implements 
 	/** @see org.eclipse.draw2d.Figure#getClientArea() */
 	@Override
 	public Rectangle getClientArea(Rectangle rect) {
-		return getScaledRect(super.getClientArea(rect));
+		return IScalablePaneHelper.getClientArea(this, super::getClientArea, rect);
 	}
 
 	/**
@@ -65,17 +65,7 @@ public class ScalableFreeformLayeredPane extends FreeformLayeredPane implements 
 	/** @see org.eclipse.draw2d.Figure#paintClientArea(Graphics) */
 	@Override
 	protected void paintClientArea(final Graphics graphics) {
-		if (getChildren().isEmpty()) {
-			return;
-		}
-
-		if (scale == 1.0) {
-			super.paintClientArea(graphics);
-		} else {
-			Graphics graphicsToUse = IScalablePaneHelper.prepareScaledGraphics(graphics, this);
-			paintChildren(graphicsToUse);
-			IScalablePaneHelper.cleanupScaledGraphics(graphics, graphicsToUse);
-		}
+		IScalablePaneHelper.paintClientArea(this, super::paintClientArea, graphics);
 	}
 
 	/**
@@ -115,13 +105,13 @@ public class ScalableFreeformLayeredPane extends FreeformLayeredPane implements 
 	/** @see org.eclipse.draw2d.Figure#translateToParent(Translatable) */
 	@Override
 	public void translateToParent(Translatable t) {
-		t.performScale(getScale());
+		IScalablePaneHelper.translateToParent(this, t);
 	}
 
 	/** @see org.eclipse.draw2d.Figure#translateFromParent(Translatable) */
 	@Override
 	public void translateFromParent(Translatable t) {
-		t.performScale(1 / getScale());
+		IScalablePaneHelper.translateFromParent(this, t);
 	}
 
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,8 +11,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d;
-
-import org.eclipse.swt.SWT;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -46,27 +44,19 @@ public class ScalableLayeredPane extends LayeredPane implements IScalablePane {
 	/** @see IFigure#getClientArea(Rectangle) */
 	@Override
 	public Rectangle getClientArea(Rectangle rect) {
-		return getScaledRect(super.getClientArea(rect));
+		return IScalablePaneHelper.getClientArea(this, super::getClientArea, rect);
 	}
 
 	/** @see Figure#getMinimumSize(int, int) */
 	@Override
 	public Dimension getMinimumSize(int wHint, int hHint) {
-		Dimension d = super.getMinimumSize(wHint != SWT.DEFAULT ? (int) (wHint / getScale()) : SWT.DEFAULT,
-				hHint != SWT.DEFAULT ? (int) (hHint / getScale()) : SWT.DEFAULT);
-		int w = getInsets().getWidth();
-		int h = getInsets().getHeight();
-		return d.getExpanded(-w, -h).scale(scale).expand(w, h);
+		return IScalablePaneHelper.getMinimumSize(this, super::getMinimumSize, wHint, hHint);
 	}
 
 	/** @see Figure#getPreferredSize(int, int) */
 	@Override
 	public Dimension getPreferredSize(int wHint, int hHint) {
-		Dimension d = super.getPreferredSize(wHint != SWT.DEFAULT ? (int) (wHint / getScale()) : SWT.DEFAULT,
-				hHint != SWT.DEFAULT ? (int) (hHint / getScale()) : SWT.DEFAULT);
-		int w = getInsets().getWidth();
-		int h = getInsets().getHeight();
-		return d.getExpanded(-w, -h).scale(scale).expand(w, h);
+		return IScalablePaneHelper.getPreferredSize(this, super::getPreferredSize, wHint, hHint);
 	}
 
 	/**
@@ -82,17 +72,7 @@ public class ScalableLayeredPane extends LayeredPane implements IScalablePane {
 	/** @see org.eclipse.draw2d.Figure#paintClientArea(Graphics) */
 	@Override
 	protected void paintClientArea(Graphics graphics) {
-		if (getChildren().isEmpty()) {
-			return;
-		}
-
-		if (scale == 1.0) {
-			super.paintClientArea(graphics);
-		} else {
-			Graphics graphicsToUse = IScalablePaneHelper.prepareScaledGraphics(graphics, this);
-			paintChildren(graphicsToUse);
-			IScalablePaneHelper.cleanupScaledGraphics(graphics, graphicsToUse);
-		}
+		IScalablePane.IScalablePaneHelper.paintClientArea(this, super::paintClientArea, graphics);
 	}
 
 	/**
@@ -132,13 +112,13 @@ public class ScalableLayeredPane extends LayeredPane implements IScalablePane {
 	/** @see org.eclipse.draw2d.Figure#translateToParent(Translatable) */
 	@Override
 	public void translateToParent(Translatable t) {
-		t.performScale(getScale());
+		IScalablePaneHelper.translateToParent(this, t);
 	}
 
 	/** @see org.eclipse.draw2d.Figure#translateFromParent(Translatable) */
 	@Override
 	public void translateFromParent(Translatable t) {
-		t.performScale(1 / getScale());
+		IScalablePaneHelper.translateFromParent(this, t);
 	}
 
 	/** @see org.eclipse.draw2d.IFigure#isCoordinateSystem() */

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d;
+
+import org.eclipse.swt.widgets.Canvas;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
+
+/**
+ * Custom lightweight-system that is used in combination with the
+ * {@code draw2d.enableAutoscale} environment variable. The root figure of this
+ * class implements the {@link IScalablePane} interface and is automatically
+ * scaled to match the monitor zoom.<br>
+ * <b>Important:</b> This class is only public so that it can be referencd in
+ * the other GEF plugins. This class must <b>not</b> be used together with a
+ * {@link Viewport}. Otherwise the scrollbar and content are always rendered as
+ * if at 100% zoom (at least on Windows}.
+ *
+ * @noreference This class is not intended to be referenced by clients.
+ */
+public class ScalableLightweightSystem extends LightweightSystem {
+
+	@Override
+	public void setControl(Canvas c) {
+		if (c == null) {
+			return;
+		}
+		InternalDraw2dUtils.configureForAutoscalingMode(c, getRootFigure()::setScale);
+		super.setControl(c);
+	}
+
+	@Override
+	protected ScalableRootFigure createRootFigure() {
+		ScalableRootFigure f = new ScalableRootFigure();
+		f.addNotify();
+		f.setOpaque(true);
+		f.setLayoutManager(new StackLayout());
+		return f;
+	}
+
+	@Override
+	public ScalableFigure getRootFigure() {
+		return (ScalableFigure) super.getRootFigure();
+	}
+
+	private class ScalableRootFigure extends RootFigure implements IScalablePane {
+		private double scale = 1.0;
+
+		@Override
+		public void setScale(double scale) {
+			if (this.scale == scale) {
+				return;
+			}
+			this.scale = scale;
+			fireFigureMoved();
+			fireCoordinateSystemChanged();
+			revalidate();
+			repaint();
+		}
+
+		@Override
+		public double getScale() {
+			return scale;
+		}
+
+		@Override
+		public boolean useScaledGraphics() {
+			return true;
+		}
+
+		@Override
+		public boolean optimizeClip() {
+			return super.optimizeClip();
+		}
+
+		@Override
+		public Rectangle getClientArea(Rectangle rect) {
+			return IScalablePaneHelper.getClientArea(this, super::getClientArea, rect);
+		}
+
+		@Override
+		public Dimension getMinimumSize(int wHint, int hHint) {
+			return IScalablePaneHelper.getMinimumSize(this, super::getMinimumSize, wHint, hHint);
+		}
+
+		@Override
+		public Dimension getPreferredSize(int wHint, int hHint) {
+			return IScalablePaneHelper.getPreferredSize(this, super::getPreferredSize, wHint, hHint);
+		}
+
+		@Override
+		protected void paintClientArea(Graphics graphics) {
+			IScalablePaneHelper.paintClientArea(this, super::paintClientArea, graphics);
+		}
+
+		@Override
+		public void translateToParent(Translatable t) {
+			IScalablePaneHelper.translateToParent(this, t);
+		}
+
+		@Override
+		public void translateFromParent(Translatable t) {
+			IScalablePaneHelper.translateFromParent(this, t);
+		}
+	}
+}


### PR DESCRIPTION
For the PopUpHelper, a custom LWS is created when auto-scaling is enabled, which injects a ScalableLayeredPane between the root figure and its contents. The problem here is that this pane is invisible to the layout manager and therefore the figure, and all its children, have an empty size.

Rather than copy-pasting the same logic that is used in both the ScalableFreeformLayeredPane and the ScalableLayered pane, the code is instead moved to the IScalablePaneHelper. The subclasses still have to override the relevant methods, but at least the implementation is now centralized.

Closes https://github.com/eclipse-gef/gef-classic/issues/818