### PR TITLE
Only use double-precision translation when HighDPI scaling is enabled

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionTests.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.draw2d.test;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.IFigure;
@@ -21,6 +23,7 @@ import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.PrecisionDimension;
 import org.eclipse.draw2d.geometry.PrecisionPointList;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,6 +68,7 @@ public class PrecisionTests extends BaseTestCase {
 
 	@Test
 	public void testPreciseTranslateToAbsolute() {
+		assumeTrue(InternalDraw2dUtils.isAutoScaleEnabled());
 		PrecisionDimension scaleDimension = new PrecisionDimension(0, 1);
 		fig.translateToAbsolute(scaleDimension);
 		double fullScale = scaleDimension.preciseHeight();
@@ -80,6 +84,7 @@ public class PrecisionTests extends BaseTestCase {
 
 	@Test
 	public void testPreciseTranslateToRelative() {
+		assumeTrue(InternalDraw2dUtils.isAutoScaleEnabled());
 		PrecisionDimension scaleDimension = new PrecisionDimension(0, 1);
 		fig.translateToAbsolute(scaleDimension);
 		double fullScale = scaleDimension.preciseHeight();
@@ -95,6 +100,7 @@ public class PrecisionTests extends BaseTestCase {
 
 	@Test
 	public void testPreciseTranslateToAbsolute_PointList() {
+		assumeTrue(InternalDraw2dUtils.isAutoScaleEnabled());
 		PointList p1 = new PointList(new int[] { 13, 29, 32, 5 });
 		PointList p2 = new PrecisionPointList(new int[] { 13, 29, 32, 5 });
 		fig.translateToAbsolute(p1);
@@ -105,6 +111,7 @@ public class PrecisionTests extends BaseTestCase {
 
 	@Test
 	public void testPreciseTranslateToRelative_PointList() {
+		assumeTrue(InternalDraw2dUtils.isAutoScaleEnabled());
 		PointList p1 = new PointList(new int[] { 518, 628, 715, 313 });
 		PointList p2 = new PrecisionPointList(new int[] { 518, 628, 715, 313 });
 		fig.translateToRelative(p1);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
@@ -14,6 +14,7 @@ package org.eclipse.draw2d;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 /**
  * @author hudsonr
@@ -120,6 +121,6 @@ public class ScalableFreeformLayeredPane extends FreeformLayeredPane implements 
 	 */
 	@Override
 	protected boolean useDoublePrecision() {
-		return true;
+		return InternalDraw2dUtils.isAutoScaleEnabled();
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
@@ -15,6 +15,7 @@ package org.eclipse.draw2d;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 /**
  * A non-freeform, scalable layered pane.
@@ -133,7 +134,7 @@ public class ScalableLayeredPane extends LayeredPane implements IScalablePane {
 	 */
 	@Override
 	protected boolean useDoublePrecision() {
-		return true;
+		return InternalDraw2dUtils.isAutoScaleEnabled();
 	}
 
 }


### PR DESCRIPTION
When the "draw2d.enableAutoscale" system property is enabled, additional (scalable) layers are injected into the IFigure hierarchy to take the monitor zoom into consideration.

As a result of this, translating geometric shapes may cause additional rounding errors, which are the result of translating integer-values with an additional, fractional zoom level.

To work around this problem, the "useDoublePrecision()" method was added with 5cfe5b7587123e68c2077b6dbec4e5657316d458, which converts the geometric shapes to their precise variants. This conversion is generally not backwards compatible.

To make sure clients can fully opt-out of this new behavior, this conversion should only be done when the "draw2d.enableAutoscale" is set to true, meaning only when these new layers are added, that require this extended translation logic.