### PR TITLE
Use correct generic types in EditPartViewer #903

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@
 
 ## GEF
 
+* Due to an oversight, the generic types of the following type had to be adapted:
+  * Map<~~IFigure~~?, EditPart> EditPartViewer.getVisualPartMap()`
+  * EditPartViewer.findObjectAtExcluding(Point, Collection<~~IFigure~~?>)
+  * EditPartViewer.findObjectAtExcluding(Point, Collection<~~IFigure~~?>, Conditional)
+
+While this change is binarily-compatible, consumers might experience compilation issues if:
+
+a) If the map returned by `getVisualPartMap()` is stored in a local variable.
+b) If `findObjectAtExcluding` is overridden by subclasses.
+
+Reason for this change is the `TreeViewer`, where the visual part of an `EditPart` is
+realized as a `Widget` and not an `IFigure`. For the `findObjectAtExcluding` method
+specifically, the `TreeViewer` is using `EditPart`'s as exclusion set.
+
 ## Zest
 
 ## General

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeContainerEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicTreeContainerEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.gef.examples.logicdesigner.edit;
 import java.util.List;
 
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.EditPart;
@@ -58,14 +59,9 @@ public class LogicTreeContainerEditPolicy extends TreeContainerEditPolicy {
 		int index = findIndexOfTreeItemAt(request.getLocation());
 
 		for (EditPart child : request.getEditParts()) {
-			if (isAncestor(child, getHost())) {
-				command.add(UnexecutableCommand.INSTANCE);
-			} else {
-				LogicSubpart childModel = (LogicSubpart) child.getModel();
-				command.add(createCreateCommand(childModel,
-						new Rectangle(new org.eclipse.draw2d.geometry.Point(), childModel.getSize()), index,
-						"Reparent LogicSubpart"));//$NON-NLS-1$
-			}
+			LogicSubpart childModel = (LogicSubpart) child.getModel();
+			command.add(createCreateCommand(childModel, new Rectangle(new Point(), childModel.getSize()), index,
+					"Reparent LogicSubpart"));//$NON-NLS-1$
 		}
 		return command;
 	}
@@ -97,16 +93,6 @@ public class LogicTreeContainerEditPolicy extends TreeContainerEditPolicy {
 					tempIndex));
 		}
 		return command;
-	}
-
-	protected boolean isAncestor(EditPart source, EditPart target) {
-		if (source == target) {
-			return true;
-		}
-		if (target.getParent() != null) {
-			return isAncestor(source, target.getParent());
-		}
-		return false;
 	}
 
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/DirectEditManagerTest.java
@@ -24,7 +24,6 @@ import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
 import org.eclipse.ui.PlatformUI;
 
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.EditDomain;
@@ -146,7 +145,7 @@ public class DirectEditManagerTest {
 		public EditPartViewer getViewer() {
 			return new AbstractEditPartViewer() {
 				@Override
-				public EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet,
+				public EditPart findObjectAtExcluding(Point location, Collection<?> exclusionSet,
 						Conditional conditional) {
 					return null;
 				}

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gef; singleton:=true
-Bundle-Version: 3.24.100.qualifier
+Bundle-Version: 3.25.0.qualifier
 Bundle-Activator: org.eclipse.gef.internal.InternalGEFPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
@@ -28,7 +28,6 @@ import org.eclipse.jface.util.TransferDragSourceListener;
 import org.eclipse.jface.util.TransferDropTargetListener;
 import org.eclipse.jface.viewers.ISelection;
 
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 /**
@@ -203,10 +202,10 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * {@link #findObjectAt(Point)}.
 	 *
 	 * @param location     The mouse location
-	 * @param exclusionSet The set of IFigures to be excluded
+	 * @param exclusionSet The set of parts to be excluded
 	 * @return <code>null</code> or an EditPart
 	 */
-	EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet);
+	EditPart findObjectAtExcluding(Point location, Collection<?> exclusionSet);
 
 	/**
 	 * Returns <code>null</code> or the <code>EditPart</code> at the specified
@@ -214,11 +213,11 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * similarly to {@link #findObjectAt(Point)}.
 	 *
 	 * @param location     The mouse location
-	 * @param exclusionSet The set of IFigures to be excluded
+	 * @param exclusionSet The set of parts to be excluded
 	 * @param conditional  the Conditional used to evaluate a potential hit
 	 * @return <code>null</code> or an EditPart
 	 */
-	EditPart findObjectAtExcluding(Point location, Collection<IFigure> exclusionSet, Conditional conditional);
+	EditPart findObjectAtExcluding(Point location, Collection<?> exclusionSet, Conditional conditional);
 
 	/**
 	 * Flushes all pending updates to the Viewer.
@@ -419,7 +418,7 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 *
 	 * @return the visual part map
 	 */
-	Map<IFigure, EditPart> getVisualPartMap();
+	Map<?, EditPart> getVisualPartMap();
 
 	/**
 	 * Used for accessibility purposes.

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDropTargetListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/AbstractTransferDropTargetListener.java
@@ -26,7 +26,6 @@ import org.eclipse.swt.dnd.TransferData;
 
 import org.eclipse.jface.util.TransferDropTargetListener;
 
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AutoexposeHelper;
@@ -87,9 +86,13 @@ public abstract class AbstractTransferDropTargetListener
 	}
 
 	private EditPart calculateTargetEditPart() {
-		List<IFigure> exclusionFigures = getExclusionSet().stream().filter(GraphicalEditPart.class::isInstance)
-				.map(ep -> ((GraphicalEditPart) ep).getFigure()).collect(Collectors.toList());
-		EditPart ep = getViewer().findObjectAtExcluding(getDropLocation(), exclusionFigures,
+		List<Object> exclusionSet = getExclusionSet().stream().map(o -> {
+			if (o instanceof GraphicalEditPart ep) {
+				return ep.getFigure();
+			}
+			return o;
+		}).collect(Collectors.toList());
+		EditPart ep = getViewer().findObjectAtExcluding(getDropLocation(), exclusionSet,
 				editpart -> editpart.getTargetEditPart(getTargetRequest()) != null);
 		if (ep != null) {
 			ep = ep.getTargetEditPart(getTargetRequest());

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -733,8 +733,9 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#registerVisuals()
 	 */
 	@Override
+	@SuppressWarnings("unchecked")
 	protected void registerVisuals() {
-		getViewer().getVisualPartMap().put(getFigure(), this);
+		((Map<IFigure, EditPart>) getViewer().getVisualPartMap()).put(getFigure(), this);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -44,7 +44,6 @@ import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AccessibleEditPart;
@@ -98,7 +97,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 
 	private EditPartFactory factory;
 	private final Map<Object, EditPart> mapIDToEditPart = new HashMap<>();
-	private final Map<IFigure, EditPart> mapVisualToEditPart = new HashMap<>();
+	private final Map<?, EditPart> mapVisualToEditPart = new HashMap<>();
 	private Map<String, Object> properties;
 	private Control control;
 	private ResourceManager resources;
@@ -253,7 +252,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @see EditPartViewer#findObjectAtExcluding(Point, Collection)
 	 */
 	@Override
-	public final EditPart findObjectAtExcluding(Point pt, Collection<IFigure> exclude) {
+	public final EditPart findObjectAtExcluding(Point pt, Collection<?> exclude) {
 		return findObjectAtExcluding(pt, exclude, null);
 	}
 
@@ -462,7 +461,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @see EditPartViewer#getVisualPartMap()
 	 */
 	@Override
-	public Map<IFigure, EditPart> getVisualPartMap() {
+	public Map<?, EditPart> getVisualPartMap() {
 		return mapVisualToEditPart;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.gef.ui.parts;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DragSource;
@@ -163,7 +164,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	 *      EditPartViewer.Conditional)
 	 */
 	@Override
-	public EditPart findObjectAtExcluding(Point pt, Collection<IFigure> exclude, final Conditional condition) {
+	public EditPart findObjectAtExcluding(Point pt, Collection<?> exclude, final Conditional condition) {
 		class ConditionalTreeSearch extends ExclusionSearch {
 			ConditionalTreeSearch(Collection<IFigure> coll) {
 				super(coll);
@@ -179,8 +180,9 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 				return editpart != null && (condition == null || condition.evaluate(editpart));
 			}
 		}
+		@SuppressWarnings("unchecked")
 		IFigure figure = getLightweightSystem().getRootFigure().findFigureAt(pt.x, pt.y,
-				new ConditionalTreeSearch(exclude));
+				new ConditionalTreeSearch((Collection<IFigure>) exclude));
 		EditPart part = null;
 		while (part == null && figure != null) {
 			part = getVisualPartMap().get(figure);
@@ -240,6 +242,12 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	@Deprecated
 	protected IFigure getRootFigure() {
 		return rootFigure;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Map<IFigure, EditPart> getVisualPartMap() {
+		return (Map<IFigure, EditPart>) super.getVisualPartMap();
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
@@ -13,6 +13,7 @@
 package org.eclipse.gef.ui.parts;
 
 import java.util.Collection;
+import java.util.Map;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusEvent;
@@ -30,6 +31,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
+import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.jface.util.TransferDragSourceListener;
 import org.eclipse.jface.util.TransferDropTargetListener;
@@ -147,7 +149,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 *      EditPartViewer.Conditional)
 	 */
 	@Override
-	public EditPart findObjectAtExcluding(Point pt, Collection exclude, Conditional condition) {
+	public EditPart findObjectAtExcluding(Point pt, Collection<?> exclude, Conditional condition) {
 		if (getControl() == null) {
 			return null;
 		}
@@ -190,6 +192,12 @@ public class TreeViewer extends AbstractEditPartViewer {
 	@Override
 	public Tree getControl() {
 		return (Tree) super.getControl();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Map<Widget, EditPart> getVisualPartMap() {
+		return (Map<Widget, EditPart>) super.getVisualPartMap();
 	}
 
 	/**


### PR DESCRIPTION
The generic type of the following methods has to be adapted, in order to account for the fact that an EditPartViewer might be based on both IFigure's (GraphicalEdiPartViewer) and Widget's (TreeViewer):

- Map<~~IFigure~~?, EditPart> getVisualPartMap()`
- findObjectAtExcluding(Point, Collection<~~IFigure~~?>)
- findObjectAtExcluding(Point, Collection<~~IFigure~~?>, Conditional)

To reduce the impact this has on downstream projects, the `getVisualPartMap()` method is overridden by both the graphical viewer and the tree viewer, where the returned map is casted to its expected type.

For the `findObjectAtExcluding()`, the `IFigure` is only used in the exclusion set for graphical viewers. For tree viewers, the `TreeEdiPart` is used directly.

Closes https://github.com/eclipse-gef/gef-classic/issues/903