### PR TITLE
Internalize deprecated fields in precision geometry classes

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2024 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
+
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 /**
  * @author Randy Hudson
@@ -38,6 +40,16 @@ public class PrecisionDimension extends Dimension {
 	 */
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseWidth;
+
+	/**
+	 * Fractional part of the height.
+	 */
+	private double fractHeight;
+
+	/**
+	 * Fractional part of the width.
+	 */
+	private double fractWidth;
 
 	/**
 	 * Constructs a new precision dimension.
@@ -176,7 +188,7 @@ public class PrecisionDimension extends Dimension {
 	@Override
 	public double preciseHeight() {
 		updatePreciseHeightDouble();
-		return preciseHeight;
+		return height + fractHeight;
 	}
 
 	/**
@@ -185,7 +197,7 @@ public class PrecisionDimension extends Dimension {
 	@Override
 	public double preciseWidth() {
 		updatePreciseWidthDouble();
-		return preciseWidth;
+		return width + fractWidth;
 	}
 
 	/**
@@ -209,13 +221,14 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * Sets the height.
 	 *
-	 * @param h the new height
+	 * @param preciseHeight the new height
 	 * @return this for convenience
 	 * @since 3.7
 	 */
-	public PrecisionDimension setPreciseHeight(double h) {
-		preciseHeight = h;
+	public PrecisionDimension setPreciseHeight(double preciseHeight) {
+		this.preciseHeight = preciseHeight;
 		updateHeightInt();
+		fractHeight = preciseHeight - height;
 		return this;
 	}
 
@@ -247,13 +260,14 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * Sets the width.
 	 *
-	 * @param w the new width
+	 * @param preciseWidth the new width
 	 * @return this for convenience
 	 * @since 3.7
 	 */
-	public PrecisionDimension setPreciseWidth(double w) {
-		preciseWidth = w;
+	public PrecisionDimension setPreciseWidth(double preciseWidth) {
+		this.preciseWidth = preciseWidth;
 		updateWidthInt();
+		fractWidth = preciseWidth - width;
 		return this;
 	}
 
@@ -378,6 +392,9 @@ public class PrecisionDimension extends Dimension {
 	private final void updatePreciseWidthDouble() {
 		if (width != PrecisionGeometry.doubleToInteger(preciseWidth)) {
 			preciseWidth = width;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractWidth = 0;
+			}
 		}
 	}
 
@@ -387,6 +404,9 @@ public class PrecisionDimension extends Dimension {
 	private final void updatePreciseHeightDouble() {
 		if (height != PrecisionGeometry.doubleToInteger(preciseHeight)) {
 			preciseHeight = height;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractHeight = 0;
+			}
 		}
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
+
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
 
 /**
  * @author danlee
@@ -38,6 +40,16 @@ public class PrecisionPoint extends Point {
 	 */
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseY;
+
+	/**
+	 * Fractional part of X.
+	 */
+	private double fractX;
+
+	/**
+	 * Fractional part of Y.
+	 */
+	private double fractY;
 
 	/**
 	 * Constructor for PrecisionPoint.
@@ -163,7 +175,7 @@ public class PrecisionPoint extends Point {
 	@Override
 	public double preciseX() {
 		updatePreciseXDouble();
-		return preciseX;
+		return x + fractX;
 	}
 
 	/**
@@ -172,7 +184,7 @@ public class PrecisionPoint extends Point {
 	@Override
 	public double preciseY() {
 		updatePreciseYDouble();
-		return preciseY;
+		return y + fractY;
 	}
 
 	/**
@@ -230,26 +242,28 @@ public class PrecisionPoint extends Point {
 	/**
 	 * Sets the precise x value of this PrecisionPoint to the given value.
 	 *
-	 * @param x The new x value
+	 * @param preciseX The new x value
 	 * @return this for convenience
 	 * @since 3.7
 	 */
-	public PrecisionPoint setPreciseX(double x) {
-		preciseX = x;
+	public PrecisionPoint setPreciseX(double preciseX) {
+		this.preciseX = preciseX;
 		updateXInt();
+		fractX = preciseX - x;
 		return this;
 	}
 
 	/**
 	 * Sets the precise y value of this PrecisionPoint to the given value.
 	 *
-	 * @param y The new y value
+	 * @param preciseY The new y value
 	 * @return this for convenience
 	 * @since 3.7
 	 */
-	public PrecisionPoint setPreciseY(double y) {
-		preciseY = y;
+	public PrecisionPoint setPreciseY(double preciseY) {
+		this.preciseY = preciseY;
 		updateYInt();
+		fractY = preciseY - y;
 		return this;
 	}
 
@@ -363,6 +377,9 @@ public class PrecisionPoint extends Point {
 	private final void updatePreciseXDouble() {
 		if (x != PrecisionGeometry.doubleToInteger(preciseX)) {
 			preciseX = x;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractX = 0;
+			}
 		}
 	}
 
@@ -372,6 +389,9 @@ public class PrecisionPoint extends Point {
 	private final void updatePreciseYDouble() {
 		if (y != PrecisionGeometry.doubleToInteger(preciseY)) {
 			preciseY = y;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractY = 0;
+			}
 		}
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.draw2d.internal.InternalDraw2dUtils;
+
 /**
  * A Rectangle implementation using floating point values which are truncated
  * into the inherited integer fields. The use of floating point prevents
@@ -63,6 +65,26 @@ public final class PrecisionRectangle extends Rectangle {
 	 */
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseY;
+
+	/**
+	 * Fractional part of the height.
+	 */
+	private double fractHeight;
+
+	/**
+	 * Fractional part of the width.
+	 */
+	private double fractWidth;
+
+	/**
+	 * Fractional part of X.
+	 */
+	private double fractX;
+
+	/**
+	 * Fractional part of Y.
+	 */
+	private double fractY;
 
 	/**
 	 * Constructs a new PrecisionRectangle with all values 0.
@@ -355,7 +377,7 @@ public final class PrecisionRectangle extends Rectangle {
 	@Override
 	public double preciseHeight() {
 		updatePreciseHeightDouble();
-		return preciseHeight;
+		return height + fractHeight;
 	}
 
 	/**
@@ -373,7 +395,7 @@ public final class PrecisionRectangle extends Rectangle {
 	@Override
 	public double preciseWidth() {
 		updatePreciseWidthDouble();
-		return preciseWidth;
+		return width + fractWidth;
 	}
 
 	/**
@@ -382,7 +404,7 @@ public final class PrecisionRectangle extends Rectangle {
 	@Override
 	public double preciseX() {
 		updatePreciseXDouble();
-		return preciseX;
+		return x + fractX;
 	}
 
 	/**
@@ -391,7 +413,7 @@ public final class PrecisionRectangle extends Rectangle {
 	@Override
 	public double preciseY() {
 		updatePreciseYDouble();
-		return preciseY;
+		return y + fractY;
 	}
 
 	/**
@@ -531,6 +553,7 @@ public final class PrecisionRectangle extends Rectangle {
 	public PrecisionRectangle setPreciseHeight(double value) {
 		preciseHeight = value;
 		updateHeightInt();
+		fractHeight = value - height;
 		return this;
 	}
 
@@ -598,6 +621,7 @@ public final class PrecisionRectangle extends Rectangle {
 	public PrecisionRectangle setPreciseWidth(double value) {
 		preciseWidth = value;
 		updateWidthInt();
+		fractWidth = value - width;
 		return this;
 	}
 
@@ -611,6 +635,7 @@ public final class PrecisionRectangle extends Rectangle {
 	public PrecisionRectangle setPreciseX(double value) {
 		preciseX = value;
 		updateXInt();
+		fractX = value - x;
 		return this;
 	}
 
@@ -624,6 +649,7 @@ public final class PrecisionRectangle extends Rectangle {
 	public PrecisionRectangle setPreciseY(double value) {
 		preciseY = value;
 		updateYInt();
+		fractY = value - y;
 		return this;
 	}
 
@@ -985,6 +1011,9 @@ public final class PrecisionRectangle extends Rectangle {
 	private final void updatePreciseHeightDouble() {
 		if (height != getHeightInt()) {
 			preciseHeight = height;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractHeight = 0;
+			}
 		}
 	}
 
@@ -994,6 +1023,9 @@ public final class PrecisionRectangle extends Rectangle {
 	private final void updatePreciseWidthDouble() {
 		if (width != getWidthInt()) {
 			preciseWidth = width;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractWidth = 0;
+			}
 		}
 	}
 
@@ -1003,6 +1035,9 @@ public final class PrecisionRectangle extends Rectangle {
 	private final void updatePreciseXDouble() {
 		if (x != PrecisionGeometry.doubleToInteger(preciseX)) {
 			preciseX = x;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractX = 0;
+			}
 		}
 	}
 
@@ -1012,6 +1047,9 @@ public final class PrecisionRectangle extends Rectangle {
 	private final void updatePreciseYDouble() {
 		if (y != PrecisionGeometry.doubleToInteger(preciseY)) {
 			preciseY = y;
+			if (InternalDraw2dUtils.isClearDecimalPart()) {
+				fractY = 0;
+			}
 		}
 	}
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -35,6 +35,20 @@ public class InternalDraw2dUtils {
 	private static final String DRAW2D_ENABLE_AUTOSCALE = "draw2d.enableAutoscale"; //$NON-NLS-1$
 
 	/**
+	 * System property that controls whether the decimal part in one of the precise
+	 * geometry classes is cleared if the integer field is modified.
+	 *
+	 * Example: <code>
+	 * PrecisionPoint p = new PrecisionPoint(1.5, 1.5);
+	 * p.x = 2;
+	 * System.out.println(p.preciseX()); // returns 2.0 and not 2.5
+	 * </code>
+	 *
+	 * The current default is "false".
+	 */
+	private static final String DRAW2D_CLEAR_DECIMAL_PART = "draw2d.clearDecimalPart"; //$NON-NLS-1$
+
+	/**
 	 * Internal flag for fetching the shell zoom
 	 */
 	private static final String DATA_SHELL_ZOOM = "SHELL_ZOOM"; //$NON-NLS-1$
@@ -53,6 +67,12 @@ public class InternalDraw2dUtils {
 	private static final boolean enableAutoScale = "win32".equals(SWT.getPlatform()) //$NON-NLS-1$
 			&& Boolean.parseBoolean(System.getProperty(DRAW2D_ENABLE_AUTOSCALE, Boolean.TRUE.toString()))
 			&& SWT.getVersion() >= 4971; // SWT 2025-12 release or higher
+
+	private static final boolean clearDecimalPart = Boolean.getBoolean(DRAW2D_CLEAR_DECIMAL_PART);
+
+	public static final boolean isClearDecimalPart() {
+		return clearDecimalPart;
+	}
 
 	public static boolean isAutoScaleEnabled() {
 		return enableAutoScale;


### PR DESCRIPTION
The public fields of the PrecisionPoint, PrecisionRectangle and PrecisionDimension have been annotated with @noreference with 7865d7b918e456cb110405030e31e059ea045f38 and deprecated with 390e597e7523d4739154be895934b19997931f0f, over 15 years ago.

With this change, those fields are finally made private.