### PR TITLE
Introduce getBounds() method to Rectangle class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - ScalableLayeredPane
     - ScalableRootEditPart
     - ScalableLightweightSystem
+- Added `Rectangle.getBounds()`
 
 ## GEF
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -2128,9 +2128,7 @@ public class Figure implements IFigure {
 			} else if (source instanceof PrecisionDimension d1 && target instanceof Dimension d2) {
 				d2.setSize(d1.width, d1.height);
 			} else if (source instanceof PrecisionRectangle r1 && target instanceof Rectangle r2) {
-				r2.setBounds(r1.x, r1.y,
-						(int) (Math.ceil(r1.preciseX() + r1.preciseWidth()) - Math.floor(r1.preciseX())),
-						(int) (Math.ceil(r1.preciseY() + r1.preciseHeight()) - Math.floor(r1.preciseY())));
+				r2.setBounds(r1.getBounds());
 			} else if (source instanceof PrecisionPointList p1 && target instanceof PointList p2) {
 				System.arraycopy(p1.toIntArray(), 0, p2.toIntArray(), 0, p2.size() * 2);
 			}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -106,6 +106,18 @@ public final class PrecisionRectangle extends Rectangle {
 	}
 
 	/**
+	 * @see Rectangle#getBounds()
+	 */
+	@Override
+	public Rectangle getBounds() {
+		int x1 = x;
+		int y1 = y;
+		int w1 = PrecisionGeometry.doubleToInteger(Math.ceil(preciseX() + preciseWidth()) - Math.floor(preciseX()));
+		int h1 = PrecisionGeometry.doubleToInteger(Math.ceil(preciseY() + preciseHeight()) - Math.floor(preciseY()));
+		return new Rectangle(x1, y1, w1, h1);
+	}
+
+	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#contains(double, double)
 	 */
 	@Override

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -325,6 +325,16 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	}
 
 	/**
+	 * Returns an integer {@link Rectangle} that completely encloses this shape.
+	 *
+	 * @return an integer {@code Rectangle} that completely encloses this shape.
+	 * @since 3.22
+	 */
+	public Rectangle getBounds() {
+		return new Rectangle(x, y, width, height);
+	}
+
+	/**
 	 * Returns a new Rectangle which has the exact same parameters as this
 	 * Rectangle.
 	 *


### PR DESCRIPTION
The getBounds() method is a convenience method that returns an integer-precision rectangle enclosing the current rectangle. For a plain Rectangle, this is simply a copy operation, but for the PrecisionRectangle, proper rounding needs to be performed.