### PR TITLE
Create custom cursor for 100%, 150% and 200% zoom #872

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SharedCursors.java
@@ -60,7 +60,13 @@ public class SharedCursors extends Cursors {
 		if (ImageUtils.isSvgSupported()) {
 			ImageDescriptor src1 = InternalImages.createDescriptor(sourceName);
 			ImageDescriptor src2 = InternalCursor.getCursorDescriptor();
-			ImageDescriptor src = new DecorationOverlayIcon(src1, src2, IDecoration.TOP_LEFT);
+			ImageDescriptor src = new DecorationOverlayIcon(src1, src2, IDecoration.TOP_LEFT) {
+				@Override
+				// Disabled by default due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=97506
+				protected boolean supportsZoomLevel(int zoomLevel) {
+					return true;
+				}
+			};
 			return InternalGEFPlugin.createCursor(src, 0, 0);
 		}
 		ImageDescriptor src = InternalImages.createDescriptor(sourceName);

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalCursor.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalCursor.java
@@ -13,21 +13,9 @@
 
 package org.eclipse.gef.internal;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.PaletteData;
-import org.eclipse.swt.graphics.Path;
-import org.eclipse.swt.widgets.Display;
-
 import org.eclipse.jface.resource.ImageDescriptor;
-
-import org.eclipse.draw2d.ColorConstants;
 
 /**
  * This class defines the shape of the default GEF-cursor used for the plug/tree
@@ -38,89 +26,25 @@ import org.eclipse.draw2d.ColorConstants;
  */
 public class InternalCursor {
 	/**
-	 * Defines the shape of the cursor at 100% zoom.
-	 */
-	//@formatter:off
-	private static final float[] CURSOR_POINTS = {
-			 0f,  0f,
-			 0f, 17f,
-			 4f, 13f,
-			 7f, 19f,
-			 9f, 18f,
-			 7f, 13f,
-			 7f, 12f,
-			12f, 12f,
-			 0f,  0f
-	};
-	//@formatter:on
-	/**
 	 * Local cache to store the cursor data for each zoom level.
 	 */
-	private static final Map<Integer, ImageData> CURSOR_AT_ZOOM = new HashMap<>();
+	private static final ImageDescriptor CURSOR_AT_100_ZOOM = InternalImages.createDescriptor("icons/cursor@1x.svg"); //$NON-NLS-1$
+	private static final ImageDescriptor CURSOR_AT_150_ZOOM = InternalImages.createDescriptor("icons/cursor@1.5x.svg"); //$NON-NLS-1$
+	private static final ImageDescriptor CURSOR_AT_200_ZOOM = InternalImages.createDescriptor("icons/cursor@2x.svg"); //$NON-NLS-1$
 	/**
 	 * The default cursor that is constructed using {link {@link #CURSOR_POINTS}.
 	 * May be replaced with a custom cursor by calling
 	 * {@link #setCursorDescriptor(ImageDescriptor)}.
 	 */
-	private static ImageDescriptor CURRENT_CURSOR_DESCRIPTOR = ImageDescriptor
-			.createFromImageDataProvider(zoom -> CURSOR_AT_ZOOM.computeIfAbsent(zoom, InternalCursor::getCursorAtZoom));
-
-	/**
-	 * This method generates the image data for the cursor at the given zoom level.
-	 * The points defined with {@link #CURSOR_POINTS} are scaled by the given zoom
-	 * and painted onto an image.
-	 *
-	 * @param zoom The zoom level. e.g. 100, 125, 200
-	 * @return The cursor image data at the given zoom level.
-	 */
-	private static ImageData getCursorAtZoom(int zoom) {
-		float maxWidth = 0f;
-		float maxHeight = 0f;
-
-		for (int i = 0; i < CURSOR_POINTS.length; i += 2) {
-			maxWidth = Math.max(maxWidth, CURSOR_POINTS[i]);
-			maxHeight = Math.max(maxHeight, CURSOR_POINTS[i + 1]);
+	private static ImageDescriptor CURRENT_CURSOR_DESCRIPTOR = ImageDescriptor.createFromImageDataProvider(zoom -> {
+		if (zoom < 150) {
+			return CURSOR_AT_100_ZOOM.getImageData(100);
 		}
-
-		float zoomFactor = zoom / 100.0f;
-
-		int width = 1 + (int) Math.ceil(zoomFactor * maxWidth);
-		int height = 1 + (int) Math.ceil(zoomFactor * maxHeight);
-
-		//
-		Display display = Display.getDefault();
-		// Construct path
-		Path path = new Path(display);
-		for (int i = 0; i < CURSOR_POINTS.length; i += 2) {
-			float x = zoomFactor * CURSOR_POINTS[i];
-			float y = zoomFactor * CURSOR_POINTS[i + 1];
-			if (i == 0) {
-				path.moveTo(x, y);
-			} else {
-				path.lineTo(x, y);
-			}
+		if (zoom < 200) {
+			return CURSOR_AT_150_ZOOM.getImageData(100);
 		}
-		// Construct image
-		ImageData imageData = new ImageData(width, height, 32, new PaletteData(0xFF0000, 0x00FF00, 0x0000FF));
-		imageData.alphaData = new byte[width * height];
-		Image image = new Image(display, imageData);
-		GC gc = new GC(image);
-		gc.setAlpha(0);
-		gc.fillRectangle(0, 0, width, height);
-		gc.setAlpha(255);
-		gc.setAntialias(SWT.ON);
-		gc.setLineWidth(1);
-		gc.setBackground(ColorConstants.white);
-		gc.fillPath(path);
-		gc.setBackground(ColorConstants.black);
-		gc.drawPath(path);
-		gc.dispose();
-		path.dispose();
-		// Image is already scaled to expected zoom level
-		imageData = image.getImageData(100);
-		image.dispose();
-		return imageData;
-	}
+		return CURSOR_AT_200_ZOOM.getImageData(100);
+	});
 
 	/**
 	 * Returns the image descriptor for the GEF cursor. Never {@code null}.

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
@@ -127,9 +127,18 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 	 */
 	public static Cursor createCursor(ImageDescriptor source, int hotspotX, int hotspotY) {
 		try {
+			ImageDataProvider provider = zoom -> {
+				if (zoom < 150) {
+					return source.getImageData(100);
+				}
+				if (zoom < 200) {
+					return source.getImageData(150);
+				}
+				return source.getImageData(200);
+			};
 			Constructor<Cursor> ctor = Cursor.class.getConstructor(Device.class, ImageDataProvider.class, int.class,
 					int.class);
-			return ctor.newInstance(null, (ImageDataProvider) source::getImageData, hotspotX, hotspotY);
+			return ctor.newInstance(null, provider, hotspotX, hotspotY);
 		} catch (NoSuchMethodException e) {
 			// SWT version < 3.131.0 (no ImageDataProvider-based constructor)
 			return new Cursor(null, source.getImageData(100), hotspotX, hotspotY); // older constructor

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/cursor@1.5x.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/cursor@1.5x.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     transform="translate(0,-0.05476875)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0.1322915,0.18708826 V 6.8016437 l 1.5875,-1.4551806 1.190625,2.38125 0.7937499,-0.396875 -0.7937499,-1.984375 v -0.396875 h 1.9843749 z"
+       id="path1516" />
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/cursor@1x.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/cursor@1x.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666665 8.4666666"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     transform="translate(0,-0.18706042)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0.13229166,0.31937992 V 4.8172966 L 1.190625,3.7589632 1.984375,5.3464632 2.5135417,5.0818799 1.984375,3.7589632 V 3.4943799 h 1.3229167 z"
+       id="path1516" />
+  </g>
+</svg>

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/icons/cursor@2x.svg
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/icons/cursor@2x.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933332"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     transform="translate(0,-0.1870604)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0.1322915,0.31937992 V 8.7860464 L 2.2489581,7.1985465 3.8364581,10.373547 4.8947914,9.8443798 3.8364581,7.1985465 V 6.6693798 h 2.6458333 z"
+       id="path1516" />
+  </g>
+</svg>


### PR DESCRIPTION
At least on Windows and Linux, the operating system doesn't seem to linearly scale the system cursor.

Instead, predefined cursor images are used for:

- ( ..., 150%) - Cursor at 100% monitor zoom
- [150%, 200%) - Cursor at 150% monitor zoom
- (200%,  ...) - Cursor at 200% monitor zoom

SWT is linearly scaling the cursor icon. So if at e.g. 125% zoom, the cursor inside the widget will be scaled to 125% zoom but is not scaled outside the widget.

To account for this, the SWT-based cursor is replaced with three cursor SVGs, one for each of those zoom levels. Note that the images are split up to make sure the line width is exactly one for each cursor.

Closes https://github.com/eclipse-gef/gef-classic/issues/872