### PR TITLE
Guard scalable layers in root editparts behind system property

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,6 +23,7 @@ import org.eclipse.draw2d.LayeredPane;
 import org.eclipse.draw2d.ScalableFreeformLayeredPane;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.AutoexposeHelper;
 import org.eclipse.gef.DragTracker;
@@ -88,7 +89,7 @@ import org.eclipse.gef.tools.MarqueeDragTracker;
  */
 public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements LayerConstants, LayerManager {
 
-	private ScalableFreeformLayeredPane innerLayers;
+	private FreeformLayeredPane innerLayers;
 	private LayeredPane printableLayers;
 	private final PropertyChangeListener gridListener = evt -> {
 		String property = evt.getPropertyName();
@@ -104,8 +105,13 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	@Override
 	protected IFigure createFigure() {
 		FreeformViewport viewport = new FreeformViewport();
-		innerLayers = new ScalableFreeformLayeredPane();
-		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerLayers));
+		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
+			ScalableFreeformLayeredPane innerScalableLayers = new ScalableFreeformLayeredPane();
+			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerScalableLayers));
+			innerLayers = innerScalableLayers;
+		} else {
+			innerLayers = new FreeformLayeredPane();
+		}
 		createLayers(innerLayers);
 		viewport.setContents(innerLayers);
 		return viewport;

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,6 +26,7 @@ import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.AutoexposeHelper;
 import org.eclipse.gef.DragTracker;
@@ -122,7 +123,7 @@ public class ScalableRootEditPart extends SimpleRootEditPart implements LayerCon
 
 	}
 
-	private ScalableLayeredPane innerLayers;
+	private LayeredPane innerLayers;
 	private LayeredPane printableLayers;
 	private ScalableLayeredPane scaledLayers;
 	private final PropertyChangeListener gridListener = (PropertyChangeEvent evt) -> {
@@ -175,8 +176,13 @@ public class ScalableRootEditPart extends SimpleRootEditPart implements LayerCon
 	protected IFigure createFigure() {
 		Viewport viewport = createViewport();
 
-		innerLayers = new ScalableLayeredPane();
-		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerLayers));
+		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
+			ScalableLayeredPane innerScalableLayers = new ScalableLayeredPane(useScaledGraphics);
+			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerScalableLayers));
+			innerLayers = innerScalableLayers;
+		} else {
+			innerLayers = new LayeredPane();
+		}
 		createLayers(innerLayers);
 
 		viewport.setContents(innerLayers);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/SimpleAutoscaledRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/SimpleAutoscaledRootEditPart.java
@@ -12,12 +12,23 @@
  *******************************************************************************/
 package org.eclipse.gef.internal;
 
+import org.eclipse.core.runtime.Assert;
+
 import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.ScalableLayeredPane;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.editparts.SimpleRootEditPart;
 
+/**
+ * <b>Important:</b> This edit part should only be used when the Draw2D-based
+ * auto-scaling is enabled. Otherwise scaling might be applied twice; Once by
+ * Draw2D and once by SWT.
+ */
 public final class SimpleAutoscaledRootEditPart extends SimpleRootEditPart {
+	public SimpleAutoscaledRootEditPart() {
+		Assert.isTrue(InternalDraw2dUtils.isAutoScaleEnabled());
+	}
 
 	@Override
 	protected final ScalableFigure createFigure() {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,10 +27,12 @@ import org.eclipse.ui.IMemento;
 import org.eclipse.draw2d.ColorProvider.SystemColorFactory;
 import org.eclipse.draw2d.FigureCanvas;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.eclipse.gef.EditDomain;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.editparts.SimpleRootEditPart;
 import org.eclipse.gef.internal.SimpleAutoscaledRootEditPart;
 import org.eclipse.gef.internal.ui.palette.PaletteSelectionTool;
 import org.eclipse.gef.internal.ui.palette.editparts.DrawerEditPart;
@@ -127,7 +129,8 @@ public class PaletteViewer extends ScrollingGraphicalViewer {
 	 */
 	@Override
 	protected void createDefaultRoot() {
-		setRootEditPart(new SimpleAutoscaledRootEditPart());
+		setRootEditPart(InternalDraw2dUtils.isAutoScaleEnabled() ? new SimpleAutoscaledRootEditPart()
+				: new SimpleRootEditPart());
 	}
 
 	private void disposeFont() {


### PR DESCRIPTION
This only creates the scalable layers required for the Draw2D-based monitor scaling when then "draw2d.enableAutoscale" system property is set. Meaning clients who decide to opt-out of this functionality don't get any intermediate figures.

Furthermore, the scalable layers only use scaled graphics if explicitly set in the root editpart. The ScalableGraphics class has several issues and should not be used, if consumers don't want it.