### PR TITLE
Prevent FigureCanvas from propagating AutoScaleDisabled to children

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 /**
  * A scrolling Canvas that contains {@link Figure Figures} viewed through a
@@ -160,6 +161,7 @@ public class FigureCanvas extends Canvas {
 		this.lws = lws;
 		lws.setControl(this);
 		hook();
+		InternalDraw2dUtils.setPropagateAutoScaleDisabled(this, false);
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -44,6 +44,12 @@ public class InternalDraw2dUtils {
 	 */
 	private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED"; //$NON-NLS-1$
 
+	/**
+	 * Data that can be set to make a control not propagate autoScale disabling to
+	 * children.
+	 */
+	private static final String DATA_PROPOGATE_AUTOSCALE_DISABLED = "PROPOGATE_AUTOSCALE_DISABLED"; //$NON-NLS-1$
+
 	private static final boolean enableAutoScale = "win32".equals(SWT.getPlatform()) //$NON-NLS-1$
 			&& Boolean.parseBoolean(System.getProperty(DRAW2D_ENABLE_AUTOSCALE, Boolean.TRUE.toString()))
 			&& SWT.getVersion() >= 4971; // SWT 2025-12 release or higher
@@ -59,6 +65,13 @@ public class InternalDraw2dUtils {
 		control.setData(InternalDraw2dUtils.DATA_AUTOSCALE_DISABLED, true);
 		control.addListener(SWT.ZoomChanged, e -> zoomConsumer.accept(e.detail / 100.0));
 		zoomConsumer.accept(InternalDraw2dUtils.calculateScale(control));
+	}
+
+	public static void setPropagateAutoScaleDisabled(Control control, boolean propagate) {
+		if (control == null || !isAutoScaleEnabled()) {
+			return;
+		}
+		control.setData(DATA_PROPOGATE_AUTOSCALE_DISABLED, propagate);
 	}
 
 	private static double calculateScale(Control control) {


### PR DESCRIPTION
FigureCanvas may contain SWT widgets as children. While the FigureCanvas itself is AutoScaleDisabled (since scaling is handled by GEF), child SWT widgets such as cell editors should remain auto-scale enabled.

This change sets a flag on the control to prevent AutoScaleDisabled from being propagated to its children. 

The first commit in this PR originates from [@akoch-yatta’s branch](https://github.com/vi-eclipse/gef-classic/commits/fix-for-rulers-and-guides).

This change depends on [eclipse-platform/eclipse.platform.swt#2748](https://github.com/eclipse-platform/eclipse.platform.swt/pull/2748) where the flag to prevent AutoScaleDisabled from being propagated to children is introduced.
.

### Steps to reproduce:

On a monitor with zoom = 150%, open a GEF Logic Diagram.

Add a logic editor, right-click on it, and start typing. The text appears at 100% zoom (too small).

To test this fix:
Checkout SWT from [this branch](https://github.com/vi-eclipse/eclipse.platform.swt/tree/arunjose696/494/InheritAutoScaleDisablement).

Apply the changes from this PR.
 The font size of the edited text in logic editor will now correctly scale according to the monitor’s zoom level.

| Before  | After  |
|:------------------------:|:------------------:|
| ![Before](https://github.com/user-attachments/assets/3568b152-3e74-4a50-9e2e-4c5a3205b987) | ![After](https://github.com/user-attachments/assets/63c3a758-c023-4939-a2f1-966898d69542) |


FIxes #837 