### PR TITLE
Fix PrecisionRectangle#getLeft #getRight inconsistency

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionRectangleTest.java
@@ -189,4 +189,22 @@ public class PrecisionRectangleTest extends BaseTestCase {
 		assertEquals(rect.getTopRight().y, rect.getTop().y);
 		assertEquals(rect.getTopLeft().y, rect.getTop().y);
 	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testConsistencyGetLeft() {
+		Rectangle rect = new PrecisionRectangle(100.5, 100.5, 250.5, 250.5);
+		assertEquals(rect.getTopLeft().x, rect.getLeft().x);
+		assertEquals(rect.getBottomLeft().x, rect.getLeft().x);
+		assertEquals(rect.getRight().y, rect.getLeft().y);
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testConsistencyGetRight() {
+		Rectangle rect = new PrecisionRectangle(100.5, 100.5, 250.5, 250.5);
+		assertEquals(rect.getTopRight().x, rect.getRight().x);
+		assertEquals(rect.getBottomRight().x, rect.getRight().x);
+		assertEquals(rect.getLeft().y, rect.getRight().y);
+	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -221,6 +221,22 @@ public final class PrecisionRectangle extends Rectangle {
 	}
 
 	/**
+	 * @see org.eclipse.draw2d.geometry.Rectangle#getLeft()
+	 */
+	@Override
+	public Point getLeft() {
+		return new PrecisionPoint(preciseX(), preciseY() + preciseHeight() / 2);
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.Rectangle#getRight()
+	 */
+	@Override
+	public Point getRight() {
+		return new PrecisionPoint(preciseX() + preciseWidth(), preciseY() + preciseHeight() / 2);
+	}
+
+	/**
 	 * @see org.eclipse.draw2d.geometry.Rectangle#getBottom()
 	 */
 	@Override


### PR DESCRIPTION
Similar to #870, the x/y value of PrecisionRectangle#getLeft and PrecisionRectangle#getRight can return a different x or y value in comparision to the behavior of the other directional methods in PrecisionRectangle as #getBottomLeft. This PR overrides #getLeft and #getRight in PrecisionRectangle.