### PR TITLE
Fix double-scaling introduced by AutoscaleFreeformViewport

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
@@ -20,7 +20,7 @@ package org.eclipse.draw2d;
  *
  * @noreference This class is not intended to be referenced by clients.
  */
-public class AutoscaleFreeformViewport extends FreeformViewport implements ScalableFigure {
+public class AutoscaleFreeformViewport extends FreeformViewport {
 
 	public AutoscaleFreeformViewport(boolean useScaledGraphics) {
 		super.setContents(new ScalableFreeformLayeredPane(useScaledGraphics));
@@ -37,11 +37,6 @@ public class AutoscaleFreeformViewport extends FreeformViewport implements Scala
 	}
 
 	@Override
-	public double getScale() {
-		return getAutoScaleLayerPane().getScale();
-	}
-
-	@Override
 	public void setContents(IFigure figure) {
 		ScalableFreeformLayeredPane autoScaleLayerPane = getAutoScaleLayerPane();
 		if (!autoScaleLayerPane.getChildren().isEmpty()) {
@@ -51,7 +46,6 @@ public class AutoscaleFreeformViewport extends FreeformViewport implements Scala
 		autoScaleLayerPane.add(figure);
 	}
 
-	@Override
 	public void setScale(double scale) {
 		getAutoScaleLayerPane().setScale(scale);
 	}

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -7,12 +7,26 @@
                 <message_argument value="FreeformGraphicalRootEditPart"/>
             </message_arguments>
         </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AutoscaleFreeformViewport"/>
+                <message_argument value="FreeformGraphicalRootEditPart"/>
+                <message_argument value="setScale(double)"/>
+            </message_arguments>
+        </filter>
     </resource>
     <resource path="src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java" type="org.eclipse.gef.editparts.ScalableFreeformRootEditPart">
         <filter id="640708718">
             <message_arguments>
                 <message_argument value="AutoscaleFreeformViewport(boolean)"/>
                 <message_argument value="ScalableFreeformRootEditPart"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AutoscaleFreeformViewport"/>
+                <message_argument value="ScalableFreeformRootEditPart"/>
+                <message_argument value="setScale(double)"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/FreeformGraphicalRootEditPart.java
@@ -161,7 +161,7 @@ public class FreeformGraphicalRootEditPart extends SimpleRootEditPart implements
 	protected FreeformViewport createViewport() {
 		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
 			AutoscaleFreeformViewport viewport = new AutoscaleFreeformViewport(false);
-			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(viewport));
+			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(viewport::setScale));
 			return viewport;
 		}
 		return new FreeformViewport();

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java
@@ -152,7 +152,7 @@ public class ScalableFreeformRootEditPart extends FreeformGraphicalRootEditPart 
 	protected FreeformViewport createViewport() {
 		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
 			AutoscaleFreeformViewport viewPort = new AutoscaleFreeformViewport(useScaledGraphics);
-			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(viewPort));
+			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(viewPort::setScale));
 			return viewPort;
 		}
 		return super.createViewport();

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
@@ -178,7 +178,7 @@ public class ScalableRootEditPart extends SimpleRootEditPart implements LayerCon
 
 		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
 			ScalableLayeredPane innerScalableLayers = new ScalableLayeredPane(useScaledGraphics);
-			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerScalableLayers));
+			addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(innerScalableLayers::setScale));
 			innerLayers = innerScalableLayers;
 		} else {
 			innerLayers = new LayeredPane();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
@@ -16,6 +16,7 @@ package org.eclipse.gef.internal;
 import java.beans.PropertyChangeListener;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
@@ -32,7 +33,6 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 
 import org.eclipse.draw2d.BasicColorProvider;
 import org.eclipse.draw2d.ColorProvider;
-import org.eclipse.draw2d.ScalableFigure;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartListener;
@@ -138,11 +138,11 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 		}
 	}
 
-	public static EditPartListener createAutoscaleEditPartListener(ScalableFigure figure) {
+	public static EditPartListener createAutoscaleEditPartListener(Consumer<Double> consumer) {
 		final PropertyChangeListener autoScaleListener = evt -> {
 			if (InternalGEFPlugin.MONITOR_SCALE_PROPERTY.equals(evt.getPropertyName()) && evt.getNewValue() != null) {
 				double newValue = (double) evt.getNewValue();
-				figure.setScale(newValue);
+				consumer.accept(newValue);
 			}
 		};
 
@@ -152,7 +152,7 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 				editpart.getViewer().addPropertyChangeListener(autoScaleListener);
 				try {
 					double scale = (double) editpart.getViewer().getProperty(InternalGEFPlugin.MONITOR_SCALE_PROPERTY);
-					figure.setScale(scale);
+					consumer.accept(scale);
 				} catch (NullPointerException | ClassCastException e) {
 					// no value available
 				}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/SimpleAutoscaledRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/SimpleAutoscaledRootEditPart.java
@@ -33,7 +33,7 @@ public final class SimpleAutoscaledRootEditPart extends SimpleRootEditPart {
 	@Override
 	protected final ScalableFigure createFigure() {
 		ScalableFigure scalableFigure = new ScalableLayeredPane();
-		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(scalableFigure));
+		this.addEditPartListener(InternalGEFPlugin.createAutoscaleEditPartListener(scalableFigure::setScale));
 		return scalableFigure;
 	}
 


### PR DESCRIPTION
This class is a container for a ScalableFreeformLayeredPane but doesn't do any scaling itself. It should therefore not implement the ScalableFigure.