### PR TITLE
Harden scaling algorithm in Rectangle #829

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2010 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@
 package org.eclipse.draw2d.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.draw2d.geometry.Insets;
@@ -104,4 +105,16 @@ public class PrecisionRectangleTest {
 		assertTrue(r.contains(-9.486614173228347 + 41.99055118110235, -34.431496062992125 + 25.92755905511810));
 	}
 	// contains
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testScale() {
+		// check work scale(double) with rounding errors
+		PrecisionRectangle r = new PrecisionRectangle(10, 10, 52, 52);
+		assertSame(r, r.scale(1.75));
+		assertEquals(17.5, r.preciseX(), 0);
+		assertEquals(17.5, r.preciseY(), 0);
+		assertEquals(91, r.preciseWidth(), 0);
+		assertEquals(91, r.preciseHeight(), 0);
+	}
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/RectangleTest.java
@@ -468,6 +468,11 @@ public class RectangleTest extends BaseTestCase {
 		template = new Rectangle(10, 10, 20, 20);
 		assertSame(template, template.scale(0.5, 0.5));
 		assertEquals(5, 5, 10, 10, template);
+
+		// check work scale(double) with rounding errors
+		template = new Rectangle(10, 10, 52, 52);
+		assertSame(template, template.scale(1.75));
+		assertEquals(17, 17, 92, 92, template);
 	}
 
 	@SuppressWarnings("static-method")

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2024 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -433,6 +433,18 @@ public final class PrecisionRectangle extends Rectangle {
 	private PrecisionRectangle resizePrecise(double w, double h) {
 		setPreciseWidth(preciseWidth() + w);
 		setPreciseHeight(preciseHeight() + h);
+		return this;
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.Rectangle#scale(double, double)
+	 */
+	@Override
+	public Rectangle scale(double scaleX, double scaleY) {
+		setPreciseX(preciseX() * scaleX);
+		setPreciseY(preciseY() * scaleY);
+		setPreciseWidth(preciseWidth() * scaleX);
+		setPreciseHeight(preciseHeight() * scaleY);
 		return this;
 	}
 


### PR DESCRIPTION
This change avoids the rounding errors that were introduced with 5f3da64668ae1fe9f977fc95a9874f16ffd0fe04. By combining a rounded-down value with a rounded-up value, the resulting width and height might be one point larger than it should be, leading to off-by-one errors.