### PR TITLE
Override getSize() and getLocation() in PrecisionRectangle

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -117,4 +117,20 @@ public class PrecisionRectangleTest {
 		assertEquals(91, r.preciseWidth(), 0);
 		assertEquals(91, r.preciseHeight(), 0);
 	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testScaleLocation() {
+		// check work scale(double) with rounding errors
+		PrecisionRectangle r = new PrecisionRectangle(-9.47, -34.43, 41.95, 25.92);
+		assertEquals(r.getPreciseCopy().getLocation().scale(1.153), r.getPreciseCopy().scale(1.153).getLocation());
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testScaleDimension() {
+		// check work scale(double) with rounding errors
+		PrecisionRectangle r = new PrecisionRectangle(-9.47, -34.43, 41.95, 25.92);
+		assertEquals(r.getPreciseCopy().getSize().scale(1.153), r.getPreciseCopy().scale(1.153).getSize());
+	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -261,12 +261,30 @@ public final class PrecisionRectangle extends Rectangle {
 	}
 
 	/**
+	 * @see org.eclipse.draw2d.geometry.Rectangle#getLocation()
+	 * @since 3.21
+	 */
+	@Override
+	public PrecisionPoint getLocation() {
+		return new PrecisionPoint(preciseX(), preciseY());
+	}
+
+	/**
 	 * Returns a precise copy of this.
 	 *
 	 * @return a precise copy
 	 */
 	public PrecisionRectangle getPreciseCopy() {
 		return new PrecisionRectangle(preciseX(), preciseY(), preciseWidth(), preciseHeight());
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.Rectangle#getSize()
+	 * @since 3.21
+	 */
+	@Override
+	public PrecisionDimension getSize() {
+		return new PrecisionDimension(preciseWidth(), preciseHeight());
 	}
 
 	/**


### PR DESCRIPTION
Both methods should return a precise Dimension and Point, respectively, to avoid rounding errors when transforming them.