### PR TITLE
Catch ServiceConfigurationError when JSVG is not in classpath

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/ImageUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/ImageUtils.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ServiceConfigurationError;
 
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.ImageLoader;
@@ -67,8 +68,8 @@ public final class ImageUtils {
 		} catch (IOException ignore) {
 			// Should never happen
 			isSvgSupported = false;
-		} catch (SWTException e) {
-			// SVGs unsupported
+		} catch (SWTException | ServiceConfigurationError e) {
+			// SVGs unsupported / not in classpath
 			isSvgSupported = false;
 		}
 		return isSvgSupported;


### PR DESCRIPTION
When Draw2D is used in a pure Java environment, it might happen that the JSVG library, which provides the SVG support, is not in the classpath.

The call to isSvgSupported() should return `false` in such a situation, rather than throwing a ServiceConfigurationError. This problem can be observed when e.g. running any of the widgets that access an SVG.