### PR TITLE
Generify `extendedData` + accessors in Request #155

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/Request.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/Request.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,7 +24,7 @@ import java.util.Map;
 public class Request {
 
 	private Object type;
-	private Map extendedData;
+	private Map<Object, Object> extendedData;
 
 	/**
 	 * Constructs an empty Request
@@ -47,9 +47,9 @@ public class Request {
 	 *
 	 * @return a map to store useful information
 	 */
-	public Map getExtendedData() {
+	public Map<Object, Object> getExtendedData() {
 		if (extendedData == null) {
-			extendedData = new HashMap();
+			extendedData = new HashMap<>();
 		}
 		return extendedData;
 	}
@@ -71,8 +71,9 @@ public class Request {
 	 *
 	 * @param map The new map
 	 */
-	public void setExtendedData(Map map) {
-		extendedData = map;
+	@SuppressWarnings("unchecked")
+	public void setExtendedData(Map<?, ?> map) {
+		extendedData = (Map<Object, Object>) map;
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/SnapToGeometry.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SnapToGeometry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2024 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -222,7 +222,7 @@ public class SnapToGeometry extends SnapToHelper {
 	 * @param far          the right/bottom side of the rectangle
 	 * @return the correction amount or #getThreshold () if no correction was made
 	 */
-	protected double getCorrectionFor(Entry[] entries, Map extendedData, boolean vert, double near, double far) {
+	protected double getCorrectionFor(Entry[] entries, Map<Object, Object> extendedData, boolean vert, double near, double far) {
 		far -= 1.0;
 		double total = near + far;
 		// If the width is even (i.e., odd right now because we have reduced one
@@ -254,7 +254,7 @@ public class SnapToGeometry extends SnapToHelper {
 	 * @param side         which sides should be considered
 	 * @return the correction or #getThreshold () if no correction was made
 	 */
-	protected double getCorrectionFor(Entry[] entries, Map extendedData, boolean vert, double value, int side) {
+	protected double getCorrectionFor(Entry[] entries, Map<Object, Object> extendedData, boolean vert, double value, int side) {
 		double resultMag = getThreshold();
 		double result = getThreshold();
 

--- a/org.eclipse.gef/src/org/eclipse/gef/SnapToGuides.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SnapToGuides.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -155,7 +155,7 @@ public class SnapToGuides extends SnapToHelper {
 	 *                     <code>false</code> for horizontal.
 	 * @return the correction amount or getThreshold() if no correction was made
 	 */
-	protected double getCorrectionFor(int[] guides, double near, double far, Map extendedData, boolean isVertical) {
+	protected double getCorrectionFor(int[] guides, double near, double far, Map<Object, Object> extendedData, boolean isVertical) {
 		far -= 1.0;
 		double total = near + far;
 		// If the width is even, there is no middle pixel so favor the left -
@@ -189,7 +189,7 @@ public class SnapToGuides extends SnapToHelper {
 	 * @param side         the integer indicating which side is being snapped
 	 * @return a correction amount or getThreshold() if no correction was made
 	 */
-	protected double getCorrectionFor(int[] guides, double value, Map extendedData, boolean vert, int side) {
+	protected double getCorrectionFor(int[] guides, double value, Map<Object, Object> extendedData, boolean vert, int side) {
 		double resultMag = getThreshold();
 		double result = getThreshold();
 


### PR DESCRIPTION
The extended data of a request contains arbitrary data. Because the map is supposed to be mutable, the getter has to return a `Map<Object, Object>` and because the request should accept any Map, wildcards have to be used. The unchecked typecast from a `Map<?,?>` to `Map<Object,Object>` is generally safe, as every type is also an `Object`.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/155