### PR TITLE
Enable advanced mode for FigureUtilities GC

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LabelTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/LabelTest.java
@@ -147,6 +147,7 @@ public class LabelTest extends BaseTestCase {
 	private static final void assertTextSize(Label label) throws Exception {
 		// create calc GC
 		GC gc = new GC(Display.getDefault());
+		gc.setAdvanced(true);
 		// set label font
 		gc.setFont(label.getFont());
 		// calc text size

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
@@ -219,7 +219,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 		doTest2("foo4 ", " bar4", "foo4 ", new String[] { "foo4 ", "", "bar4", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
 		doTest2("wwww ", " bar", "wwww", new String[] { "wwww", "", " bar", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
 		doTest2("foo5 ", "bar5", "foo5 ", new String[] { "foo5", NEWLINE, "", "bar5", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
-		doTest2("foot bar", "xyz", "barxyz", new String[] { "foot", "bar", SAMELINE, "xyz", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+		doTest2("foot bar", "xyz", "booxyz", new String[] { "foot", "bar", SAMELINE, "xyz", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
 		doTest2("foo\n", " bar6", null, new String[] { "foo", NEWLINE, "", SAMELINE, " bar6", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 		// doTest2("foo7-bar7", "mo", "foo7-ba", new String[] {"foo7-", NEWLINE,
 		// "bar7", SAMELINE, "mo", TERMINATE});
@@ -260,8 +260,8 @@ public class TextFlowWrapTest extends BaseTestCase {
 	}
 
 	protected void runTruncatedWrappingTests() {
-		doTest("Flowing  Container", "Flo...", new String[] { "Flo", NEWLINE, "Co", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		doTest("Flowing C", "Flo...", new String[] { "Flo", "C", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		doTest("Flowing  Container", "Flo ...", new String[] { "Flo", NEWLINE, "Co", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+		doTest("Flowing C", "Flo ...", new String[] { "Flo", "C", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		doTest("Fooooooo", "...", new String[] { "", TRUNCATED, TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		doTest("WWW", "|...", new String[] { "", TRUNCATED, TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		doTest(" Foo", "Foo", new String[] { "", "Foo", TERMINATE }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -77,6 +77,7 @@ public class FigureUtilities {
 	protected static GC getGC() {
 		if (gc == null) {
 			gc = new GC(getShell());
+			gc.setAdvanced(true);
 			appliedFont = gc.getFont();
 		}
 		return gc;
@@ -362,6 +363,7 @@ public class FigureUtilities {
 			gc.dispose();
 		}
 		gc = new GC(getShell());
+		gc.setAdvanced(true);
 		gc.setFont(f);
 		appliedFont = f;
 		metrics = null;


### PR DESCRIPTION
The GC used in FigureUtilities for text extent calculation does currently not have advanced mode enabled. In most usage scenarios, however, the context that uses the extents to render text will have a GC with advanced mode enabled, as many GC operations such as applying transforms and several draw operations implicitly activate it. As a result, the extents calculated by the FigureUtilities will, in most cases, not return appropriate results.

This change adapts the FigureUtilities to always use a GC in advanced mode for extent calculation. It adapts few tests to conform to the different widths returned for some of the used strings.

Fixes https://github.com/eclipse-gef/gef-classic/issues/809