### PR TITLE
Scale shell for edit-part tip by monitor zoom #860

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/EditPartTipHelper.java
@@ -76,6 +76,7 @@ class EditPartTipHelper extends org.eclipse.draw2d.PopUpHelper {
 			// Display the tip
 			EditPartTipHelper.setHelper(this);
 			getLightweightSystem().setContents(tip);
+			tip.translateToAbsolute(tipSize);
 			setShellBounds(tipPosX, tipPosY, tipSize.width, tipSize.height);
 			show();
 			getShell().setCapture(true);


### PR DESCRIPTION
The size of the shell that is created to show the tool-tip is calculated using the unscaled size of the figure. If the Draw2D-based auto-scaling is enabled, this then causes the shell to be sized as if at 100% zoom.

Closes https://github.com/eclipse-gef/gef-classic/issues/860