### PR TITLE
Fix PrecisionRectangle#getBottom inconsistency

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -174,4 +174,19 @@ public class PrecisionRectangleTest extends BaseTestCase {
 		assertEquals(rect.getBottomRight().y - rect.getTopLeft().y, rect.height);
 	}
 
+	@SuppressWarnings("static-method")
+	@Test
+	public void testConsistencyGetBottom() {
+		Rectangle rect = new PrecisionRectangle(100.5, 100.5, 250.5, 250.5);
+		assertEquals(rect.getBottomRight().y, rect.getBottom().y);
+		assertEquals(rect.getBottomLeft().y, rect.getBottom().y);
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testConsistencyGetTop() {
+		Rectangle rect = new PrecisionRectangle(100.5, 100.5, 250.5, 250.5);
+		assertEquals(rect.getTopRight().y, rect.getTop().y);
+		assertEquals(rect.getTopLeft().y, rect.getTop().y);
+	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -225,7 +225,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 */
 	@Override
 	public Point getBottom() {
-		return new PrecisionPoint(preciseX() + preciseWidth() / 2, bottom());
+		return new PrecisionPoint(preciseX() + preciseWidth() / 2, preciseY() + preciseHeight());
 	}
 
 	/**


### PR DESCRIPTION
The y value of `PrecisionRectangle#getBottom` can return a different y value to `PrecisionRectangle#getBottomLeft` and
`PrecisionRectangle#getBottomRight` because the first uses the int values the later two use precision values. This commit adapt `PrecisionRectangle#getBottom` to use the precision values as well.

Similar applies at least to getLeft (only regarding the center y coord) and getRight, as both are not overwritten in PrecisionRectangle, but I did not touch them for this PR.