### PR TITLE
Harmonize calculation of int-width and int-height in PrecisionRectangle

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -13,10 +13,6 @@
 
 package org.eclipse.draw2d.test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -27,7 +23,7 @@ import org.junit.jupiter.api.Test;
  * @author sshaw
  *
  */
-public class PrecisionRectangleTest {
+public class PrecisionRectangleTest extends BaseTestCase {
 
 	@SuppressWarnings("static-method")
 	@Test
@@ -58,6 +54,10 @@ public class PrecisionRectangleTest {
 
 		r = new PrecisionRectangle(-9.486614173228347, -34.431496062992125, 41.99055118110236, 25.92755905511811);
 		r.performScale(26.458333333333332);
+		assertEquals(-251.0, r.preciseX(), 0);
+		assertEquals(-910.9999999999999, r.preciseY(), 0);
+		assertEquals(1111.0, r.preciseWidth(), 0);
+		assertEquals(686.0, r.preciseHeight(), 0);
 		r.performScale(1.0 / 26.458333333333332);
 		assertEquals(-9.486614173228347, r.preciseX(), 0);
 		assertEquals(-34.431496062992125, r.preciseY(), 0);
@@ -116,6 +116,8 @@ public class PrecisionRectangleTest {
 		assertEquals(17.5, r.preciseY(), 0);
 		assertEquals(91, r.preciseWidth(), 0);
 		assertEquals(91, r.preciseHeight(), 0);
+		// Different rounding behavior between Rectangle and PrecisionRectangle.
+		assertEquals(17, 17, 92, 92, r);
 	}
 
 	@SuppressWarnings("static-method")

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -346,10 +346,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 */
 	@Override
 	public void performScale(double factor) {
-		setPreciseX(preciseX() * factor);
-		setPreciseY(preciseY() * factor);
-		setPreciseWidth(preciseWidth() * factor);
-		setPreciseHeight(preciseHeight() * factor);
+		scale(factor, factor);
 	}
 
 	/**
@@ -459,10 +456,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 */
 	@Override
 	public Rectangle scale(double scaleX, double scaleY) {
-		setPreciseX(preciseX() * scaleX);
-		setPreciseY(preciseY() * scaleY);
-		setPreciseWidth(preciseWidth() * scaleX);
-		setPreciseHeight(preciseHeight() * scaleY);
+		setPreciseBounds(preciseX() * scaleX, preciseY() * scaleY, preciseWidth() * scaleX, preciseHeight() * scaleY);
 		return this;
 	}
 
@@ -972,7 +966,16 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Updates the height integer field using the value of preciseHeight.
 	 */
 	private final void updateHeightInt() {
-		height = PrecisionGeometry.doubleToInteger(preciseHeight);
+		height = getHeightInt();
+	}
+
+	/**
+	 * Calculates the int-height of this rectangle using the same algorithm as used
+	 * by AWT in {@link java.awt.geom.RectangularShape#getBounds()
+	 * RectangularShape#getBounds()}
+	 */
+	private int getHeightInt() {
+		return PrecisionGeometry.doubleToInteger((Math.ceil(preciseY + preciseHeight) - Math.floor(preciseY)));
 	}
 
 	/**
@@ -1000,7 +1003,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Updates the preciseHeight double field using the value of height.
 	 */
 	private final void updatePreciseHeightDouble() {
-		if (height != PrecisionGeometry.doubleToInteger(preciseHeight)) {
+		if (height != getHeightInt()) {
 			preciseHeight = height;
 		}
 	}
@@ -1009,7 +1012,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Updates the preciseWidth double field using the value of width.
 	 */
 	private final void updatePreciseWidthDouble() {
-		if (width != PrecisionGeometry.doubleToInteger(preciseWidth)) {
+		if (width != getWidthInt()) {
 			preciseWidth = width;
 		}
 	}
@@ -1036,7 +1039,16 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Updates the width integer field using the value of preciseWidth.
 	 */
 	private final void updateWidthInt() {
-		width = PrecisionGeometry.doubleToInteger(preciseWidth);
+		width = getWidthInt();
+	}
+
+	/**
+	 * Calculates the int-height of this rectangle using the same algorithm as used
+	 * by AWT in {@link java.awt.geom.RectangularShape#getBounds()
+	 * RectangularShape#getBounds()}
+	 */
+	private int getWidthInt() {
+		return PrecisionGeometry.doubleToInteger(Math.ceil(preciseX + preciseWidth) - Math.floor(preciseX));
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-up to 116c3dd2d5c73db11d2d3702820dc881d274a6b8, due to which the scale() method was overriden, similar to the performScale() method.

When scaling a PrecisionRectangle, we need to make sure that its int-representation is identical to a plain Rectangle, which be off by one pixel compared to its double-representation.