### PR TITLE
Add missing `@SuppressWarnings` where deprecated types are used

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Dtycho-version=5.0.1
+-Dcbi-ecj-version=3.44.0

--- a/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/EditPartViewer.java
@@ -102,6 +102,7 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * @deprecated Use {@link #addDragSourceListener(TransferDragSourceListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.21", forRemoval = true)
 	void addDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener);
 
@@ -123,6 +124,7 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * @deprecated Use {@link #addDragSourceListener(TransferDragSourceListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.21", forRemoval = true)
 	void addDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener);
 
@@ -436,6 +438,7 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * @deprecated Use {@link #removeDragSourceListener(TransferDragSourceListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.0", forRemoval = true)
 	void removeDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener);
 
@@ -457,6 +460,7 @@ public interface EditPartViewer extends org.eclipse.jface.viewers.ISelectionProv
 	 * @deprecated Use {@link #removeDropTargetListener(TransferDropTargetListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.0", forRemoval = true)
 	void removeDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener);
 

--- a/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStack.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStack.java
@@ -135,6 +135,7 @@ public class CommandStack {
 	 *             {@link #notifyListeners()}. This field will be removed after the
 	 *             2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.11", forRemoval = true)
 	protected List<CommandStackListener> listeners = new CopyOnWriteArrayList<>();
 
@@ -173,6 +174,7 @@ public class CommandStack {
 	 *             {@link #addCommandStackEventListener(CommandStackEventListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.11", forRemoval = true)
 	public void addCommandStackListener(CommandStackListener listener) {
 		listeners.add(listener);
@@ -402,6 +404,7 @@ public class CommandStack {
 	 * @deprecated Use {@link CommandStackEventListener} instead. This method will
 	 *             be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.11", forRemoval = true)
 	public void removeCommandStackListener(CommandStackListener listener) {
 		listeners.remove(listener);

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDragAdapter.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDragAdapter.java
@@ -50,6 +50,7 @@ public class DelegatingDragAdapter extends org.eclipse.jface.util.DelegatingDrag
 	 *             {@link #addDragSourceListener(org.eclipse.jface.util.TransferDragSourceListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.0", forRemoval = true)
 	public void addDragSourceListener(TransferDragSourceListener listener) {
 		super.addDragSourceListener(listener);
@@ -76,6 +77,7 @@ public class DelegatingDragAdapter extends org.eclipse.jface.util.DelegatingDrag
 	 *             {@link #removeDragSourceListener(org.eclipse.jface.util.TransferDragSourceListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.0", forRemoval = true)
 	public void removeDragSourceListener(TransferDragSourceListener listener) {
 		super.removeDragSourceListener(listener);

--- a/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDropAdapter.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/dnd/DelegatingDropAdapter.java
@@ -43,6 +43,7 @@ public class DelegatingDropAdapter extends org.eclipse.jface.util.DelegatingDrop
 	 *             {@link #addDropTargetListener(org.eclipse.jface.util.TransferDropTargetListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.0", forRemoval = true)
 	public void addDropTargetListener(TransferDropTargetListener listener) {
 		super.addDropTargetListener(listener);
@@ -67,6 +68,7 @@ public class DelegatingDropAdapter extends org.eclipse.jface.util.DelegatingDrop
 	 *             {@link #removeDropTargetListener(org.eclipse.jface.util.TransferDropTargetListener)}
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.21", forRemoval = true)
 	public void removeDropTargetListener(TransferDropTargetListener listener) {
 		super.removeDropTargetListener(listener);

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/AbstractEditPartViewer.java
@@ -144,6 +144,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
 	@Override
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.21", forRemoval = true)
 	public void addDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener) {
 		addDragSourceListener((TransferDragSourceListener) listener);
@@ -164,6 +165,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
 	@Override
+	@SuppressWarnings("removal")
 	@Deprecated(since = "3.21", forRemoval = true)
 	public void addDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener) {
 		addDropTargetListener((TransferDropTargetListener) listener);
@@ -572,6 +574,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
 	@Deprecated(since = "3.0", forRemoval = true)
+	@SuppressWarnings("removal")
 	@Override
 	public void removeDragSourceListener(org.eclipse.gef.dnd.TransferDragSourceListener listener) {
 		removeDragSourceListener((TransferDragSourceListener) listener);
@@ -594,6 +597,7 @@ public abstract class AbstractEditPartViewer implements EditPartViewer {
 	 *             instead. This method will be removed after the 2027-03 release.
 	 */
 	@Deprecated(since = "3.0", forRemoval = true)
+	@SuppressWarnings("removal")
 	@Override
 	public void removeDropTargetListener(org.eclipse.gef.dnd.TransferDropTargetListener listener) {
 		removeDropTargetListener((TransferDropTargetListener) listener);

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/ConstraintAdapter.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/ConstraintAdapter.java
@@ -21,13 +21,13 @@ import org.eclipse.zest.layouts.constraints.LayoutConstraint;
  * an up-to-date list).
  *
  * @author Ian Bull
- * @deprecated No longer used in Zest 2.x. This class will be removed in a
- *             future release in accordance with the two year deprecation
- *             policy.
+ * @deprecated No longer used in Zest 2.x. This class will be after the 2026-12
+ *             release.
  * @noextend This interface is not intended to be extended by clients.
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "1.12", forRemoval = true)
 public interface ConstraintAdapter {
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -304,10 +304,10 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 * Adds a new constraint adapter to the list of constraint adapters
 	 *
 	 * @param constraintAdapter
-	 * @deprecated No longer used in Zest 2.x. This class will be removed in a
-	 *             future release in accordance with the two year deprecation
-	 *             policy.
+	 * @deprecated No longer used in Zest 2.x. This method will be removed after the
+	 *             2026-12 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "2.0", forRemoval = true)
 	public void addConstraintAdapter(ConstraintAdapter constraintAdapter) {
 		this.constraintAdapters.add(constraintAdapter);
@@ -317,10 +317,10 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 * Sets the constraint adapters on this model
 	 *
 	 * @param constraintAdapters
-	 * @deprecated No longer used in Zest 2.x. This class will be removed in a
-	 *             future release in accordance with the two year deprecation
-	 *             policy.
+	 * @deprecated No longer used in Zest 2.x. This method will be removed after the
+	 *             2026-12 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "2.0", forRemoval = true)
 	public void setConstraintAdapters(List<ConstraintAdapter> constraintAdapters) {
 		this.constraintAdapters = constraintAdapters;
@@ -1159,9 +1159,10 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	}
 
 	/**
-	 * @deprecated Not used in Zest 2.x. This method will be removed in a future
-	 *             release in accordance with the two year deprecation policy.
+	 * @deprecated Not used in Zest 2.x. This method will be removed after the
+	 *             2026-12 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "1.12", forRemoval = true)
 	LayoutRelationship[] getConnectionsToLayout(List<GraphNode> nodesToLayout) {
 		// @tag zest.bug.156528-Filters.follows : make sure not to layout
@@ -1189,9 +1190,10 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	}
 
 	/**
-	 * @deprecated Not used in Zest 2.x. This method will be removed in a future
-	 *             release in accordance with the two year deprecation policy.
+	 * @deprecated Not used in Zest 2.x. This method will be removed after the
+	 *             2026-12 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "1.12", forRemoval = true)
 	LayoutEntity[] getNodesToLayout(List<? extends GraphNode> nodes) {
 		// @tag zest.bug.156528-Filters.follows : make sure not to layout
@@ -1369,10 +1371,10 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 *
 	 * @param object
 	 * @param constraint
-	 * @deprecated No longer used in Zest 2.x. This class will be removed in a
-	 *             future release in accordance with the two year deprecation
-	 *             policy.
+	 * @deprecated No longer used in Zest 2.x. This method will be removed after the
+	 *             2026-12 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "2.0", forRemoval = true)
 	void invokeConstraintAdapters(Object object, LayoutConstraint constraint) {
 		if (constraintAdapters == null) {

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -86,8 +86,10 @@ public class GraphConnection extends GraphItem {
 
 	private boolean highlighted;
 	/**
-	 * @deprecated Not used in Zest 2.x. This class will be removed in a future
-	 *             release in accordance with the two year deprecation policy.
+	 * /**
+	 *
+	 * @deprecated Not used in Zest 2.x. This field will be removed after the
+	 *             2026-12 release.
 	 */
 	@Deprecated(since = "1.12", forRemoval = true)
 	private GraphLayoutConnection layoutConnection = null;
@@ -218,12 +220,13 @@ public class GraphConnection extends GraphItem {
 	/**
 	 * Gets a proxy to this connection that can be used with the Zest layout engine
 	 *
-	 * @deprecated Not used in Zest 2.x. This class will be removed in a future
-	 *             release in accordance with the two year deprecation policy.
+	 * @deprecated Not used in Zest 2.x. This method will be removed after the
+	 *             2026-12 release.
 	 * @nooverride This method is not intended to be re-implemented or extended by
 	 *             clients.
 	 * @noreference This method is not intended to be referenced by clients.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "1.12", forRemoval = true)
 	public LayoutRelationship getLayoutRelationship() {
 		return this.layoutConnection;
@@ -233,9 +236,8 @@ public class GraphConnection extends GraphItem {
 	 * Gets the external connection object.
 	 *
 	 * @return Object
-	 * @deprecated Use {@link #getData()} instead. This class will be removed in a
-	 *             future release in accordance with the two year deprecation
-	 *             policy.
+	 * @deprecated Use {@link #getData()} instead. This method will be removed after
+	 *             the 2026-12 release.
 	 * @nooverride This method is not intended to be re-implemented or extended by
 	 *             clients.
 	 * @noreference This method is not intended to be referenced by clients.
@@ -761,9 +763,10 @@ public class GraphConnection extends GraphItem {
 	}
 
 	/**
-	 * @deprecated Not used in Zest 2.x. This class will be removed in a future
-	 *             release in accordance with the two year deprecation policy.
+	 * @deprecated Not used in Zest 2.x. This class will be removed after the
+	 *             2026-12 release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "1.12", forRemoval = true)
 	class GraphLayoutConnection implements LayoutRelationship {
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphNode.java
@@ -80,6 +80,7 @@ public class GraphNode extends GraphItem {
 	 * @deprecated Not used in Zest 2.x. This class will be removed in a future
 	 *             release.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "1.12", forRemoval = true)
 	private LayoutEntity layoutEntity;
 
@@ -157,6 +158,7 @@ public class GraphNode extends GraphItem {
 	 * @deprecated Since Zest 2.0, use {@link #GraphNode(IContainer, int, IFigure)},
 	 *             {@link #setText(String)} and {@link #setImage(Image)}.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "1.12", forRemoval = true)
 	public GraphNode(IContainer graphModel, int style, String text, Image image, Object data) {
 		super(graphModel.getGraph(), style, data);
@@ -230,6 +232,7 @@ public class GraphNode extends GraphItem {
 	 *             clients.
 	 * @noreference This method is not intended to be referenced by clients.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "1.12", forRemoval = true)
 	public LayoutEntity getLayoutEntity() {
 		return layoutEntity;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Filter.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Filter.java
@@ -27,7 +27,7 @@ package org.eclipse.zest.layouts;
  * @noimplement This interface is not intended to be implemented by clients.
  * @noreference This interface is not intended to be referenced by clients.
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings({ "javadoc", "removal" })
 @Deprecated(since = "2.0", forRemoval = true)
 public interface Filter {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutAlgorithm.java
@@ -37,12 +37,12 @@ public interface LayoutAlgorithm {
 	 *
 	 * @since 2.0
 	 * @deprecated Use {@link LayoutAlgorithm} instead. This interface will be
-	 *             removed in a future release in accordance with the two year
-	 *             deprecation policy.
+	 *             removed after the 2026-12 release.
 	 * @noextend This interface is not intended to be extended by clients.
 	 * @noreference This interface is not intended to be referenced by clients.
 	 * @noimplement This interface is not intended to be implemented by clients.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "2.0", forRemoval = true)
 	static interface Zest1 extends LayoutAlgorithm {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutEntity.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutEntity.java
@@ -28,7 +28,7 @@ import org.eclipse.zest.layouts.interfaces.NodeLayout;
  * @noreference This interface is not intended to be referenced by clients..
  * @noimplement This interface is not intended to be implemented by clients.
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({ "rawtypes", "removal" })
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutEntity extends Comparable, LayoutItem {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutGraph.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutGraph.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({ "rawtypes", "removal" })
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutGraph {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutRelationship.java
@@ -27,6 +27,7 @@ import org.eclipse.zest.layouts.interfaces.ConnectionLayout;
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutRelationship extends LayoutItem {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/NestedLayoutEntity.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/NestedLayoutEntity.java
@@ -26,7 +26,7 @@ import org.eclipse.zest.layouts.interfaces.SubgraphLayout;
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({ "rawtypes", "removal" })
 @Deprecated(since = "2.0", forRemoval = true)
 public interface NestedLayoutEntity extends LayoutEntity {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Stoppable.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Stoppable.java
@@ -22,6 +22,7 @@ import org.eclipse.zest.layouts.progress.ProgressListener;
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public interface Stoppable {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
@@ -61,7 +61,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @since 2.0
 	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes", "unchecked", "removal" })
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static abstract class Zest1 implements LayoutAlgorithm.Zest1, Stoppable {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/CompositeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/CompositeLayoutAlgorithm.java
@@ -32,6 +32,7 @@ public class CompositeLayoutAlgorithm implements LayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/ContinuousLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/ContinuousLayoutAlgorithm.java
@@ -26,6 +26,7 @@ import org.eclipse.zest.layouts.dataStructures.InternalRelationship;
  * @noextend This class is not intended to be subclassed by clients.
  * @noreference This class is not intended to be referenced by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public abstract class ContinuousLayoutAlgorithm extends AbstractLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
@@ -46,6 +46,7 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
@@ -40,7 +40,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "removal" })
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm.Zest1 {
 
@@ -336,6 +336,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @deprecated Since Zest 2.0, use {@link #GridLayoutAlgorithm()}.
 	 */
 	@Deprecated
+	@SuppressWarnings("removal")
 	public GridLayoutAlgorithm(int style) {
 		this();
 		setResizing(style != LayoutStyles.NO_LAYOUT_NODE_RESIZING);

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
@@ -26,6 +26,7 @@ import org.eclipse.zest.layouts.LayoutStyles;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class HorizontalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
@@ -30,6 +30,7 @@ import org.eclipse.zest.layouts.dataStructures.InternalRelationship;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class HorizontalShift extends AbstractLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
@@ -31,6 +31,7 @@ import org.eclipse.zest.layouts.dataStructures.InternalRelationship;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class HorizontalTreeLayoutAlgorithm extends TreeLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
@@ -43,7 +43,7 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes", "unchecked", "removal" })
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends TreeLayoutAlgorithm.Zest1 {
 		private static final double MAX_DEGREES = Math.PI * 2;
@@ -186,6 +186,7 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @deprecated Since Zest 2.0, use {@link #RadialLayoutAlgorithm()}.
 	 */
 	@Deprecated
+	@SuppressWarnings("removal")
 	public RadialLayoutAlgorithm(int style) {
 		this();
 		setResizing(style != LayoutStyles.NO_LAYOUT_NODE_RESIZING);

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SpringLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SpringLayoutAlgorithm.java
@@ -53,6 +53,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends ContinuousLayoutAlgorithm {
 
@@ -1024,6 +1025,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @deprecated Since Zest 2.0, use {@link #SpringLayoutAlgorithm()}.
 	 */
 	@Deprecated
+	@SuppressWarnings("removal")
 	public SpringLayoutAlgorithm(int style) {
 		this();
 		setResizing(style != LayoutStyles.NO_LAYOUT_NODE_RESIZING);

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
@@ -55,7 +55,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	 * @noreference This class is not intended to be referenced by clients.
 	 * @noinstantiate This class is not intended to be instantiated by clients.
 	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes", "unchecked", "removal" })
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
@@ -26,6 +26,7 @@ import org.eclipse.zest.layouts.LayoutStyles;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class VerticalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/CycleChecker.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/CycleChecker.java
@@ -27,13 +27,13 @@ import org.eclipse.zest.layouts.algorithms.AbstractLayoutAlgorithm;
  * Checks for cycles in the given graph.
  *
  * @author Casey Best
- * @deprecated No longer used in Zest 2.x. This class will be removed in a
- *             future release in accordance with the two year deprecation
- *             policy.
+ * @deprecated No longer used in Zest 2.x. This class will be removed after the
+ *             2026-12 release.
  * @noextend This class is not intended to be subclassed by clients.
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class CycleChecker {
 	/**

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
@@ -20,13 +20,13 @@ import org.eclipse.zest.layouts.dataStructures.DisplayIndependentRectangle;
 import org.eclipse.zest.layouts.dataStructures.InternalNode;
 
 /**
- * @deprecated No longer used in Zest 2.x. This class will be removed in a
- *             future release in accordance with the two year deprecation
- *             policy.
+ * @deprecated No longer used in Zest 2.x. This class will be removed after the
+ *             2026-12 release.
  * @noextend This class is not intended to be subclassed by clients.
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class DynamicScreen {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEdgeConstraints.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEdgeConstraints.java
@@ -21,6 +21,7 @@ package org.eclipse.zest.layouts.constraints;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class BasicEdgeConstraints implements LayoutConstraint {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEntityConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEntityConstraint.java
@@ -22,6 +22,7 @@ package org.eclipse.zest.layouts.constraints;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class BasicEntityConstraint implements LayoutConstraint {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/EntityPriorityConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/EntityPriorityConstraint.java
@@ -22,6 +22,7 @@ package org.eclipse.zest.layouts.constraints;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class EntityPriorityConstraint implements LayoutConstraint {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LabelLayoutConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LabelLayoutConstraint.java
@@ -21,6 +21,7 @@ package org.eclipse.zest.layouts.constraints;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class LabelLayoutConstraint implements LayoutConstraint {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/BendPoint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/BendPoint.java
@@ -25,6 +25,7 @@ import org.eclipse.zest.layouts.LayoutBendPoint;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public class BendPoint extends DisplayIndependentPoint implements LayoutBendPoint {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
@@ -27,7 +27,7 @@ import org.eclipse.zest.layouts.constraints.LayoutConstraint;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({ "rawtypes", "removal" })
 @Deprecated(since = "2.0", forRemoval = true)
 public class InternalNode implements Comparable, LayoutEntity {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
@@ -29,7 +29,7 @@ import org.eclipse.zest.layouts.constraints.LayoutConstraint;
  * @noreference This class is not intended to be referenced by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({ "rawtypes", "removal" })
 @Deprecated(since = "2.0", forRemoval = true)
 public class InternalRelationship implements LayoutRelationship {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
@@ -24,6 +24,7 @@ package org.eclipse.zest.layouts.progress;
  * @noreference This interface is not intended to be referenced by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "2.0", forRemoval = true)
 public interface ProgressListener {
 	/**

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@
 					<logDirectory>${project.build.directory}/ecj</logDirectory>
 					<showWarnings>true</showWarnings>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>ecj</artifactId>
+						<version>${cbi-ecj-version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			
 			<plugin>


### PR DESCRIPTION
With the 4.38 Eclipse release, JDT revised the way deprecations are handled. As a result, referencing a deprecated method/class now produces a deprecation warning, even when used inside another deprecated method/class.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4572