### PR TITLE
Correct mapping of tracker size for FlyoutPaletteComposite movement

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -951,6 +951,7 @@ public class FlyoutPaletteComposite extends Composite {
 			if (paletteContainer.getVisible()) {
 				bounds = bounds.union(paletteContainer.getBounds());
 			}
+			final Point origSize = new Point(bounds.width, bounds.height);
 			final Rectangle origBounds = Display.getCurrent().map(flyout, null, bounds);
 			final Tracker tracker = new Tracker(Display.getDefault(), SWT.NULL);
 			tracker.setRectangles(new Rectangle[] { origBounds });
@@ -977,10 +978,10 @@ public class FlyoutPaletteComposite extends Composite {
 				Rectangle placeHolder = origBounds;
 				if (switchDock) {
 					if (dock == PositionConstants.EAST) {
-						placeHolder = new Rectangle(0, 0, origBounds.width, origBounds.height);
+						placeHolder = new Rectangle(0, 0, origSize.x, origSize.y);
 					} else {
-						placeHolder = new Rectangle(flyoutBounds.width - origBounds.width, 0, origBounds.width,
-								origBounds.height);
+						placeHolder = new Rectangle(flyoutBounds.width - origSize.x, flyoutBounds.height - origSize.y,
+								origSize.x, origSize.y);
 					}
 					placeHolder = Display.getCurrent().map(flyout, null, placeHolder);
 				}


### PR DESCRIPTION
When dragging a flyout palette, a tracker on the Display is instantiated to show a preview of the drag result. When different zooms are involved (such as when using Draw2d autoscaling for the monitor-specific scaling capability on Windows), the tracker preview has a wrong size on non-100% monitors. This is caused by multiple Display#map() methods being applied on the same rectangle, which leads to the zoom being applied multiple times.

This change adapts the preview size calculation to prevent that the map operation (and thus the zoom) is not applied multiple times to the width and height of the preview rectangle. The change is backward compatible as without monitor-specific scaling capabilities and Draw2d autoscaling there are no zoom transformations involved, which is why the multiple map operations applied did not lead to any issues.

Fixes https://github.com/eclipse-gef/gef-classic/issues/868

For the tracker preview to work properly, a recent SWT state is also required, as an SWT fix is also necessary to make the tracker work properly:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2799

This supercedes and thus closes #https://github.com/eclipse-gef/gef-classic/pull/869
It is less invasive and thus better preserves existing behavior and reduces the risk of regressions.


### Before
![flyout_tracker_broken](https://github.com/user-attachments/assets/8d022c54-3cd7-4306-9856-7f547f616d1f)

### After
![flyout_tracker_fixed](https://github.com/user-attachments/assets/fa0f675e-945c-4084-83ee-5e71c8d9dad9)
