### PR TITLE
Use assertNull(...) and fail(...) where appropriate

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/TextFlowWrapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -153,7 +153,7 @@ public class TextFlowWrapTest extends BaseTestCase {
 			// which would cause an index out of bounds exception if there were
 			// no leftover
 			// fragments
-			assertFalse(true, "Failed on: \"" + string1 + "\" + \"" + string2 + "\" Fragment expected: -" + answers[index] //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			fail("Failed on: \"" + string1 + "\" + \"" + string2 + "\" Fragment expected: -" + answers[index] //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 					+ "- No corresponding fragment\n"); //$NON-NLS-1$
 		}
 	}

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/CommandStackTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG and others.
+ * Copyright (c) 2015, 2025 itemis AG and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.gef.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -114,7 +115,7 @@ public class CommandStackTest {
 		stack.flush();
 
 		assertEquals(2, commandStackEvents.size());
-		assertEquals(null, commandStackEvents.get(0).getCommand());
+		assertNull(commandStackEvents.get(0).getCommand());
 		assertTrue(commandStackEvents.get(0).isPreChangeEvent());
 		assertFalse(commandStackEvents.get(0).isPostChangeEvent());
 		assertEquals(stack, commandStackEvents.get(0).getSource());
@@ -122,7 +123,7 @@ public class CommandStackTest {
 		assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
 		assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
 
-		assertEquals(null, commandStackEvents.get(1).getCommand());
+		assertNull(commandStackEvents.get(1).getCommand());
 		assertFalse(commandStackEvents.get(1).isPreChangeEvent());
 		assertTrue(commandStackEvents.get(1).isPostChangeEvent());
 		assertEquals(stack, commandStackEvents.get(1).getSource());
@@ -137,7 +138,7 @@ public class CommandStackTest {
 		stack.markSaveLocation();
 
 		assertEquals(2, commandStackEvents.size());
-		assertEquals(null, commandStackEvents.get(0).getCommand());
+		assertNull(commandStackEvents.get(0).getCommand());
 		assertTrue(commandStackEvents.get(0).isPreChangeEvent());
 		assertFalse(commandStackEvents.get(0).isPostChangeEvent());
 		assertEquals(stack, commandStackEvents.get(0).getSource());
@@ -145,7 +146,7 @@ public class CommandStackTest {
 		assertNotEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.PRE_MASK);
 		assertEquals(0, commandStackEvents.get(0).getDetail() & CommandStack.POST_MASK);
 
-		assertEquals(null, commandStackEvents.get(1).getCommand());
+		assertNull(commandStackEvents.get(1).getCommand());
 		assertFalse(commandStackEvents.get(1).isPreChangeEvent());
 		assertTrue(commandStackEvents.get(1).isPostChangeEvent());
 		assertEquals(stack, commandStackEvents.get(1).getSource());


### PR DESCRIPTION
This replaces calls to assertEquals(null, ...) with assertNull(...) and assertTrue(false) with fail().