### PR TITLE
Dispose GC in FigureUtilities if Shell is destroyed #831

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -14,6 +14,7 @@ package org.eclipse.draw2d;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
@@ -82,8 +83,14 @@ public class FigureUtilities {
 	}
 
 	private static Shell getShell() {
-		if (shell == null) {
+		if (shell == null || shell.isDisposed()) {
 			shell = new Shell();
+			shell.addDisposeListener(event -> {
+				if (gc != null) {
+					gc.dispose();
+					gc = null;
+				}
+			});
 			InternalDraw2dUtils.configureForAutoscalingMode(shell, event -> {
 				// ignored
 			});
@@ -348,7 +355,7 @@ public class FigureUtilities {
 	 * @since 2.0
 	 */
 	protected static void setFont(Font f) {
-		if ((appliedFont == null && f == null && gc != null) || (f != null && f.equals(appliedFont))) {
+		if (gc != null && !gc.isDisposed() && Objects.equals(appliedFont, f)) {
 			return;
 		}
 		if (gc != null && !gc.isDisposed()) {


### PR DESCRIPTION
If the invisible Shell created by the FigureUtilities class is disposed, any successive calls to GC.dispose() fail with a "Widget is disposed" exception.

To avoid this, the checks in getShell() and setFonts() are hardened to make sure that the previously created Shell/GC instances are still valid.

For the Shell, dispose listener is added that explicitly invalidates any previously created GC object.

Closes https://github.com/eclipse-gef/gef-classic/issues/831