### PR TITLE
Generify Tool.setProperties(Map) #155

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/Tool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/Tool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -256,6 +256,6 @@ public interface Tool {
 	 *                   can be <code>null</code>
 	 * @since 3.1
 	 */
-	void setProperties(Map properties);
+	void setProperties(Map<?, ?> properties);
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/AbstractTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,10 +18,8 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DragSourceEvent;
@@ -1480,15 +1478,11 @@ public abstract class AbstractTool extends org.eclipse.gef.util.FlagSupport impl
 	 * @see org.eclipse.gef.Tool#setProperties(java.util.Map)
 	 */
 	@Override
-	public void setProperties(Map properties) {
+	public void setProperties(Map<?, ?> properties) {
 		if (properties == null) {
 			return;
 		}
-		Iterator entries = properties.entrySet().iterator();
-		while (entries.hasNext()) {
-			Entry entry = (Entry) entries.next();
-			applyProperty(entry.getKey(), entry.getValue());
-		}
+		properties.forEach(this::applyProperty);
 	}
 
 	/**


### PR DESCRIPTION
Consumers may configure GEF tool by setting arbitrary properties. Given that the type of these properties is unknown, we have to use wildcards, rather than Objects. This allows consumers to call `setProperties` with any generic map, without having to do any type-casting.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/155