### PR TITLE
PoC - Introduce dedicated autoScale layer

### DIFF
--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.21.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Johannes Kepler University Linz and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alois Zoitl - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d;
+
+/**
+ * <b>IMPORTANT:</b> This class is <em>not</em> part of the GEF public API. It
+ * is marked public only so that it can be by other GEF plugins and should never
+ * be accessed from application code.
+ *
+ * @noreference This class is not intended to be referenced by clients.
+ */
+public class AutoscaleFreeformViewport extends FreeformViewport implements ScalableFigure {
+
+	public AutoscaleFreeformViewport(boolean useScaledGraphics) {
+		super.setContents(new ScalableFreeformLayeredPane(useScaledGraphics));
+	}
+
+	private ScalableFreeformLayeredPane getAutoScaleLayerPane() {
+		return (ScalableFreeformLayeredPane) super.getContents();
+	}
+
+	@Override
+	public IFigure getContents() {
+		ScalableFreeformLayeredPane autoScaleLayerPane = getAutoScaleLayerPane();
+		return (!autoScaleLayerPane.getChildren().isEmpty()) ? autoScaleLayerPane.getChildren().get(0) : null;
+	}
+
+	@Override
+	public double getScale() {
+		return getAutoScaleLayerPane().getScale();
+	}
+
+	@Override
+	public void setContents(IFigure figure) {
+		ScalableFreeformLayeredPane autoScaleLayerPane = getAutoScaleLayerPane();
+		if (!autoScaleLayerPane.getChildren().isEmpty()) {
+			IFigure oldContent = autoScaleLayerPane.getChildren().get(0);
+			autoScaleLayerPane.remove(oldContent);
+		}
+		autoScaleLayerPane.add(figure);
+	}
+
+	@Override
+	public void setScale(double scale) {
+		getAutoScaleLayerPane().setScale(scale);
+	}
+
+	@Override
+	protected FreeformFigure getFreeformFigure() {
+		return getAutoScaleLayerPane();
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FreeformViewport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,10 +24,10 @@ public class FreeformViewport extends Viewport {
 	class FreeformViewportLayout extends ViewportLayout {
 		@Override
 		protected Dimension calculatePreferredSize(IFigure parent, int wHint, int hHint) {
-			getContents().validate();
+			getFreeformFigure().validate();
 			wHint = Math.max(0, wHint);
 			hHint = Math.max(0, hHint);
-			return ((FreeformFigure) getContents()).getFreeformExtent().getExpanded(getInsets()).union(0, 0)
+			return getFreeformFigure().getFreeformExtent().getExpanded(getInsets()).union(0, 0)
 					.union(wHint - 1, hHint - 1).getSize();
 		}
 
@@ -66,13 +66,10 @@ public class FreeformViewport extends Viewport {
 	 */
 	@Override
 	protected void readjustScrollBars() {
-		if (getContents() == null) {
+		FreeformFigure ff = getFreeformFigure();
+		if (ff == null) {
 			return;
 		}
-		if (!(getContents() instanceof FreeformFigure)) {
-			return;
-		}
-		FreeformFigure ff = (FreeformFigure) getContents();
 		Rectangle clientArea = getClientArea();
 		Rectangle bounds = ff.getFreeformExtent().getCopy();
 		bounds.union(0, 0, clientArea.width, clientArea.height);
@@ -92,4 +89,16 @@ public class FreeformViewport extends Viewport {
 		return true;
 	}
 
+	/**
+	 * Returns the {@link FreeformFigure} that is the contents of this viewport or
+	 * {@code null}, if the contents is not set or not a {@link FreeformFigure}.
+	 *
+	 * @since 3.21
+	 */
+	protected FreeformFigure getFreeformFigure() {
+		if (getContents() instanceof FreeformFigure ff) {
+			return ff;
+		}
+		return null;
+	}
 }

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.gef" version="2">
+    <resource path="src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java" type="org.eclipse.gef.editparts.FreeformGraphicalRootEditPart">
+        <filter id="640708718">
+            <message_arguments>
+                <message_argument value="AutoscaleFreeformViewport(boolean)"/>
+                <message_argument value="FreeformGraphicalRootEditPart"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java" type="org.eclipse.gef.editparts.ScalableFreeformRootEditPart">
+        <filter id="640708718">
+            <message_arguments>
+                <message_argument value="AutoscaleFreeformViewport(boolean)"/>
+                <message_argument value="ScalableFreeformRootEditPart"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/gef/ui/actions/AlignmentRetargetAction.java" type="org.eclipse.gef.ui.actions.AlignmentRetargetAction">
         <filter id="571473929">
             <message_arguments>

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
@@ -14,13 +14,13 @@ package org.eclipse.gef.editparts;
 
 import java.beans.PropertyChangeListener;
 
+import org.eclipse.draw2d.AutoscaleFreeformViewport;
 import org.eclipse.draw2d.ConnectionLayer;
 import org.eclipse.draw2d.FreeformLayer;
 import org.eclipse.draw2d.FreeformLayeredPane;
 import org.eclipse.draw2d.FreeformViewport;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.LayeredPane;
-import org.eclipse.draw2d.ScalableFreeformLayeredPane;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.internal.InternalDraw2dUtils;
@@ -105,13 +105,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	@Override
 	protected IFigure createFigure() {
 		FreeformViewport viewport = createViewport();
-		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
-			ScalableFreeformLayeredPane innerScalableLayers = new ScalableFreeformLayeredPane();
-			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerScalableLayers));
-			innerLayers = innerScalableLayers;
-		} else {
-			innerLayers = new FreeformLayeredPane();
-		}
+		innerLayers = new FreeformLayeredPane();
 		createLayers(innerLayers);
 		viewport.setContents(innerLayers);
 		return viewport;
@@ -164,8 +158,12 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	 *
 	 * @since 3.24
 	 */
-	@SuppressWarnings("static-method") // allow subclasses to override
 	protected FreeformViewport createViewport() {
+		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
+			AutoscaleFreeformViewport viewport = new AutoscaleFreeformViewport(false);
+			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(viewport));
+			return viewport;
+		}
 		return new FreeformViewport();
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java
@@ -12,12 +12,17 @@
  *******************************************************************************/
 package org.eclipse.gef.editparts;
 
+import org.eclipse.draw2d.AutoscaleFreeformViewport;
 import org.eclipse.draw2d.FreeformLayer;
+import org.eclipse.draw2d.FreeformViewport;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.LayeredPane;
 import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.ScalableFreeformLayeredPane;
 import org.eclipse.draw2d.Viewport;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
+
+import org.eclipse.gef.internal.InternalGEFPlugin;
 
 /**
  * Adds Zoom support to the standard FreeformGraphicalRootEditPart. This root is
@@ -141,6 +146,16 @@ public class ScalableFreeformRootEditPart extends FreeformGraphicalRootEditPart 
 		layers.add(getPrintableLayers(), PRINTABLE_LAYERS);
 		layers.add(new FeedbackLayer(), SCALED_FEEDBACK_LAYER);
 		return layers;
+	}
+
+	@Override
+	protected FreeformViewport createViewport() {
+		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
+			AutoscaleFreeformViewport viewPort = new AutoscaleFreeformViewport(useScaledGraphics);
+			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(viewPort));
+			return viewPort;
+		}
+		return super.createViewport();
 	}
 
 	/**


### PR DESCRIPTION
This builds upon the new AutoScaleFreeformViewport added with
bbac50002c390ceca3e8da7b8ce8aea390f78f49 by perform the following
changes:

- The AutoscaleFreeformViewport is marked with @noreference
- The "view" field in the Viewport class is changed back to private.
  Instead, the FreeformFigure can be accessed via a getFreeformFigure()
  method.
- The AutoscaleFreeformViewport is only created when
  Draw2D-based auto-scaling is enabled.