### PR TITLE
Update JRuby to 9.4.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<comparator.repo>https://download.eclipse.org/tools/gef/classic/release/3.25.0</comparator.repo>
 		<surefire.timeout>300</surefire.timeout>
 		<asciidoctor-maven-plugin.version>3.2.0</asciidoctor-maven-plugin.version>
-		<jruby.version>9.4.5.0</jruby.version>
+		<jruby.version>9.4.14.0</jruby.version>
 		<target-platform>../target-platform/GEF_classic.target</target-platform>
 		<execution-environment>JavaSE-21</execution-environment>
 		<!-- SonarQube configuration -->


### PR DESCRIPTION
When verifying SSL certificates, jruby-openssl is not verifying that the hostname presented in the certificate matches the one we are trying to connect to, meaning a MITM could just present any valid cert for a completely different domain they own, and JRuby wouldn't complain.

While this likely isn't relevant for the AsciiDoc generation, it is still flagged by GitHub as potential vulnerability.