### PR TITLE
Mark `Node.sortValue` as "for removal"

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/BreakCycles.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/BreakCycles.java
@@ -206,6 +206,7 @@ class BreakCycles extends GraphVisitor {
 		n.workingInts[0] = index;
 	}
 
+	@SuppressWarnings("removal")
 	private static void sortedInsert(List<Node> list, Node node) {
 		int insert = 0;
 		while (insert < list.size() && (list.get(insert)).sortValue > node.sortValue) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundRankSorter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/CompoundRankSorter.java
@@ -102,6 +102,7 @@ class CompoundRankSorter extends RankSorter {
 		return map.get(new RowKey(row, s));
 	}
 
+	@SuppressWarnings("removal")
 	void copyConstraints(NestingTree tree) {
 		if (tree.subgraph != null) {
 			tree.sortValue = tree.subgraph.getRowConstraint();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NestingTree.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NestingTree.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2023 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -64,6 +64,7 @@ class NestingTree {
 		return nestingMap.get(null);
 	}
 
+	@SuppressWarnings("removal")
 	void calculateSortValues() {
 		int total = 0;
 		for (Object o : contents) {
@@ -82,6 +83,7 @@ class NestingTree {
 		sortValue = (double) total / size;
 	}
 
+	@SuppressWarnings("removal")
 	void getSortValueFromSubgraph() {
 		if (subgraph != null) {
 			sortValue = subgraph.sortValue;
@@ -129,6 +131,7 @@ class NestingTree {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	boolean swap(int index) {
 		Object left = contents.get(index);
 		Object right = contents.get(index + 1);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Node.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/Node.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -108,9 +108,10 @@ public class Node {
 	int rank;
 
 	/**
-	 * @deprecated for internal use only
+	 * @deprecated for internal use only. This field will be made package-private
+	 *             after the 2028-03 release.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public double sortValue;
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodeList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/NodeList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -46,6 +46,7 @@ public class NodeList extends ArrayList<Node> {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	void resetSortValues() {
 		for (int i = 0; i < size(); i++) {
 			get(i).sortValue = 0.0;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RankSorter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RankSorter.java
@@ -191,6 +191,7 @@ class RankSorter {
 		} while (change);
 	}
 
+	@SuppressWarnings("removal")
 	boolean swap(int i) {
 		Node left = rank.get(i);
 		Node right = rank.get(i + 1);
@@ -214,6 +215,7 @@ class RankSorter {
 		postSort();
 	}
 
+	@SuppressWarnings("removal")
 	void sortValueIncoming() {
 		node.sortValue = evaluateNodeIncoming();
 		// $TODO restore this optimization
@@ -228,6 +230,7 @@ class RankSorter {
 		// node.sortValue += Math.random() * rankSize / (5 + 8 * progress);
 	}
 
+	@SuppressWarnings("removal")
 	void sortValueOutgoing() {
 		node.sortValue = evaluateNodeOutgoing();
 		// $TODO restore this optimization

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/SortSubgraphs.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/SortSubgraphs.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -34,6 +34,7 @@ class SortSubgraphs extends GraphVisitor {
 	Set<Node> orderingGraphNodes = new HashSet<>();
 	NodePair pair = new NodePair();
 
+	@SuppressWarnings("removal")
 	private void breakSubgraphCycles() {
 		// The stack of nodes which have no unmarked incoming edges
 		List<Node> noLefts = new ArrayList<>();
@@ -183,6 +184,7 @@ class SortSubgraphs extends GraphVisitor {
 		rightOf(left).add(right);
 	}
 
+	@SuppressWarnings("removal")
 	static void sortedInsert(List<Node> list, Node node) {
 		int insert = 0;
 		while (insert < list.size() && list.get(insert).sortValue > node.sortValue) {


### PR DESCRIPTION
The field has been marked as deprecated since forever and should only be used internally, hence be package-private instead of public.

Because this field is only accessed within the same package, the removal warning can be safely suppressed.

Contributes to https://github.com/eclipse-gef/gef-classic/pull/778