### PR TITLE
Combine ScaledGraphics when layering them

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ScaledGraphicsTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/ScaledGraphicsTest.java
@@ -52,6 +52,32 @@ public class ScaledGraphicsTest {
 
 	@Test
 	@SuppressWarnings("static-method")
+	public void testTranlsationWithMulipleScaledLayers() {
+		Display display = Display.getDefault();
+		Image image = new Image(display, 100, 100);
+		GC gc = new GC(image);
+		RecordingSwtGraphics graphics = new RecordingSwtGraphics(gc);
+		ScaledGraphics scaledGraphics = new ScaledGraphics(graphics);
+		scaledGraphics.scale(1.5);
+		scaledGraphics.translate(1f, 1f);
+		ScaledGraphics scaledGraphics2 = new ScaledGraphics(scaledGraphics);
+		scaledGraphics2.scale(2.5);
+		scaledGraphics2.translate(1f, 1f);
+
+		scaledGraphics2.drawRectangle(0, 0, 10, 10);
+		assertEquals(5, graphics.translation.x);
+		assertEquals(5, graphics.translation.y);
+
+		validateDrawRectangle(graphics, new Rectangle(5, 5, 37, 37));
+		scaledGraphics2.dispose();
+		scaledGraphics.dispose();
+		graphics.dispose();
+		gc.dispose();
+		image.dispose();
+	}
+
+	@Test
+	@SuppressWarnings("static-method")
 	public void testDrawLineForRegression() {
 		RecordingSwtGraphics swtGraphics = executeTranslatedWithOneLayer(200, 250,
 				scaledGraphics -> scaledGraphics.drawLine(new Point(5, 5), new Point(5, 5 + 20)));
@@ -1108,8 +1134,8 @@ public class ScaledGraphicsTest {
 
 		@Override
 		public void translate(int dx, int dy) {
-			translation.setX(dx);
-			translation.setY(dy);
+			translation.setX(translation.x + dx);
+			translation.setY(translation.y + dy);
 		}
 
 		@Override

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
@@ -165,7 +165,14 @@ public class ScaledGraphics extends Graphics {
 	 * @param g the base graphics object
 	 */
 	public ScaledGraphics(Graphics g) {
-		graphics = g;
+		if (g instanceof ScaledGraphics scaledGraphics) {
+			graphics = scaledGraphics.graphics;
+			zoom = scaledGraphics.zoom;
+			fractionalX = scaledGraphics.fractionalX;
+			fractionalY = scaledGraphics.fractionalY;
+		} else {
+			graphics = g;
+		}
 		localFont = g.getFont();
 		localLineWidth = g.getLineWidthFloat();
 	}


### PR DESCRIPTION
This PR improves layering of `ScaledGraphics` but not creating several `ScaledGraphics` on top of each other but aggregating each new `ScaledGraphics` instance to inherit the state of the parent. This is probably a way simpler solution than #834 and could make the changes to `ScaledGraphics` there unnecessary. Due to my testing all looks fine with this approach and it would improve the handling of font scaling (that was the one limitation from #834).

Do you see any possible problems with this?