### PR TITLE
Restore PrecisionRectangle substitutability for Rectangle

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -119,7 +119,7 @@ public class PrecisionRectangleTest extends BaseTestCase {
 		assertEquals(91, r.preciseWidth(), 0);
 		assertEquals(91, r.preciseHeight(), 0);
 		// Different rounding behavior between Rectangle and PrecisionRectangle.
-		assertEquals(17, 17, 92, 92, r);
+		assertEquals(17, 17, 91, 91, r);
 	}
 
 	@SuppressWarnings("static-method")
@@ -149,10 +149,29 @@ public class PrecisionRectangleTest extends BaseTestCase {
 
 	@SuppressWarnings("static-method")
 	@Test
+	public void testGetSize_Zero() {
+		PrecisionRectangle r = new PrecisionRectangle(0.5, 0.5, 0, 0);
+		assertEquals(r.width, r.getSize().width);
+		assertEquals(r.height, r.getSize().height);
+		assertEquals(0, r.getSize().width);
+		assertEquals(0, r.getSize().height);
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
 	public void testGetLocation() {
 		PrecisionRectangle r = new PrecisionRectangle(8.94, -34.37, 0, 0);
 		assertEquals(r.getLocation().getClass(), Point.class);
 		assertEquals(r.x, r.getLocation().x);
 		assertEquals(r.y, r.getLocation().y);
 	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testGetBottomRight() {
+		Rectangle rect = new PrecisionRectangle(100.5, 100.5, 250, 250);
+		assertEquals(rect.getBottomRight().x - rect.getTopLeft().x, rect.width);
+		assertEquals(rect.getBottomRight().y - rect.getTopLeft().y, rect.height);
+	}
+
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
@@ -69,7 +69,7 @@ public class PrecisionTests extends BaseTestCase {
 		Rectangle r2 = new PrecisionRectangle(13, 37, 163, 377);
 		fig.translateToAbsolute(r1);
 		fig.translateToAbsolute(r2);
-		assertEquals(493, 1404, 6187, 14309, r1);
+		assertEquals(493, 1404, 6186, 14307, r1);
 		assertEquals(r1.x, r2.x);
 		assertEquals(r1.y, r2.y);
 		assertEquals(r1.width, r2.width);
@@ -82,7 +82,7 @@ public class PrecisionTests extends BaseTestCase {
 		Rectangle r2 = new PrecisionRectangle(753, 891, 353, 564);
 		fig.translateToRelative(r1);
 		fig.translateToRelative(r2);
-		assertEquals(19, 23, 11, 16, r1);
+		assertEquals(19, 23, 9, 14, r1);
 		assertEquals(r1.x, r2.x);
 		assertEquals(r1.y, r2.y);
 		assertEquals(r1.width, r2.width);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -952,12 +952,10 @@ public final class PrecisionRectangle extends Rectangle {
 	}
 
 	/**
-	 * Calculates the int-height of this rectangle using the same algorithm as used
-	 * by AWT in {@link java.awt.geom.RectangularShape#getBounds()
-	 * RectangularShape#getBounds()}
+	 * Calculates the int-height of this rectangle.
 	 */
 	private int getHeightInt() {
-		return PrecisionGeometry.doubleToInteger((Math.ceil(preciseY + preciseHeight) - Math.floor(preciseY)));
+		return PrecisionGeometry.doubleToInteger(preciseHeight);
 	}
 
 	/**
@@ -1025,12 +1023,10 @@ public final class PrecisionRectangle extends Rectangle {
 	}
 
 	/**
-	 * Calculates the int-height of this rectangle using the same algorithm as used
-	 * by AWT in {@link java.awt.geom.RectangularShape#getBounds()
-	 * RectangularShape#getBounds()}
+	 * Calculates the int-height of this rectangle.
 	 */
 	private int getWidthInt() {
-		return PrecisionGeometry.doubleToInteger(Math.ceil(preciseX + preciseWidth) - Math.floor(preciseX));
+		return PrecisionGeometry.doubleToInteger(preciseWidth);
 	}
 
 	/**


### PR DESCRIPTION
Recent changes to PrecisionRectangle adapting how the integer-based values are calculated and how size and location of a rectangle is derived broke the substitution principle with respect to the Rectangle superclass and may also break existing consumers due to the changed behavior of API methods.

This change reverts the changes to the necessary extent such that the existing behavior is restored. It also adds a test for the substitutability of PrecisionRectangles with Rectangles.

The added test methods testScaleLocation() and testScaleDimension() are removed because scaling results for context-free rounded sizes or locations are obviously different from scaling a rectangle and then investigating its context-dependent rounded size and location values, so the different results are expected.

See also:
- https://github.com/eclipse-gef/gef-classic/pull/844#issuecomment-3541357947
- https://github.com/eclipse-gef/gef-classic/pull/844#issuecomment-3541877516
- https://github.com/eclipse-gef/gef-classic/pull/845#issuecomment-3541826688