### PR TITLE
Embed tracker for dragging flyout palette composite into control

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -951,8 +951,8 @@ public class FlyoutPaletteComposite extends Composite {
 			if (paletteContainer.getVisible()) {
 				bounds = bounds.union(paletteContainer.getBounds());
 			}
-			final Rectangle origBounds = Display.getCurrent().map(flyout, null, bounds);
-			final Tracker tracker = new Tracker(Display.getDefault(), SWT.NULL);
+			final Rectangle origBounds = bounds;
+			final Tracker tracker = new Tracker(flyout, SWT.NULL);
 			tracker.setRectangles(new Rectangle[] { origBounds });
 			tracker.setStippled(true);
 			tracker.addListener(SWT.Move, evt -> {
@@ -982,7 +982,6 @@ public class FlyoutPaletteComposite extends Composite {
 						placeHolder = new Rectangle(flyoutBounds.width - origBounds.width, 0, origBounds.width,
 								origBounds.height);
 					}
-					placeHolder = Display.getCurrent().map(flyout, null, placeHolder);
 				}
 				// update the cursor
 				int cursor;


### PR DESCRIPTION
The tracker for dragging the flyout palette is currently instantiated on the display rather than the control itself. This leads to offsets with monitor-specific scaling on Windows, as the display is lacking the monitor-specific zoom context.

This change adapts the tracker to operate on the flyout palette control rather than the display. It simplifies the implementation as the control/display coordinate conversions can be removed.

Fixes https://github.com/eclipse-gef/gef-classic/issues/868

### Before
![flyout_broken](https://github.com/user-attachments/assets/2d198d9d-287f-4ece-a471-6884e4e5f0aa)

### After
![flyout_fixed](https://github.com/user-attachments/assets/e70f1724-7126-456e-94d4-36ea2fa04d06)

My only concern is that I wonder why the implementation used the (more complex) logic via the display at all and did not just embed it into the view.

Very seldom I see that palette is drawn over the tracker border
<img width="211" height="308" alt="image" src="https://github.com/user-attachments/assets/c661f0da-2d17-4b6c-908a-f0364d26e1bd" />
which then may also leave behind an artifact of the border aftwards
<img width="207" height="70" alt="image" src="https://github.com/user-attachments/assets/19fa95ac-d69e-48c8-8a55-60a4580238d4" />
which will just disappear when any redraw is triggered (e.g., by hovering over it).

Maybe that was a reason or maybe the implementation even goes back to a time where trackers did not work (well) on controls.