### PR TITLE
Do not wrap custom Translatable representations as precise types

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -2092,14 +2092,19 @@ public class Figure implements IFigure {
 	 */
 	private Translatable toPreciseShape(Translatable source) {
 		if (getParent() instanceof Figure parentFigure && parentFigure.useDoublePrecision()) {
-			if (source instanceof Point p && !(source instanceof PrecisionPoint)) {
-				return new PrecisionPoint(p);
-			} else if (source instanceof Dimension d && !(source instanceof PrecisionDimension)) {
-				return new PrecisionDimension(d);
-			} else if (source instanceof Rectangle r && !(source instanceof PrecisionRectangle)) {
-				return new PrecisionRectangle(r);
-			} else if (source instanceof PointList p && !(source instanceof PrecisionPointList)) {
-				return new PrecisionPointList(p);
+			// Cannot check for instanceof as consumers might have custom specializations
+			// which might not be wrapped properly
+			if (source.getClass().equals(Point.class)) {
+				return new PrecisionPoint((Point) source);
+			}
+			if (source.getClass().equals(Dimension.class)) {
+				return new PrecisionDimension((Dimension) source);
+			}
+			if (source.getClass().equals(Rectangle.class)) {
+				return new PrecisionRectangle((Rectangle) source);
+			}
+			if (source.getClass().equals(PointList.class)) {
+				return new PrecisionPointList((PointList) source);
 			}
 		}
 		// is already precise or doesn't have a precise variant


### PR DESCRIPTION
The wrapping mechanism for Translatables when performing Figure#translate...() operations currently wraps every instance of the Translatable types provided by Draw2d. However, consumers may have custom specializations of those types, which can be incompatible with the implemented wrapping. This particularly applies to types like PointList, for which precision implementations did not exist such that consumers may use custom implementations of them.

This adapts the wrapping logic to ensure that only the relevant basic Draw2d types are wrapped to avoid that custom specializations that are potentially incompatible with the implemented wrapping mechanism get wrapped as well.

As indicated by the description, we have exactly such a custom `PrecisionPointList` in our product, which we use for translations at several places and which breaks if additionally wrapped into the preliminary `PrecisionPointList` now provided via Draw2d. This can easily happen for other consumers as well.

Problematic behavior for `PrecisionPointList` was introduced with:
- https://github.com/eclipse-gef/gef-classic/pull/849