### PR TITLE
Implement remaining methods of PrecisionPointList

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -44,6 +44,7 @@ import org.junit.platform.suite.api.Suite;
 	PointListTests.class,
 	PrecisionDimensionTest.class,
 	PrecisionPointTest.class,
+	PrecisionPointListTest.class,
 	PrecisionRectangleTest.class,
 	ThumbnailTest.class,
 	FigurePaintingTest.class,

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionPointListTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/PrecisionPointListTest.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PrecisionPoint;
+import org.eclipse.draw2d.geometry.PrecisionPointList;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JUnit Tests for {@link PrecisionPointList}.
+ */
+public class PrecisionPointListTest {
+	private static final double EPSILON = 1e-14;
+
+	private static PrecisionPointList create(double... doublePoints) {
+		if (doublePoints.length % 2 != 0) {
+			throw new IllegalArgumentException("The number of points must be event: " + doublePoints.length); //$NON-NLS-1$
+		}
+		int[] intPoints = new int[doublePoints.length];
+		PrecisionPointList p = new PrecisionPointList(intPoints);
+		double[] decimalFractions = p.toDoubleArray();
+		for (int i = 0; i < doublePoints.length; i += 2) {
+			intPoints[i] = (int) Math.floor(doublePoints[i]);
+			intPoints[i + 1] = (int) Math.floor(doublePoints[i + 1]);
+			decimalFractions[i] = doublePoints[i] - intPoints[i];
+			decimalFractions[i + 1] = doublePoints[i + 1] - intPoints[i + 1];
+		}
+		return p;
+	}
+
+	private PrecisionPointList source;
+	private Point p;
+
+	@BeforeEach
+	public void setUp() {
+		source = create(1.5, 2.33, 8.14, 6.91);
+		p = new PrecisionPoint();
+	}
+
+	@Test
+	public void testAddAll() {
+		source.addAll(create(1.33, 7.19));
+		assertArrayEquals(new int[] { 1, 2, 8, 6, 1, 7 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.5, 0.33, 0.14, 0.91, 0.33, 0.19 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testAddPoint() {
+		source.addPoint(new PrecisionPoint(3.4, 8.53));
+		assertArrayEquals(new int[] { 1, 2, 8, 6, 3, 8 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.5, 0.33, 0.14, 0.91, 0.4, 0.53 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testGetCopy() {
+		PrecisionPointList copy = (PrecisionPointList) source.getCopy();
+		assertNotSame(source, copy);
+		assertNotSame(source.toIntArray(), copy.toIntArray());
+		assertNotSame(source.toDoubleArray(), copy.toDoubleArray());
+		assertArrayEquals(new int[] { 1, 2, 8, 6 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.5, 0.33, 0.14, 0.91 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testGetPointI() {
+		p = source.getPoint(0);
+		assertEquals(1.5, p.preciseX(), EPSILON);
+		assertEquals(2.33, p.preciseY(), EPSILON);
+		p = source.getPoint(1);
+		assertEquals(8.14, p.preciseX(), EPSILON);
+		assertEquals(6.91, p.preciseY(), EPSILON);
+	}
+
+	@Test
+	public void testGetPointII() {
+		source.getPoint(p, 0);
+		assertEquals(1.5, p.preciseX(), EPSILON);
+		assertEquals(2.33, p.preciseY(), EPSILON);
+		source.getPoint(p, 1);
+		assertEquals(8.14, p.preciseX(), EPSILON);
+		assertEquals(6.91, p.preciseY(), EPSILON);
+	}
+
+	@Test
+	public void testInsertPoint() {
+		source.insertPoint(new PrecisionPoint(4.13, 7.31), 1);
+		assertArrayEquals(new int[] { 1, 2, 4, 7, 8, 6 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.5, 0.33, 0.13, 0.31, 0.14, 0.91 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testPerformScale() {
+		source.performScale(7.13);
+		assertArrayEquals(new int[] { 10, 16, 58, 49 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.695, 0.6129, 0.0382, 0.2683 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testRemovePoint() {
+		p = source.removePoint(1);
+		assertEquals(8.14, p.preciseX(), EPSILON);
+		assertEquals(6.91, p.preciseY(), EPSILON);
+		assertArrayEquals(new int[] { 1, 2 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.5, 0.33 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testReverse() {
+		source.reverse();
+		assertArrayEquals(new int[] { 8, 6, 1, 2 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.14, 0.91, 0.5, 0.33 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testSetPoint() {
+		source.setPoint(new PrecisionPoint(2.33, 1.5), 0);
+		source.setPoint(new PrecisionPoint(8.14, 7.33), 1);
+		assertArrayEquals(new int[] { 2, 1, 8, 7 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.33, 0.5, 0.14, 0.33 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testSetSizeI() {
+		source.setSize(3);
+		assertEquals(source.size(), 3);
+		assertArrayEquals(new int[] { 1, 2, 8, 6, 0, 0 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.5, 0.33, 0.14, 0.91, 0.0, 0.0 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testSetSizeII() {
+		source.setSize(1);
+		assertEquals(source.size(), 1);
+		assertArrayEquals(new int[] { 1, 2 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.5, 0.33 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testTranspose() {
+		source.transpose();
+		assertArrayEquals(new int[] { 2, 1, 6, 8 }, source.toIntArray());
+		assertArrayEquals(new double[] { 0.33, 0.5, 0.91, 0.14 }, source.toDoubleArray(), EPSILON);
+	}
+
+	@Test
+	public void testGetBounds() {
+		Rectangle r = source.getBounds();
+		assertEquals(1.5, r.preciseX(), EPSILON);
+		assertEquals(2.33, r.preciseY(), EPSILON);
+		assertEquals(6.64, r.preciseWidth(), EPSILON);
+		assertEquals(4.58, r.preciseHeight(), EPSILON);
+	}
+}

--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.draw2d;singleton:=true
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.1.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.draw2d,

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PointList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PointList.java
@@ -64,7 +64,7 @@ public class PointList implements java.io.Serializable, Translatable {
 	 */
 	public void addAll(PointList source) {
 		ensureCapacity(size + source.size);
-		System.arraycopy(source.points, 0, points, size * 2, source.size * 2);
+		System.arraycopy(source.points, 0, points, arraySize(), source.arraySize());
 		size += source.size;
 	}
 
@@ -88,7 +88,7 @@ public class PointList implements java.io.Serializable, Translatable {
 	 */
 	public void addPoint(int x, int y) {
 		bounds = null;
-		int index = size * 2;
+		int index = arraySize();
 		ensureCapacity(size + 1);
 		points[index] = x;
 		points[index + 1] = y;
@@ -100,7 +100,7 @@ public class PointList implements java.io.Serializable, Translatable {
 		if (points.length < newSize) {
 			int old[] = points;
 			points = new int[Math.max(newSize, size * 4)];
-			System.arraycopy(old, 0, points, 0, size * 2);
+			System.arraycopy(old, 0, points, 0, arraySize());
 		}
 	}
 
@@ -114,7 +114,7 @@ public class PointList implements java.io.Serializable, Translatable {
 		if (bounds != null) {
 			return bounds;
 		}
-		bounds = new Rectangle();
+		bounds = createBounds();
 		if (size > 0) {
 			bounds.setLocation(getPoint(0));
 			for (int i = 0; i < size; i++) {
@@ -124,6 +124,12 @@ public class PointList implements java.io.Serializable, Translatable {
 		return bounds;
 	}
 
+	@SuppressWarnings("static-method")
+	// overridden by PrecisionPointList
+	/* package */ Rectangle createBounds() {
+		return new Rectangle();
+	}
+
 	/**
 	 * Creates a copy
 	 *
@@ -131,7 +137,7 @@ public class PointList implements java.io.Serializable, Translatable {
 	 */
 	public PointList getCopy() {
 		PointList result = new PointList(size);
-		System.arraycopy(points, 0, result.points, 0, size * 2);
+		System.arraycopy(points, 0, result.points, 0, arraySize());
 		result.size = size;
 		result.bounds = null;
 		return result;
@@ -256,7 +262,7 @@ public class PointList implements java.io.Serializable, Translatable {
 		if (r.isEmpty()) {
 			return false;
 		}
-		for (int i = 0; i < size * 2; i += 2) {
+		for (int i = 0; i < arraySize(); i += 2) {
 			if (r.contains(points[i], points[i + 1])) {
 				return true;
 			}
@@ -290,7 +296,7 @@ public class PointList implements java.io.Serializable, Translatable {
 	 */
 	@Override
 	public void performTranslate(int dx, int dy) {
-		for (int i = 0; i < size * 2; i += 2) {
+		for (int i = 0; i < arraySize(); i += 2) {
 			points[i] += dx;
 			points[i + 1] += dy;
 		}
@@ -329,8 +335,8 @@ public class PointList implements java.io.Serializable, Translatable {
 
 		index *= 2;
 		Point pt = new Point(points[index], points[index + 1]);
-		if (index != size * 2 - 2) {
-			System.arraycopy(points, index + 2, points, index, size * 2 - index - 2);
+		if (index != arraySize() - 2) {
+			System.arraycopy(points, index + 2, points, index, arraySize() - index - 2);
 		}
 		size--;
 		return pt;
@@ -343,7 +349,7 @@ public class PointList implements java.io.Serializable, Translatable {
 	 */
 	public void reverse() {
 		int temp;
-		for (int i = 0, j = size * 2 - 2; i < size; i += 2, j -= 2) {
+		for (int i = 0, j = arraySize() - 2; i < size; i += 2, j -= 2) {
 			temp = points[i];
 			points[i] = points[j];
 			points[j] = temp;
@@ -396,6 +402,10 @@ public class PointList implements java.io.Serializable, Translatable {
 		return size;
 	}
 
+	/* package */ int arraySize() {
+		return size * 2;
+	}
+
 	/**
 	 * Returns the contents of this PointList as an integer array. The returned
 	 * array is by reference. Any changes made to the array will also be changing
@@ -405,10 +415,10 @@ public class PointList implements java.io.Serializable, Translatable {
 	 * @since 2.0
 	 */
 	public int[] toIntArray() {
-		if (points.length != size * 2) {
+		if (points.length != arraySize()) {
 			int[] old = points;
-			points = new int[size * 2];
-			System.arraycopy(old, 0, points, 0, size * 2);
+			points = new int[arraySize()];
+			System.arraycopy(old, 0, points, 0, arraySize());
 		}
 		return points;
 	}
@@ -442,7 +452,7 @@ public class PointList implements java.io.Serializable, Translatable {
 		if (bounds != null) {
 			bounds.translate(x, y);
 		}
-		for (int i = 0; i < size * 2; i += 2) {
+		for (int i = 0; i < arraySize(); i += 2) {
 			points[i] += x;
 			points[i + 1] += y;
 		}
@@ -458,7 +468,7 @@ public class PointList implements java.io.Serializable, Translatable {
 		if (bounds != null) {
 			bounds.transpose();
 		}
-		for (int i = 0; i < size * 2; i += 2) {
+		for (int i = 0; i < arraySize(); i += 2) {
 			temp = points[i];
 			points[i] = points[i + 1];
 			points[i + 1] = temp;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPointList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPointList.java
@@ -16,9 +16,10 @@ package org.eclipse.draw2d.geometry;
 import java.util.Arrays;
 
 /**
- * A PointList implementation using floating point values which are truncated
- * into the inherited integer fields. The use of floating point prevents
- * rounding errors from accumulating.
+ * A PointList implementation using floating point values. The use of floating
+ * point prevents rounding errors from accumulating. For the sake of
+ * compatibility with the integer-precision {@link PointList}, the integer
+ * coordinates and their decimal part are stored in two separate arrays.
  *
  * <strong>EXPERIMENTAL</strong> This class has been added as part of a work in
  * progress and there is no guarantee that this API will remain unchanged. This
@@ -28,8 +29,24 @@ import java.util.Arrays;
  * @noreference This class is not intended to be referenced by clients.
  */
 public final class PrecisionPointList extends PointList {
-	private static final Point PRIVATE_POINT = new Point();
-	private double[] precisePoints = {};
+	private static final PrecisionPoint PRIVATE_POINT = new PrecisionPoint();
+	private double[] decimalFractions = {};
+
+	/**
+	 * Constructs an empty PrecisionPointList
+	 */
+	public PrecisionPointList() {
+	}
+
+	/**
+	 * Constructs a PrecisionPointList with the given size.
+	 *
+	 * @param size Number of points to hold.
+	 */
+	public PrecisionPointList(int size) {
+		super(size);
+		decimalFractions = new double[size * 2];
+	}
 
 	/**
 	 * Constructs a PrecisionPointList with the given points.
@@ -39,7 +56,7 @@ public final class PrecisionPointList extends PointList {
 	 */
 	public PrecisionPointList(int[] points) {
 		super(points);
-		precisePoints = Arrays.stream(points).asDoubleStream().toArray();
+		decimalFractions = new double[points.length];
 	}
 
 	/**
@@ -48,30 +65,194 @@ public final class PrecisionPointList extends PointList {
 	 * @param points PointList from which the initial values are taken
 	 */
 	public PrecisionPointList(PointList points) {
-		this(points.getCopy().toIntArray());
-	}
-
-	@Override
-	public void performScale(double factor) {
-		for (int i = 0; i < precisePoints.length; ++i) {
-			precisePoints[i] *= factor;
-		}
-		for (int i = 0; i < size(); ++i) {
-			updateIntPoint(i);
+		this(Arrays.copyOf(points.toIntArray(), points.arraySize()));
+		if (points instanceof PrecisionPointList other) {
+			System.arraycopy(other.decimalFractions, 0, decimalFractions, 0, arraySize());
 		}
 	}
 
 	/**
-	 * Updates the int-point at the given index using its precise coordinates.
+	 * @see org.eclipse.draw2d.geometry.PointList#addAll(PointList)
 	 */
-	private void updateIntPoint(int i) {
-		getPoint(PRIVATE_POINT, i);
-		int preciseX = PrecisionGeometry.doubleToInteger(precisePoints[i * 2]);
-		int preciseY = PrecisionGeometry.doubleToInteger(precisePoints[i * 2 + 1]);
-		if (preciseX != PRIVATE_POINT.x || preciseY != PRIVATE_POINT.y) {
-			PRIVATE_POINT.x = preciseX;
-			PRIVATE_POINT.y = preciseY;
+	@Override
+	public void addAll(PointList points) {
+		ensureCapacity(size() + points.size());
+		if (points instanceof PrecisionPointList other) {
+			System.arraycopy(other.decimalFractions, 0, decimalFractions, arraySize(), other.arraySize());
+		}
+		super.addAll(points);
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#addPoint(Point)
+	 */
+	@Override
+	public void addPoint(Point point) {
+		ensureCapacity(size() + 1);
+		if (point instanceof PrecisionPoint) {
+			int index = arraySize();
+			decimalFractions[index] = point.preciseX() - point.x;
+			decimalFractions[index + 1] = point.preciseY() - point.y;
+		}
+		super.addPoint(point);
+	}
+
+	@Override
+	/* package */ Rectangle createBounds() {
+		return new PrecisionRectangle();
+	}
+
+	private void ensureCapacity(int newSize) {
+		int arraySize = newSize * 2;
+		if (decimalFractions.length < arraySize) {
+			decimalFractions = Arrays.copyOf(decimalFractions, Math.max(arraySize, size() * 4));
+		}
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#getCopy()
+	 */
+	@Override
+	public PointList getCopy() {
+		return new PrecisionPointList(this);
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#getPoint(int)
+	 */
+	@Override
+	public Point getPoint(int index) {
+		return getPoint(new PrecisionPoint(), index);
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#getPoint(Point, int)
+	 */
+	@Override
+	public Point getPoint(Point point, int index) {
+		super.getPoint(point, index);
+		int arrayIndex = index * 2;
+		// Ignore decimal part for integer-precision points
+		if (point instanceof PrecisionPoint precisePoint) {
+			precisePoint.translate(decimalFractions[arrayIndex], decimalFractions[arrayIndex + 1]);
+		}
+		return point;
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#insertPoint(Point, int)
+	 */
+	@Override
+	public void insertPoint(Point p, int index) {
+		super.insertPoint(p, index);
+		int length = decimalFractions.length;
+		double old[] = decimalFractions;
+		decimalFractions = new double[length + 2];
+		int arrayIndex = index * 2;
+		System.arraycopy(old, 0, decimalFractions, 0, arrayIndex);
+		System.arraycopy(old, arrayIndex, decimalFractions, arrayIndex + 2, length - arrayIndex);
+		decimalFractions[arrayIndex] = p.preciseX() - p.x;
+		decimalFractions[arrayIndex + 1] = p.preciseY() - p.y;
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#performScale(double)
+	 */
+	@Override
+	public void performScale(double factor) {
+		for (int i = 0; i < size(); ++i) {
+			getPoint(PRIVATE_POINT, i);
+			PRIVATE_POINT.scale(factor);
 			setPoint(PRIVATE_POINT, i);
+		}
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#removePoint(int)
+	 */
+	@Override
+	public Point removePoint(int index) {
+		int arraySize = arraySize();
+		Point pt1 = super.removePoint(index);
+		int arrayIndex = index * 2;
+		Point pt2 = new PrecisionPoint(decimalFractions[arrayIndex], decimalFractions[arrayIndex + 1]);
+		// If not the last point
+		if (arrayIndex != arraySize - 2) {
+			System.arraycopy(decimalFractions, arrayIndex + 2, decimalFractions, arrayIndex,
+					arraySize - arrayIndex - 2);
+		}
+		pt2.translate(pt1);
+		return pt2;
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#reverse()
+	 */
+	@Override
+	public void reverse() {
+		super.reverse();
+		double temp;
+		for (int i = 0, j = arraySize() - 2; i < size(); i += 2, j -= 2) {
+			temp = decimalFractions[i];
+			decimalFractions[i] = decimalFractions[j];
+			decimalFractions[j] = temp;
+			temp = decimalFractions[i + 1];
+			decimalFractions[i + 1] = decimalFractions[j + 1];
+			decimalFractions[j + 1] = temp;
+		}
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#setPoint(Point, int)
+	 */
+	@Override
+	public void setPoint(Point point, int index) {
+		super.setPoint(point, index);
+		int arrayIndex = index * 2;
+		decimalFractions[arrayIndex] = point.preciseX() - point.x;
+		decimalFractions[arrayIndex + 1] = point.preciseY() - point.y;
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#setSize(int)
+	 */
+	@Override
+	public void setSize(int newSize) {
+		super.setSize(newSize);
+		int arraySize = newSize * 2;
+		if (decimalFractions.length > arraySize) {
+			return;
+		}
+		decimalFractions = Arrays.copyOf(decimalFractions, arraySize);
+	}
+
+	/**
+	 * Returns the decimal fractions of this PointList as an double array. The
+	 * returned array is by reference. Any changes made to the array will also be
+	 * changing the original PointList.
+	 *
+	 * @return the double array of decimal fractions by reference
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public double[] toDoubleArray() {
+		int arraySize = arraySize();
+		if (decimalFractions.length != arraySize) {
+			decimalFractions = Arrays.copyOf(decimalFractions, arraySize);
+		}
+		return decimalFractions;
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.geometry.PointList#transpose()
+	 */
+	@Override
+	public void transpose() {
+		super.transpose();
+		double temp;
+		for (int i = 0; i < arraySize(); i += 2) {
+			temp = decimalFractions[i];
+			decimalFractions[i] = decimalFractions[i + 1];
+			decimalFractions[i + 1] = temp;
 		}
 	}
 }


### PR DESCRIPTION
This overrides all methods in the PointList that require double-precision handling.

Unlike the other precision classes, the double-array in the PrecisionPointList only keeps track of the fractional parts of all points. This has the advantage that we don't need to

Instead of keeping a double-precision copy of the (x,y) coordinates of all contained points, the PrecisionPointList only keeps the decimal parts. This safes us the overhead of keeping both arrays in sync, at the cost of a minor overhead when accessing the precise points.

Closes https://github.com/eclipse-gef/gef-classic/issues/883