### PR TITLE
Revert GC recreation in FigureUtilities

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -33,7 +33,6 @@ public class FigureUtilities {
 
 	private static final float RGB_VALUE_MULTIPLIER = 0.6f;
 	private static GC gc;
-	private static Shell shell;
 	private static Font appliedFont;
 	private static FontMetrics metrics;
 	private static Color ghostFillColor = new Color(null, 31, 31, 31);
@@ -61,7 +60,7 @@ public class FigureUtilities {
 	public static FontMetrics getFontMetrics(Font f) {
 		setFont(f);
 		if (metrics == null) {
-			metrics = gc.getFontMetrics();
+			metrics = getGC().getFontMetrics();
 		}
 		return metrics;
 	}
@@ -76,27 +75,15 @@ public class FigureUtilities {
 	@Deprecated
 	protected static GC getGC() {
 		if (gc == null) {
-			gc = new GC(getShell());
+			Shell shell = new Shell();
+			InternalDraw2dUtils.configureForAutoscalingMode(shell, event -> {
+				// ignored
+			});
+			gc = new GC(shell);
 			gc.setAdvanced(true);
 			appliedFont = gc.getFont();
 		}
 		return gc;
-	}
-
-	private static Shell getShell() {
-		if (shell == null || shell.isDisposed()) {
-			shell = new Shell();
-			shell.addDisposeListener(event -> {
-				if (gc != null) {
-					gc.dispose();
-					gc = null;
-				}
-			});
-			InternalDraw2dUtils.configureForAutoscalingMode(shell, event -> {
-				// ignored
-			});
-		}
-		return shell;
 	}
 
 	/**
@@ -110,7 +97,7 @@ public class FigureUtilities {
 	 */
 	protected static org.eclipse.swt.graphics.Point getTextDimension(String s, Font f) {
 		setFont(f);
-		return gc.textExtent(s);
+		return getGC().textExtent(s);
 	}
 
 	/**
@@ -138,7 +125,7 @@ public class FigureUtilities {
 	 */
 	protected static org.eclipse.swt.graphics.Point getStringDimension(String s, Font f) {
 		setFont(f);
-		return gc.stringExtent(s);
+		return getGC().stringExtent(s);
 	}
 
 	/**
@@ -356,15 +343,10 @@ public class FigureUtilities {
 	 * @since 2.0
 	 */
 	protected static void setFont(Font f) {
-		if (gc != null && !gc.isDisposed() && Objects.equals(appliedFont, f)) {
+		if (Objects.equals(appliedFont, f)) {
 			return;
 		}
-		if (gc != null && !gc.isDisposed()) {
-			gc.dispose();
-		}
-		gc = new GC(getShell());
-		gc.setAdvanced(true);
-		gc.setFont(f);
+		getGC().setFont(f);
 		appliedFont = f;
 		metrics = null;
 	}


### PR DESCRIPTION
With commit efc73d2d6c2c076ad38190de2b8c0908a0537d18, GC disposals and recreations were introduced in FigureUtilities. They used to fix a memory leak caused by a long-living GC, as the operations executed on such a GC were permanently stored in the GC instance (on Windows). That change introduced two issues:
- In case a subclass of FigureUtilities performs further modifications to the used GC, those modifications will be lost upon next call of FigureUtilities#setFont(). This may be considered a breaking API change. While creating such subclasses may be questionable, it's also the only reason for keeping a static GC at all instead of using auto-disposed GCs for the duration of the individual method calls.
- Resource leak tests became more difficult, as every test for a diagram will usually leave behind a new GC (handle), precisely the last GC created by the FigureUtilities upon setting a font during diagram usage. That GC is detected as a leak and must somehow be excluded from leak detected, such as using Sleak.

With a recent improvement to SWT, the GC implementation on Windows is not prone to a memory leak when using a long-living GC on which only a single operation (in this case setFont()) is performed repeatedly anymore. Due to the mentioned issue and because the fix became unnecessary with SWT enhancements, this reverts the previous change to FigureUtilties.