### PR TITLE
Add missing types in RulerDragTracker & SelectionSynchronizer #155

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerDragTracker.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerDragTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -121,7 +121,7 @@ public class RulerDragTracker extends SimpleDragTracker {
 			return false;
 		}
 		int position = getCurrentPosition();
-		Iterator guides = source.getRulerProvider().getGuides().iterator();
+		Iterator<?> guides = source.getRulerProvider().getGuides().iterator();
 		while (guides.hasNext()) {
 			int guidePos = source.getRulerProvider().getGuidePosition(guides.next());
 			if (Math.abs(guidePos - position) < GuideEditPart.MIN_DISTANCE_BW_GUIDES) {

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/parts/SelectionSynchronizer.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/parts/SelectionSynchronizer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -149,7 +149,7 @@ public class SelectionSynchronizer implements ISelectionChangedListener {
 	 */
 	protected void applySelection(EditPartViewer viewer, ISelection selection) {
 		List<EditPart> result = new ArrayList<>();
-		Iterator iter = ((IStructuredSelection) selection).iterator();
+		Iterator<?> iter = ((IStructuredSelection) selection).iterator();
 		while (iter.hasNext()) {
 			EditPart part = convert(viewer, (EditPart) iter.next());
 			if (part != null && part.isSelectable()) {


### PR DESCRIPTION
The generic types for some local variables were missing. Given that the type is not known, wildcards are used.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/155