### PR TITLE
Move configuration of auto-scaling mode to GraphicalViewerImpl

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -46,7 +46,6 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
-import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.EditDomain;
@@ -56,7 +55,6 @@ import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.KeyHandler;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.gef.SelectionManager;
-import org.eclipse.gef.internal.InternalGEFPlugin;
 
 /**
  * The base implementation for EditPartViewer.
@@ -485,10 +483,6 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 		refreshDropTargetAdapter();
 		if (contextMenu != null) {
 			control.setMenu(contextMenu.createContextMenu(getControl()));
-		}
-		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
-			InternalDraw2dUtils.configureForAutoscalingMode(control,
-					scale -> setProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY, scale));
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,6 +38,7 @@ import org.eclipse.draw2d.ExclusionSearch;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.LightweightSystem;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.EditDomain;
@@ -53,6 +54,7 @@ import org.eclipse.gef.MouseWheelHelper;
 import org.eclipse.gef.RootEditPart;
 import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.gef.editparts.ScalableRootEditPart;
+import org.eclipse.gef.internal.InternalGEFPlugin;
 
 /**
  * An EditPartViewer implementation based on {@link org.eclipse.draw2d.IFigure
@@ -291,6 +293,10 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 				handleFocusLost(e);
 			}
 		});
+		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
+			InternalDraw2dUtils.configureForAutoscalingMode(getControl(),
+					scale -> setProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY, scale));
+		}
 	}
 
 	/**


### PR DESCRIPTION
The SWT-based auto-scaling must only be disabled for viewers that are based on IFigure's and can't therefore be done in the AbstractEditPartViewer.

Otherwise the Outline view, which is populated with a TreeViewer, is always drawn at 100% zoom, as there is no ScalableFigure to scale its content to the monitor zoom.

Regression from 1bd28834343bce2bf73cbf66d9cb2accc54382f0