### PR TITLE
Remove unnecessary getFigure call in RulerViewport

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerRootEditPart.java
@@ -250,7 +250,7 @@ public class RulerRootEditPart extends SimpleRootEditPart {
 		@Override
 		public Point getViewLocation() {
 			Point viewLocation = new Point(getHorizontalRangeModel().getValue(), getVerticalRangeModel().getValue());
-			getFigure().translateToRelative(viewLocation);
+			translateToRelative(viewLocation);
 			return viewLocation;
 		}
 


### PR DESCRIPTION
This PR simplifies a translateToRelative call as the call to getFigure will return the RulerViewport itself.