### PR TITLE
Don't override getSize() and getLocation() in PrecisionRectangle

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.draw2d.test;
 
+import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PrecisionRectangle;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -125,7 +127,7 @@ public class PrecisionRectangleTest extends BaseTestCase {
 	public void testScaleLocation() {
 		// check work scale(double) with rounding errors
 		PrecisionRectangle r = new PrecisionRectangle(-9.47, -34.43, 41.95, 25.92);
-		assertEquals(r.getPreciseCopy().getLocation().scale(1.153), r.getPreciseCopy().scale(1.153).getLocation());
+		assertEquals(r.getCopy().preciseLocation().scale(1.153), r.getCopy().scale(1.153).preciseLocation());
 	}
 
 	@SuppressWarnings("static-method")
@@ -133,6 +135,24 @@ public class PrecisionRectangleTest extends BaseTestCase {
 	public void testScaleDimension() {
 		// check work scale(double) with rounding errors
 		PrecisionRectangle r = new PrecisionRectangle(-9.47, -34.43, 41.95, 25.92);
-		assertEquals(r.getPreciseCopy().getSize().scale(1.153), r.getPreciseCopy().scale(1.153).getSize());
+		assertEquals(r.getCopy().preciseSize().scale(1.153), r.getCopy().scale(1.153).preciseSize());
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testGetSize() {
+		PrecisionRectangle r = new PrecisionRectangle(0, 0, 41.95, 25.92);
+		assertEquals(r.getSize().getClass(), Dimension.class);
+		assertEquals(r.width, r.getSize().width);
+		assertEquals(r.height, r.getSize().height);
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testGetLocation() {
+		PrecisionRectangle r = new PrecisionRectangle(8.94, -34.37, 0, 0);
+		assertEquals(r.getLocation().getClass(), Point.class);
+		assertEquals(r.x, r.getLocation().x);
+		assertEquals(r.y, r.getLocation().y);
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -261,30 +261,12 @@ public final class PrecisionRectangle extends Rectangle {
 	}
 
 	/**
-	 * @see org.eclipse.draw2d.geometry.Rectangle#getLocation()
-	 * @since 3.21
-	 */
-	@Override
-	public PrecisionPoint getLocation() {
-		return new PrecisionPoint(preciseX(), preciseY());
-	}
-
-	/**
 	 * Returns a precise copy of this.
 	 *
 	 * @return a precise copy
 	 */
 	public PrecisionRectangle getPreciseCopy() {
 		return new PrecisionRectangle(preciseX(), preciseY(), preciseWidth(), preciseHeight());
-	}
-
-	/**
-	 * @see org.eclipse.draw2d.geometry.Rectangle#getSize()
-	 * @since 3.21
-	 */
-	@Override
-	public PrecisionDimension getSize() {
-		return new PrecisionDimension(preciseWidth(), preciseHeight());
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -824,6 +824,27 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	}
 
 	/**
+	 * Returns the precise dimensions of this Rectangle.
+	 *
+	 * @return Size of this Rectangle as a PrecisionDimension
+	 * @since 3.21
+	 */
+	public final PrecisionDimension preciseSize() {
+		return new PrecisionDimension(preciseWidth(), preciseHeight());
+	}
+
+	/**
+	 * Returns the precise upper left hand corner of the rectangle.
+	 *
+	 * @return Precise location of the rectangle
+	 * @see #setLocation(Point)
+	 * @since 3.21
+	 */
+	public final PrecisionPoint preciseLocation() {
+		return new PrecisionPoint(preciseX(), preciseY());
+	}
+
+	/**
 	 * Resizes this Rectangle by the Dimension provided as input and returns this
 	 * for convenience. This Rectange's width will become this.width +
 	 * sizeDelta.width. Likewise for height.


### PR DESCRIPTION
The PreciseDimension/PrecisePoint might have a different rounding behavior. Therefore a call to e.g. r.getSize().width might be different from r.width.

Instead, two new preciseSize() and preciseLocation() methods have been added.

See https://github.com/eclipse-gef/gef-classic/pull/845#issuecomment-3541826688