### PR TITLE
Avoid accumulative rounding errors when using nested scalable figures

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -60,7 +60,8 @@ import org.junit.platform.suite.api.Suite;
 	InsetsTest.class,
 	DirectedGraphLayoutTest.class,
 	ScrollPaneTests.class,
-	LabelTest.class
+	LabelTest.class,
+	PrecisionTests.class
 })
 public class Draw2dTestSuite {
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.FigureUtilities;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.ScalableLayeredPane;
+import org.eclipse.draw2d.geometry.PrecisionRectangle;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case to ensure rounding errors don't accumulate when translating
+ * coordinates through multiple scalable layers.
+ */
+public class PrecisionTests extends BaseTestCase {
+	private IFigure fig;
+
+	@BeforeEach
+	public void setUp() {
+		fig = new Figure();
+		IFigure layers = createLayers();
+		layers.add(fig);
+		IFigure root = new Figure();
+		root.add(FigureUtilities.getRoot(layers));
+	}
+
+	private static IFigure createLayers() {
+		ScalableLayeredPane f1 = createLayer(1.33);
+		ScalableLayeredPane f2 = createLayer(5.79);
+		ScalableLayeredPane f3 = createLayer(0.87);
+		ScalableLayeredPane f4 = createLayer(3.88);
+		ScalableLayeredPane f5 = createLayer(1.46);
+
+		f1.add(f2);
+		f2.add(f3);
+		f3.add(f4);
+		f4.add(f5);
+
+		return f5;
+	}
+
+	private static ScalableLayeredPane createLayer(double scale) {
+		ScalableLayeredPane figure = new ScalableLayeredPane();
+		figure.setScale(scale);
+		figure.setOpaque(true);
+		return figure;
+	}
+
+	@Test
+	public void testPreciseTranslateToAbsolute() {
+		Rectangle r1 = new Rectangle(13, 37, 163, 377);
+		Rectangle r2 = new PrecisionRectangle(13, 37, 163, 377);
+		fig.translateToAbsolute(r1);
+		fig.translateToAbsolute(r2);
+		assertEquals(493, 1404, 6187, 14309, r1);
+		assertEquals(r1.x, r2.x);
+		assertEquals(r1.y, r2.y);
+		assertEquals(r1.width, r2.width);
+		assertEquals(r1.height, r2.height);
+	}
+
+	@Test
+	public void testPreciseTranslateToRelative() {
+		Rectangle r1 = new Rectangle(753, 891, 353, 564);
+		Rectangle r2 = new PrecisionRectangle(753, 891, 353, 564);
+		fig.translateToRelative(r1);
+		fig.translateToRelative(r2);
+		assertEquals(19, 23, 11, 16, r1);
+		assertEquals(r1.x, r2.x);
+		assertEquals(r1.y, r2.y);
+		assertEquals(r1.width, r2.width);
+		assertEquals(r1.height, r2.height);
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
@@ -114,4 +114,12 @@ public class ScalableFreeformLayeredPane extends FreeformLayeredPane implements 
 		IScalablePaneHelper.translateFromParent(this, t);
 	}
 
+	/**
+	 * @since 3.21
+	 * @see org.eclipse.draw2d.Figure#useDoublePrecision()
+	 */
+	@Override
+	protected boolean useDoublePrecision() {
+		return true;
+	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
@@ -127,4 +127,13 @@ public class ScalableLayeredPane extends LayeredPane implements IScalablePane {
 		return true;
 	}
 
+	/**
+	 * @since 3.21
+	 * @see org.eclipse.draw2d.Figure#useDoublePrecision()
+	 */
+	@Override
+	protected boolean useDoublePrecision() {
+		return true;
+	}
+
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
@@ -116,5 +116,10 @@ public class ScalableLightweightSystem extends LightweightSystem {
 		public void translateFromParent(Translatable t) {
 			IScalablePaneHelper.translateFromParent(this, t);
 		}
+
+		@Override
+		protected boolean useDoublePrecision() {
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
When translating geometric shapes across multiple scalable layers, rounding errors may occur if each layer is using a fractional scaling factor. This is because the methods translateToRelative() and translateToAbsolute() work with integer precision. Given an integer-based shape, this causes rounding errors after every layer.

To avoid this, an internal useDoublePrecision() method is added to the Figure, which indicates whether those methods should convert the integer-precision shape to (intermediate) double-precision shape. The fractional values are accumulated and only converted back to integer precision at the end.

Relates to https://github.com/eclipse-gef/gef-classic/issues/829