### PR TITLE
Try to stabilize testGraphSnippet6() #784

### DIFF
--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/AbstractGraphTest.java
@@ -38,7 +38,6 @@ import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 import org.eclipse.zest.core.widgets.Graph;
 import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphNode;
-import org.eclipse.zest.core.widgets.internal.GraphLabel;
 import org.eclipse.zest.layouts.algorithms.SpringLayoutAlgorithm;
 import org.eclipse.zest.tests.examples.AbstractGraphTest.SWTBotExtension;
 import org.eclipse.zest.tests.utils.ISWTBotGraphContainer;
@@ -250,18 +249,6 @@ public abstract class AbstractGraphTest {
 		LightweightSystem lws = (LightweightSystem) getter2.invoke(toolTipHelper);
 
 		return lws.getRootFigure().getChildren().get(0);
-	}
-
-	/**
-	 * Returns the fish-eye figure at the given coordinates. Note that those figures
-	 * are on a separate layer.
-	 *
-	 * @param x The x coordinate of the fish-eye figure.
-	 * @param y The x coordinate of the fish-eye figure.
-	 */
-	protected GraphLabel getFishEyeFigure(int x, int y) {
-		IFigure fishEyeLayer = graph.getRootLayer().getChildren().get(1);
-		return (GraphLabel) fishEyeLayer.findFigureAt(x, y);
 	}
 
 	/**

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/examples/GraphSWTTests.java
@@ -339,7 +339,7 @@ public class GraphSWTTests extends AbstractGraphTest {
 			assertEquals(figure.getText(), "");
 
 			graphRobot.mouseMove(location.x + 1, location.y + 1);
-			GraphLabel fishEyeFigure = getFishEyeFigure(location.x + 1, location.y + 1);
+			GraphLabel fishEyeFigure = graphRobot.getFishEyeFigureAt(location.x + 1, location.y + 1);
 			assertEquals(fishEyeFigure.getText(), labels.get(i));
 		}
 	}
@@ -725,7 +725,7 @@ public class GraphSWTTests extends AbstractGraphTest {
 		nodeFigure.translateToAbsolute(location);
 
 		graphRobot.mouseMove(location.x, location.y);
-		GraphLabel fishEyeFigure = getFishEyeFigure(location.x + 1, location.y + 1);
+		GraphLabel fishEyeFigure = graphRobot.getFishEyeFigureAt(location.x + 1, location.y + 1);
 		assertEquals(fishEyeFigure.getText(), "SomeClass.java");
 	}
 }

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/utils/SWTBotGraph.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/utils/SWTBotGraph.java
@@ -27,6 +27,7 @@ import org.eclipse.zest.core.widgets.GraphConnection;
 import org.eclipse.zest.core.widgets.GraphItem;
 import org.eclipse.zest.core.widgets.GraphNode;
 import org.eclipse.zest.core.widgets.HideNodeHelper;
+import org.eclipse.zest.core.widgets.internal.GraphLabel;
 
 import org.eclipse.draw2d.Clickable;
 import org.eclipse.draw2d.IFigure;
@@ -236,6 +237,20 @@ public class SWTBotGraph extends AbstractSWTBotControl<Graph> implements ISWTBot
 	 */
 	public IFigure getFigureAt(int x, int y) {
 		return syncExec(() -> widget.getFigureAt(x, y));
+	}
+
+	/**
+	 * Returns the fish-eye figure at the given coordinates. Note that those figures
+	 * are on a separate layer.
+	 *
+	 * @param x The x coordinate of the fish-eye figure.
+	 * @param y The x coordinate of the fish-eye figure.
+	 */
+	public GraphLabel getFishEyeFigureAt(int x, int y) {
+		return syncExec(() -> {
+			IFigure fishEyeLayer = widget.getRootLayer().getChildren().get(1);
+			return (GraphLabel) fishEyeLayer.findFigureAt(x, y);
+		});
 	}
 
 	/**


### PR DESCRIPTION
Search for the fish-eye figure within the SWT UI thread (just like when searching for normal figures), to avoid interference from SWT events or the animation.

May close https://github.com/eclipse-gef/gef-classic/issues/784