### PR TITLE
Add missing generic type to ToolEntry.getToolProperties() #155

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/palette/ToolEntry.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/ToolEntry.java
@@ -85,7 +85,7 @@ public abstract class ToolEntry extends PaletteEntry {
 	 * @return the properties set in {@link #setToolProperty(Object, Object)}
 	 * @since 3.1
 	 */
-	protected Map getToolProperties() {
+	protected Map<Object, Object> getToolProperties() {
 		return map;
 	}
 


### PR DESCRIPTION
The type is already defined by the local variable, so the getter only needs to be adapted to match this type.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/155