### PR TITLE
Mark getGC() in FigureUtilities for removal

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -67,12 +67,14 @@ public class FigureUtilities {
 
 	/**
 	 * Returns the GC used for various utilities. Advanced graphics must not be
-	 * switched on by clients using this GC.
+	 * switched off by clients using this GC.
 	 *
-	 * @deprecated do not mess with this GC
+	 * @deprecated do not mess with this GC. This method will be removed after the
+	 *             2027-12 release. The calling methods should create a local GC
+	 *             instance, rather than relying on a static field.
 	 * @return the GC
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2025-12")
 	protected static GC getGC() {
 		if (gc == null) {
 			Shell shell = new Shell();


### PR DESCRIPTION
This method has been marked as deprecated over 20 years ago (with 0a2d7df1263dde7a4acc0677209e58c95b4fa55a).

Using a static GC has several issues; On Windows the GC instance keeps track of previously executed operations, which accumulate over time and has only recently been changed:

https://github.com/eclipse-platform/eclipse.platform.swt/commit/fd18da97a050669fb7caa91e11aba64479fcf33d

Additionally, the utility methods an arbitrary result, depending on whether the GC instance has been modified between calls.