### PR TITLE
Create a provisional PrecisionPointList to better handle rounding errors

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
@@ -17,6 +17,8 @@ import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ScalableLayeredPane;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.draw2d.geometry.PrecisionPointList;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -85,5 +87,25 @@ public class PrecisionTests extends BaseTestCase {
 		assertEquals(r1.y, r2.y);
 		assertEquals(r1.width, r2.width);
 		assertEquals(r1.height, r2.height);
+	}
+
+	@Test
+	public void testPreciseTranslateToAbsolute_PointList() {
+		PointList p1 = new PointList(new int[] { 13, 29, 32, 5 });
+		PointList p2 = new PrecisionPointList(new int[] { 13, 29, 32, 5 });
+		fig.translateToAbsolute(p1);
+		fig.translateToAbsolute(p2);
+		assertArrayEquals(p1.toIntArray(), new int[] { 493, 1100, 1214, 189 });
+		assertArrayEquals(p1.toIntArray(), p2.toIntArray());
+	}
+
+	@Test
+	public void testPreciseTranslateToRelative_PointList() {
+		PointList p1 = new PointList(new int[] { 518, 628, 715, 313 });
+		PointList p2 = new PrecisionPointList(new int[] { 518, 628, 715, 313 });
+		fig.translateToRelative(p1);
+		fig.translateToRelative(p2);
+		assertArrayEquals(p1.toIntArray(), new int[] { 13, 16, 18, 8 });
+		assertArrayEquals(p1.toIntArray(), p2.toIntArray());
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -33,8 +33,10 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.PrecisionDimension;
 import org.eclipse.draw2d.geometry.PrecisionPoint;
+import org.eclipse.draw2d.geometry.PrecisionPointList;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
@@ -2096,6 +2098,8 @@ public class Figure implements IFigure {
 				return new PrecisionDimension(d);
 			} else if (source instanceof Rectangle r && !(source instanceof PrecisionRectangle)) {
 				return new PrecisionRectangle(r);
+			} else if (source instanceof PointList p && !(source instanceof PrecisionPointList)) {
+				return new PrecisionPointList(p);
 			}
 		}
 		// is already precise or doesn't have a precise variant
@@ -2120,6 +2124,8 @@ public class Figure implements IFigure {
 				d2.setSize(d1.width, d1.height);
 			} else if (source instanceof PrecisionRectangle r1 && target instanceof Rectangle r2) {
 				r2.setBounds(r1.x, r1.y, r1.width, r1.height);
+			} else if (source instanceof PrecisionPointList p1 && target instanceof PointList p2) {
+				System.arraycopy(p1.toIntArray(), 0, p2.toIntArray(), 0, p2.size() * 2);
 			}
 		}
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPointList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPointList.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.geometry;
+
+import java.util.Arrays;
+
+/**
+ * A PointList implementation using floating point values which are truncated
+ * into the inherited integer fields. The use of floating point prevents
+ * rounding errors from accumulating.
+ *
+ * <strong>EXPERIMENTAL</strong> This class has been added as part of a work in
+ * progress and there is no guarantee that this API will remain unchanged. This
+ * is likely to not function properly outside some very specific use-cases.
+ *
+ * @since 3.21
+ * @noreference This class is not intended to be referenced by clients.
+ */
+public final class PrecisionPointList extends PointList {
+	private static final Point PRIVATE_POINT = new Point();
+	private double[] precisePoints = {};
+
+	/**
+	 * Constructs a PrecisionPointList with the given points.
+	 *
+	 * @param points int array where two consecutive ints form the coordinates of a
+	 *               point
+	 */
+	public PrecisionPointList(int[] points) {
+		super(points);
+		precisePoints = Arrays.stream(points).asDoubleStream().toArray();
+	}
+
+	/**
+	 * Constructs a PrecisionPointList with the given points.
+	 *
+	 * @param points PointList from which the initial values are taken
+	 */
+	public PrecisionPointList(PointList points) {
+		this(points.getCopy().toIntArray());
+	}
+
+	@Override
+	public void performScale(double factor) {
+		for (int i = 0; i < precisePoints.length; ++i) {
+			precisePoints[i] *= factor;
+		}
+		for (int i = 0; i < size(); ++i) {
+			updateIntPoint(i);
+		}
+	}
+
+	/**
+	 * Updates the int-point at the given index using its precise coordinates.
+	 */
+	private void updateIntPoint(int i) {
+		getPoint(PRIVATE_POINT, i);
+		int preciseX = PrecisionGeometry.doubleToInteger(precisePoints[i * 2]);
+		int preciseY = PrecisionGeometry.doubleToInteger(precisePoints[i * 2 + 1]);
+		if (preciseX != PRIVATE_POINT.x || preciseY != PRIVATE_POINT.y) {
+			PRIVATE_POINT.x = preciseX;
+			PRIVATE_POINT.y = preciseY;
+			setPoint(PRIVATE_POINT, i);
+		}
+	}
+}


### PR DESCRIPTION
When translating a PointList through multiple scalable layers, rounding
errors accumulate over time because the remainder is discarded after
each layer. For other shapes such as Points and Rectangles, this is
solved by using a "Precision" variant.

With this change, such a variant now also exists for the PointList and
is used when calling "translateToAbsolute()" or "translateToRelative()"
on a Figure.

Note: The implementation of this PrecisionPointList is not complete and
currently only works for this specific use case. The double-array
doesn't update itself when the int-array is modified. This class should
therefore not yet be used outside Draw2D.

Relates to https://github.com/eclipse-gef/gef-classic/issues/829