### PR TITLE
Bump lower bound for dependency to Draw2D

### DIFF
--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -31,7 +31,7 @@ Export-Package: org.eclipse.gef,
  org.eclipse.gef.ui.rulers,
  org.eclipse.gef.ui.views.palette,
  org.eclipse.gef.util
-Require-Bundle: org.eclipse.draw2d;visibility:=reexport;bundle-version="[3.20.100,4.0.0)",
+Require-Bundle: org.eclipse.draw2d;visibility:=reexport;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.views;resolution:=optional;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.133.0,4.0.0)",

--- a/org.eclipse.zest.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.zest.core/META-INF/MANIFEST.MF
@@ -4,10 +4,10 @@ Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.zest.core;singleton:=true
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.16.100.qualifier
+Bundle-Version: 1.17.0.qualifier
 Require-Bundle: org.eclipse.zest.layouts,
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.draw2d;bundle-version="[3.20.100,4.0.0)";visibility:=reexport
+ org.eclipse.draw2d;bundle-version="[3.21.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.zest.core.viewers,
  org.eclipse.zest.core.viewers.internal;x-internal:=true,


### PR DESCRIPTION
Both GEF and Zest use the new auto-scale classes and therefore require the current Draw2D version.