### PR TITLE
Make the creation of the PopUpHelper configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Reason for this change is the `TreeViewer`, where the visual part of an `EditPar
 realized as a `Widget` and not an `IFigure`. For the `findObjectAtExcluding` method
 specifically, the `TreeViewer` is using `EditPart`'s as exclusion set.
 
+* Added new `IToolTipHelperFactory` interface that is used as factory in the
+  `DomainEventDispatcher` to create the `ToolTipHelper` instance. Clients may
+  contribute their own implementation via an OSGi service.
+  Alternatively, clients may inject a custom `ToolTipHelper` instance directly
+  by overriding `createToolTipHelper()` in `SWTEventDispatcher`.
+
 ## Zest
 
 ## General

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTEventDispatcher.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTEventDispatcher.java
@@ -350,9 +350,20 @@ public class SWTEventDispatcher extends EventDispatcher {
 	 */
 	protected ToolTipHelper getToolTipHelper() {
 		if (toolTipHelper == null || toolTipHelper.getShell().isDisposed()) {
-			toolTipHelper = new ToolTipHelper(control);
+			toolTipHelper = createToolTipHelper();
 		}
 		return toolTipHelper;
+	}
+
+	/**
+	 * Creates a new {@link ToolTipHelper} instance to be used by
+	 * {@link #getToolTipHelper()}. May be sub-classed.
+	 *
+	 * @return the created ToolTipHelper. Never {@code null}.
+	 * @since 3.22
+	 */
+	protected ToolTipHelper createToolTipHelper() {
+		return new ToolTipHelper(control);
 	}
 
 	/**

--- a/org.eclipse.gef.examples/.project
+++ b/org.eclipse.gef.examples/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/org.eclipse.gef.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.examples/META-INF/MANIFEST.MF
@@ -4,10 +4,11 @@ Bundle-Name: %Plugin.name
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.gef.examples;singleton:=true
-Bundle-Version: 1.0.400.qualifier
+Bundle-Version: 1.1.0.qualifier
 Require-Bundle: org.eclipse.gef;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.ui;bundle-version="[3.206.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.gef.examples
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Service-Component: OSGI-INF/org.eclipse.gef.examples.palette.PaletteSnippet2$PaletteToolTipHelperFactory.xml

--- a/org.eclipse.gef.examples/OSGI-INF/org.eclipse.gef.examples.palette.PaletteSnippet2$PaletteToolTipHelperFactory.xml
+++ b/org.eclipse.gef.examples/OSGI-INF/org.eclipse.gef.examples.palette.PaletteSnippet2$PaletteToolTipHelperFactory.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.gef.examples.palette.PaletteSnippet2$PaletteToolTipHelperFactory">
+   <service>
+      <provide interface="org.eclipse.gef.util.IToolTipHelperFactory"/>
+   </service>
+   <implementation class="org.eclipse.gef.examples.palette.PaletteSnippet2$PaletteToolTipHelperFactory"/>
+</scr:component>

--- a/org.eclipse.gef.examples/build.properties
+++ b/org.eclipse.gef.examples/build.properties
@@ -1,6 +1,7 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
+               OSGI-INF/,\
                plugin.xml,\
                about.html,\
                plugin.properties,\

--- a/org.eclipse.gef.examples/plugin.properties
+++ b/org.eclipse.gef.examples/plugin.properties
@@ -12,4 +12,5 @@
 ###############################################################################
 Plugin.name=Stand-alone GEF examples
 Plugin.providerName=Eclipse GEF
-view.name = Palette with separate fonts
+view1.name = Palette with separate fonts
+view2.name = Palette custom tool-tips

--- a/org.eclipse.gef.examples/plugin.xml
+++ b/org.eclipse.gef.examples/plugin.xml
@@ -6,7 +6,13 @@
       <view
             class="org.eclipse.gef.examples.palette.PaletteSnippet1"
             id="org.eclipse.gef.examples.view1"
-            name="%view.name"
+            name="%view1.name"
+            restorable="true">
+      </view>
+      <view
+            class="org.eclipse.gef.examples.palette.PaletteSnippet2"
+            id="org.eclipse.gef.examples.view2"
+            name="%view2.name"
             restorable="true">
       </view>
    </extension>

--- a/org.eclipse.gef.examples/src/org/eclipse/gef/examples/Messages.java
+++ b/org.eclipse.gef.examples/src/org/eclipse/gef/examples/Messages.java
@@ -19,6 +19,9 @@ public class Messages extends NLS {
 	public static String PaletteSnippet1_System;
 	public static String PaletteSnippet1_Drawer_Font;
 	public static String PaletteSnippet1_Entry_Font;
+	public static String PaletteSnippet2_System;
+	public static String PaletteSnippet2_System_Desc;
+	public static String PaletteSnippet2_Selection_Desc;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/org.eclipse.gef.examples/src/org/eclipse/gef/examples/messages.properties
+++ b/org.eclipse.gef.examples/src/org/eclipse/gef/examples/messages.properties
@@ -1,3 +1,6 @@
 PaletteSnippet1_System=System
 PaletteSnippet1_Drawer_Font=Drawer Font: {0}
 PaletteSnippet1_Entry_Font=Entry Font: {0}
+PaletteSnippet2_System=System
+PaletteSnippet2_System_Desc=This is the description of the palette drawer.
+PaletteSnippet2_Selection_Desc=This is the description of the 'Selection' palette item.

--- a/org.eclipse.gef.examples/src/org/eclipse/gef/examples/palette/PaletteSnippet2.java
+++ b/org.eclipse.gef.examples/src/org/eclipse/gef/examples/palette/PaletteSnippet2.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.examples.palette;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+import org.eclipse.ui.part.ViewPart;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.GridData;
+import org.eclipse.draw2d.GridLayout;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.Label;
+import org.eclipse.draw2d.ToolTipHelper;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.palette.PaletteDrawer;
+import org.eclipse.gef.palette.PaletteEntry;
+import org.eclipse.gef.palette.PaletteRoot;
+import org.eclipse.gef.palette.SelectionToolEntry;
+import org.eclipse.gef.palette.ToolEntry;
+import org.eclipse.gef.ui.palette.PaletteViewer;
+import org.eclipse.gef.util.IToolTipHelperFactory;
+
+import org.eclipse.gef.examples.Messages;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This snippet shows how to customize the tool-tip for the palette viewer. By
+ * using a custom tool-tip helper, we can intercept the generated tool-tip
+ * figure just as it is about to be shown and replace it with our own figure.
+ */
+public class PaletteSnippet2 extends ViewPart {
+	private static final Font BOLD_FONT = new Font(null, "Arial", 12, SWT.BOLD); //$NON-NLS-1$
+	private final PaletteRoot paletteRoot;
+	private PaletteViewer paletteViewer;
+
+	public PaletteSnippet2() {
+		PaletteDrawer paletteDrawer = new PaletteDrawer(Messages.PaletteSnippet2_System);
+		paletteDrawer.setDescription(Messages.PaletteSnippet2_System_Desc);
+		ToolEntry paletteEntry = new SelectionToolEntry();
+		paletteEntry.setDescription(Messages.PaletteSnippet2_Selection_Desc);
+		paletteDrawer.add(paletteEntry);
+		paletteRoot = new PaletteRoot();
+		paletteRoot.add(paletteDrawer);
+	}
+
+	@Override
+	public void createPartControl(Composite parent) {
+		paletteViewer = new CustomPaletteViewer();
+		paletteViewer.createControl(parent);
+		paletteViewer.setPaletteRoot(paletteRoot);
+	}
+
+	@Override
+	public void setFocus() {
+		if (paletteViewer != null) {
+			paletteViewer.getControl().setFocus();
+		}
+	}
+
+	public static class CustomPaletteViewer extends PaletteViewer {
+		// Sub-classed for the PaletteToolTipHelperFactory
+	}
+
+	public static class CustomToolTipHelper extends ToolTipHelper {
+		private final EditPartViewer viewer;
+
+		public CustomToolTipHelper(Control c, EditPartViewer viewer) {
+			super(c);
+			this.viewer = viewer;
+		}
+
+		@Override
+		public void displayToolTipNear(IFigure hoverSource, IFigure tip, int eventX, int eventY) {
+			IFigure figureToShow = createCustomToolTip(hoverSource);
+			if (figureToShow == null) {
+				figureToShow = tip;
+			}
+			super.displayToolTipNear(hoverSource, figureToShow, eventX, eventY);
+		}
+
+		private IFigure createCustomToolTip(IFigure hoverSource) {
+			EditPart editPart = findEditPart(hoverSource);
+			if (editPart == null || !(editPart.getModel() instanceof PaletteEntry paletteEntry)) {
+				return null;
+			}
+			IFigure customFigure = new Figure();
+			customFigure.setLayoutManager(new GridLayout());
+			Label label1 = new Label(paletteEntry.getLabel());
+			label1.setFont(BOLD_FONT);
+			customFigure.add(label1, new GridData(SWT.FILL, SWT.FILL, true, false));
+			Label label2 = new Label(paletteEntry.getDescription());
+			customFigure.add(label2, new GridData(SWT.FILL, SWT.FILL, true, true));
+			return customFigure;
+		}
+
+		private EditPart findEditPart(IFigure fig) {
+			EditPart editPart = viewer.getVisualPartMap().get(fig);
+			if (editPart != null) {
+				return editPart;
+			}
+
+			if (fig.getParent() != null) {
+				return findEditPart(fig.getParent());
+			}
+
+			return null;
+		}
+	}
+
+	@Component
+	public static class PaletteToolTipHelperFactory implements IToolTipHelperFactory {
+		@Override
+		public ToolTipHelper create(Control control, EditPartViewer viewer) {
+			if (viewer.getClass() == CustomPaletteViewer.class) {
+				return new CustomToolTipHelper(control, viewer);
+			}
+			return null;
+		}
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/DomainEventDispatcher.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/DomainEventDispatcher.java
@@ -30,12 +30,15 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.draw2d.EventDispatcher;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.SWTEventDispatcher;
+import org.eclipse.draw2d.ToolTipHelper;
 import org.eclipse.draw2d.geometry.Point;
 
 import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.EditDomain;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.internal.InternalGEFPlugin;
+import org.eclipse.gef.util.IToolTipHelperFactory;
 
 /**
  * A special event dispatcher that will route events to the {@link EditDomain}
@@ -245,6 +248,20 @@ public class DomainEventDispatcher extends SWTEventDispatcher {
 		domain = d;
 		viewer = v;
 		setEnableKeyTraversal(false);
+	}
+
+	/**
+	 * @see org.eclipse.draw2d.SWTEventDispatcher#createToolTipHelper()
+	 */
+	@Override
+	protected ToolTipHelper createToolTipHelper() {
+		for (IToolTipHelperFactory factory : InternalGEFPlugin.getToolTipHelperFactories()) {
+			ToolTipHelper toolTipHelper = factory.create(control, getViewer());
+			if (toolTipHelper != null) {
+				return toolTipHelper;
+			}
+		}
+		return super.createToolTipHelper();
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/util/IToolTipHelperFactory.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/util/IToolTipHelperFactory.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.util;
+
+import org.eclipse.swt.widgets.Control;
+
+import org.eclipse.draw2d.SWTEventDispatcher;
+import org.eclipse.draw2d.ToolTipHelper;
+
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.ui.parts.DomainEventDispatcher;
+
+/**
+ * OSGi service used within the {@link DomainEventDispatcher} to inject a custom
+ * {@link ToolTipHelper}.
+ *
+ * @since 3.25
+ */
+public interface IToolTipHelperFactory {
+	/**
+	 * Creates and returns a new {@link ToolTipHelper} instance. This method may
+	 * return {@code null}, if this factory can't create a helper for the given
+	 * edit-part viewer.
+	 * <p>
+	 * - If multiple services are registered, the first non-null
+	 * {@link ToolTipHelper} is used.
+	 * </p>
+	 * <p>
+	 * - If no {@link ToolTipHelper} could be created,
+	 * {@link SWTEventDispatcher#createToolTipHelper()} is used.
+	 * </p>
+	 *
+	 * @param control The {@code control} associated with the
+	 *                {@link DomainEventDispatcher}
+	 * @param viewer  The {@code viewer} associated with the
+	 *                {@link DomainEventDispatcher}.
+	 * @return as described.
+	 */
+	ToolTipHelper create(Control control, EditPartViewer viewer);
+}


### PR DESCRIPTION
This introduces a new `IToolTipHelperFactory` that is used as an OSGi service in the `DomainEventDispatcher` to allow consumers to inject their own `ToolTipHelper`.

It is currently very difficult to customize the tool-tips shown by an edit-part viewer in any meaningful ways, as one has to:

a) Subclass the event dispatcher to use a custom tool-tip helper b) Subclass the LWS to use this custom event dispatcher c) Subclass the viewer to use this custom LWS

A similar customization was already done in the past via e9839e7588032a97ede7c1fbdb8503d7a0b908aa. The advantage of using a service is that it allows implementations to customize the tool-tip of a specific viewer, rather than all viewers.