### PR TITLE
Add missing type to GuideLayer.getConstraints() #155

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/GuideLayer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/GuideLayer.java
@@ -45,7 +45,7 @@ public class GuideLayer extends FreeformLayer {
 	 * @return the Map of IFigures to their constraints (Booleans indicating whether
 	 *         or not they are horizontal guide lines)
 	 */
-	public Map getConstraints() {
+	public Map<IFigure, Object> getConstraints() {
 		if (constraints == null) {
 			constraints = new HashMap<>();
 		}


### PR DESCRIPTION
The type is already defined by the local variable. The getter only has to be adapted to match this type.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/155