### PR TITLE
Further refinement of the return type of getVisualPartMap() #903

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ## GEF
 
 * Due to an oversight, the generic types of the following type had to be adapted:
-  * Map<~~IFigure~~?, EditPart> EditPartViewer.getVisualPartMap()`
+  * <T> Map<~~IFigure~~T, EditPart> EditPartViewer.getVisualPartMap()`
   * EditPartViewer.findObjectAtExcluding(Point, Collection<~~IFigure~~?>)
   * EditPartViewer.findObjectAtExcluding(Point, Collection<~~IFigure~~?>, Conditional)
 

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
@@ -418,7 +418,7 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 *
 	 * @return the visual part map
 	 */
-	Map<?, EditPart> getVisualPartMap();
+	<T> Map<T, EditPart> getVisualPartMap();
 
 	/**
 	 * Used for accessibility purposes.

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/AbstractGraphicalEditPart.java
@@ -733,9 +733,8 @@ public abstract class AbstractGraphicalEditPart extends AbstractEditPart impleme
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#registerVisuals()
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	protected void registerVisuals() {
-		((Map<IFigure, EditPart>) getViewer().getVisualPartMap()).put(getFigure(), this);
+		getViewer().getVisualPartMap().put(getFigure(), this);
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -461,8 +461,9 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 * @see EditPartViewer#getVisualPartMap()
 	 */
 	@Override
-	public Map<?, EditPart> getVisualPartMap() {
-		return mapVisualToEditPart;
+	@SuppressWarnings("unchecked")
+	public <T> Map<T, EditPart> getVisualPartMap() {
+		return (Map<T, EditPart>) mapVisualToEditPart;
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/GraphicalViewerImpl.java
@@ -247,7 +247,7 @@ public class GraphicalViewerImpl extends AbstractEditPartViewer implements Graph
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<IFigure, EditPart> getVisualPartMap() {
-		return (Map<IFigure, EditPart>) super.getVisualPartMap();
+		return super.getVisualPartMap();
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/TreeViewer.java
@@ -197,7 +197,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Map<Widget, EditPart> getVisualPartMap() {
-		return (Map<Widget, EditPart>) super.getVisualPartMap();
+		return super.getVisualPartMap();
 	}
 
 	/**


### PR DESCRIPTION
This is a continuation of c5b0306ff812205be4d9dd6b554c476b0fd61095. Due to this change, consumers may now experience a compilation error when calling `getViewer().getVisualPartMap().put(...)`.

When calling `getVisualPartMap()`, a wildcard generic map is returned, which does not allow the addition of values. To get around this, one has to cast the map to a specific type, which is not something that should be done on consumer side. But the keys also can't be plain `Object`s, because this prevents overriding this method in sub-classes.

To get around this limitation, the following approach is taken: The signature in the `EditPartViewer` interface is changed so that this method returns a generic map. The generic type is not specified, so calling `getVisualPartMap()` returns a `Map<Object,EditPart`, which allows the addition of entries.

But when inside the AbstractEditPartViewer, this method can be overridden to return a `Map<?,EditPart`, which can then be overridden again for the `GraphicalEditPartViewer` and the `TreeEditPartViewer`.