### PR TITLE
Add missing `@Deprecated` annotations

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ConnectionLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,11 +24,13 @@ import org.eclipse.draw2d.geometry.PointList;
 public class ConnectionLocator extends AbstractLocator {
 
 	/** @deprecated Use {@link #SOURCE} */
+	@Deprecated
 	public static final int START = 2;
 	/** The start (or source) of the Connection */
 	public static final int SOURCE = 2;
 
 	/** @deprecated Use {@link #TARGET} */
+	@Deprecated
 	public static final int END = 3;
 	/** The end (or target) of the Connection */
 	public static final int TARGET = 3;
@@ -37,6 +39,7 @@ public class ConnectionLocator extends AbstractLocator {
 	 * @deprecated Use {@link #MIDDLE} instead, since the location is not the
 	 *             midpoint of a line-segment, but the middle of a polyline.
 	 */
+	@Deprecated
 	public static final int MIDPOINT = 4;
 	/** The middle of the Connection */
 	public static final int MIDDLE = 4;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -2302,6 +2302,7 @@ public class Figure implements IFigure {
 		 *
 		 * @param figure The Figure whose children to iterate over
 		 */
+		@Deprecated
 		public FigureIterator(IFigure figure) {
 			list = figure.getChildren();
 			index = list.size();
@@ -2312,6 +2313,7 @@ public class Figure implements IFigure {
 		 *
 		 * @return The next Figure
 		 */
+		@Deprecated
 		public IFigure nextFigure() {
 			return list.get(--index);
 		}
@@ -2321,6 +2323,7 @@ public class Figure implements IFigure {
 		 *
 		 * @return <code>true</code> if there's another Figure to iterate over
 		 */
+		@Deprecated
 		public boolean hasNext() {
 			return index > 0;
 		}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/InputEvent.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/InputEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,34 +26,42 @@ public abstract class InputEvent extends java.util.EventObject {
 	/**
 	 * @deprecated Use {@link SWT#ALT} instead.
 	 */
+	@Deprecated
 	public static final int ALT = SWT.ALT;
 	/**
 	 * @deprecated Use {@link SWT#CONTROL} instead.
 	 */
+	@Deprecated
 	public static final int CONTROL = SWT.CONTROL;
 	/**
 	 * @deprecated Use {@link SWT#SHIFT} instead.
 	 */
+	@Deprecated
 	public static final int SHIFT = SWT.SHIFT;
 	/**
 	 * @deprecated Use {@link SWT#BUTTON1} instead.
 	 */
+	@Deprecated
 	public static final int BUTTON1 = SWT.BUTTON1;
 	/**
 	 * @deprecated Use {@link SWT#BUTTON2} instead.
 	 */
+	@Deprecated
 	public static final int BUTTON2 = SWT.BUTTON2;
 	/**
 	 * @deprecated Use {@link SWT#BUTTON3} instead.
 	 */
+	@Deprecated
 	public static final int BUTTON3 = SWT.BUTTON3;
 	/**
 	 * @deprecated Use {@link SWT#BUTTON4} instead.
 	 */
+	@Deprecated
 	public static final int BUTTON4 = SWT.BUTTON4;
 	/**
 	 * @deprecated Use {@link SWT#BUTTON5} instead.
 	 */
+	@Deprecated
 	public static final int BUTTON5 = SWT.BUTTON5;
 	/**
 	 * A bitwise OR'ing of {@link #BUTTON1}, {@link #BUTTON2}, {@link #BUTTON3},
@@ -61,6 +69,7 @@ public abstract class InputEvent extends java.util.EventObject {
 	 *
 	 * @deprecated Use {@link SWT#BUTTON_MASK} instead.
 	 */
+	@Deprecated
 	public static final int ANY_BUTTON = SWT.BUTTON_MASK;
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseEvent.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/MouseEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,6 +60,7 @@ public class MouseEvent extends InputEvent {
 	 *             {@link #MouseEvent(EventDispatcher, IFigure, org.eclipse.swt.events.MouseEvent)}
 	 *             instead.
 	 */
+	@Deprecated
 	public MouseEvent(int x, int y, EventDispatcher dispatcher, IFigure f, int button, int stateMask) {
 		super(dispatcher, f, stateMask);
 		Point pt = Point.SINGLETON;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RoundedRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RoundedRectangle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,6 +26,7 @@ public class RoundedRectangle extends Shape {
 	 *
 	 * @deprecated Use {@link #getCornerDimensions()} instead.
 	 */
+	@Deprecated
 	protected Dimension corner = new Dimension(8, 8);
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScrollPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -154,6 +154,7 @@ public class ScrollPane extends Figure {
 	 * @deprecated use getContents()
 	 * @since 2.0
 	 */
+	@Deprecated
 	public IFigure getView() {
 		return getViewport().getContents();
 	}
@@ -312,6 +313,7 @@ public class ScrollPane extends Figure {
 	 * @deprecated call setContents(IFigure) instead
 	 * @since 2.0
 	 */
+	@Deprecated
 	public void setView(IFigure figure) {
 		getViewport().setContents(figure);
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SubordinateUpdateManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SubordinateUpdateManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 /**
  * @deprecated this class is not used
  */
+@Deprecated
 public abstract class SubordinateUpdateManager extends UpdateManager {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,8 +22,10 @@ package org.eclipse.draw2d.geometry;
 public final class Ray {
 
 	/** the X value */
+	@Deprecated
 	public int x;
 	/** the Y value */
+	@Deprecated
 	public int y;
 
 	/**
@@ -31,6 +33,7 @@ public final class Ray {
 	 *
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray() {
 	}
 
@@ -41,6 +44,7 @@ public final class Ray {
 	 * @param y Y value.
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray(int x, int y) {
 		this.x = x;
 		this.y = y;
@@ -52,6 +56,7 @@ public final class Ray {
 	 * @param p the Point
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray(Point p) {
 		x = p.x;
 		y = p.y;
@@ -65,6 +70,7 @@ public final class Ray {
 	 * @param end   End Point
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray(Point start, Point end) {
 		x = end.x - start.x;
 		y = end.y - start.y;
@@ -77,6 +83,7 @@ public final class Ray {
 	 * @param end   The end Ray
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray(Ray start, Ray end) {
 		x = end.x - start.x;
 		y = end.y - start.y;
@@ -92,6 +99,7 @@ public final class Ray {
 	 * @see #similarity(Ray)
 	 * @since 2.0
 	 */
+	@Deprecated
 	public int assimilarity(Ray r) {
 		return Math.abs(x * r.y - y * r.x);
 	}
@@ -103,6 +111,7 @@ public final class Ray {
 	 * @return The dot product
 	 * @since 2.0
 	 */
+	@Deprecated
 	public int dotProduct(Ray r) {
 		return x * r.x + y * r.y;
 	}
@@ -115,6 +124,7 @@ public final class Ray {
 	 *         overflow
 	 * @since 3.4.1
 	 */
+	@Deprecated
 	long dotProductL(Ray r) {
 		return (long) x * r.x + (long) y * r.y;
 	}
@@ -123,6 +133,7 @@ public final class Ray {
 	 * @see java.lang.Object#equals(Object)
 	 */
 	@Override
+	@Deprecated
 	public boolean equals(Object obj) {
 		if (obj == this) {
 			return true;
@@ -140,6 +151,7 @@ public final class Ray {
 	 * @return a new Ray
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray getAdded(Ray r) {
 		return new Ray(r.x + x, r.y + y);
 	}
@@ -151,6 +163,7 @@ public final class Ray {
 	 * @return a new Ray
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray getAveraged(Ray r) {
 		return new Ray((x + r.x) / 2, (y + r.y) / 2);
 	}
@@ -162,6 +175,7 @@ public final class Ray {
 	 * @return a new Ray
 	 * @since 2.0
 	 */
+	@Deprecated
 	public Ray getScaled(int s) {
 		return new Ray(x * s, y * s);
 	}
@@ -170,6 +184,7 @@ public final class Ray {
 	 * @see java.lang.Object#hashCode()
 	 */
 	@Override
+	@Deprecated
 	public int hashCode() {
 		return (x * y) ^ (x + y);
 	}
@@ -180,6 +195,7 @@ public final class Ray {
 	 * @return true if this Ray has a non-zero horizontal comonent
 	 * @since 2.0
 	 */
+	@Deprecated
 	public boolean isHorizontal() {
 		return x != 0;
 	}
@@ -190,6 +206,7 @@ public final class Ray {
 	 * @return Length of this Ray
 	 * @since 2.0
 	 */
+	@Deprecated
 	public double length() {
 		return Math.sqrt(dotProductL(this));
 	}
@@ -203,6 +220,7 @@ public final class Ray {
 	 * @see #assimilarity(Ray)
 	 * @since 2.0
 	 */
+	@Deprecated
 	public int similarity(Ray r) {
 		return Math.abs(dotProduct(r));
 	}
@@ -211,6 +229,7 @@ public final class Ray {
 	 * @return a String representation
 	 */
 	@Override
+	@Deprecated
 	public String toString() {
 		return "(" + x + "," + y + ")";//$NON-NLS-3$//$NON-NLS-2$//$NON-NLS-1$
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNode.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,11 +25,13 @@ public class VirtualNode extends Node {
 	/**
 	 * The next node.
 	 */
+	@Deprecated
 	public Node next;
 
 	/**
 	 * The previous node.
 	 */
+	@Deprecated
 	public Node prev;
 
 	/**
@@ -56,6 +58,7 @@ public class VirtualNode extends Node {
 	 * @param o      object
 	 * @param parent subgraph
 	 */
+	@Deprecated
 	public VirtualNode(Object o, Subgraph parent) {
 		super(o, parent);
 	}
@@ -65,6 +68,7 @@ public class VirtualNode extends Node {
 	 *
 	 * @return median
 	 */
+	@Deprecated
 	public double medianIncoming() {
 		return prev.index;
 	}
@@ -74,6 +78,7 @@ public class VirtualNode extends Node {
 	 *
 	 * @return outgoing
 	 */
+	@Deprecated
 	public double medianOutgoing() {
 		return next.index;
 	}
@@ -84,6 +89,7 @@ public class VirtualNode extends Node {
 	 *
 	 * @return the weighted weight, or omega
 	 */
+	@Deprecated
 	public int omega() {
 		Edge e = (Edge) data;
 		if (e.source.rank + 1 < rank && rank < e.target.rank) {
@@ -96,6 +102,7 @@ public class VirtualNode extends Node {
 	 * @see java.lang.Object#toString()
 	 */
 	@Override
+	@Deprecated
 	public String toString() {
 		if (data instanceof Edge edge) {
 			return "VN[" + (edge.vNodes.indexOf(this) + 1) //$NON-NLS-1$

--- a/org.eclipse.gef/src/org/eclipse/gef/GEF.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/GEF.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,11 +25,16 @@ import org.eclipse.swt.widgets.Text;
 @Deprecated
 public final class GEF {
 
+	@Deprecated
 	static final String TAB = "  ";//$NON-NLS-1$
 
+	@Deprecated
 	static Text text;
+	@Deprecated
 	static int msgCount;
+	@Deprecated
 	static int tab;
+	@Deprecated
 	static NumberFormat formatter = new DecimalFormat();
 
 	/**
@@ -78,6 +83,7 @@ public final class GEF {
 	 *
 	 * @since 1.0
 	 */
+	@Deprecated
 	public static void clearConsole() {
 		if (text == null) {
 			return;
@@ -91,6 +97,7 @@ public final class GEF {
 	 * @since 1.0
 	 * @param textBox the text control for streaming
 	 */
+	@Deprecated
 	public static void setConsole(Text textBox) {
 		msgCount = 0;
 		formatter.setMinimumIntegerDigits(2);
@@ -103,6 +110,7 @@ public final class GEF {
 	 *
 	 * @since 2.0
 	 */
+	@Deprecated
 	public static void debugPop() {
 		tab--;
 	}
@@ -113,6 +121,7 @@ public final class GEF {
 	 * @since 2.0
 	 * @param heading the message describing the indented text to follow
 	 */
+	@Deprecated
 	public static void debugPush(String heading) {
 		debug(heading);
 		tab++;
@@ -124,6 +133,7 @@ public final class GEF {
 	 * @since 1.0
 	 * @param message a debug message
 	 */
+	@Deprecated
 	public static void debug(String message) {
 		String lineNumber = formatter.format(msgCount++);
 		msgCount %= 100;

--- a/org.eclipse.gef/src/org/eclipse/gef/GEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/GEFPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,6 +21,7 @@ import org.eclipse.gef.internal.InternalGEFPlugin;
 /**
  * @deprecated The GEF plugin class must not be referenced by clients.
  */
+@Deprecated
 public final class GEFPlugin extends AbstractUIPlugin {
 
 	private static GEFPlugin singleton;
@@ -32,6 +33,7 @@ public final class GEFPlugin extends AbstractUIPlugin {
 	 * @param stack a command stack
 	 * @return the implementation for the entry
 	 */
+	@Deprecated
 	public static IPropertySheetEntry createUndoablePropertySheetEntry(CommandStack stack) {
 		return new org.eclipse.gef.ui.properties.UndoablePropertySheetEntry(stack);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/SnapToGrid.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/SnapToGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2010 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -68,6 +68,7 @@ public class SnapToGrid extends SnapToHelper {
 	/**
 	 * @deprecated use DEFAULT_GRID_SIZE
 	 */
+	@Deprecated
 	public static final int DEFAULT_GAP = DEFAULT_GRID_SIZE;
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStackListener.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/commands/CommandStackListener.java
@@ -30,6 +30,7 @@ public interface CommandStackListener {
 	 *
 	 * @param event the event
 	 */
+	@Deprecated
 	void commandStackChanged(EventObject event);
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/GraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/GraphicalRootEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -42,6 +42,7 @@ import org.eclipse.gef.tools.MarqueeDragTracker;
  * @deprecated this class will be deleted, use ScrollingGraphicalViewer with
  *             ScalableRootEditPart instead
  */
+@Deprecated
 public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 		implements RootEditPart, LayerConstants, LayerManager {
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ZoomManager.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ZoomManager.java
@@ -83,6 +83,7 @@ public class ZoomManager extends AbstractZoomManager {
 	 *                 ZoomManager
 	 * @param viewport The Viewport associated with this viewport
 	 */
+	@Deprecated
 	public ZoomManager(ScalableFreeformLayeredPane pane, Viewport viewport) {
 		super(pane, viewport);
 	}
@@ -104,6 +105,7 @@ public class ZoomManager extends AbstractZoomManager {
 	 * @deprecated Use {@link #getScalableFigure()} instead. Returns the pane.
 	 * @return the pane
 	 */
+	@Deprecated
 	public ScalableFreeformLayeredPane getPane() {
 		Assert.isTrue(super.getScalableFigure() instanceof ScalableFreeformLayeredPane);
 		return (ScalableFreeformLayeredPane) super.getScalableFigure();

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/AbstractEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/AbstractEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -55,6 +55,7 @@ public abstract class AbstractEditPolicy implements EditPolicy, RequestConstants
 	 * @param message the String to log
 	 * @deprecated in 3.1 This method will be removed in future releases.
 	 */
+	@Deprecated
 	protected final void debugFeedback(String message) {
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/editpolicies/AbstractTreeContainerEditPolicy.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editpolicies/AbstractTreeContainerEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ package org.eclipse.gef.editpolicies;
  * @deprecated Use TreeContainerEditPolicy
  * @author Pratik Shah
  */
+@Deprecated
 public abstract class AbstractTreeContainerEditPolicy extends TreeContainerEditPolicy {
 
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/AbstractHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/AbstractHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -127,6 +127,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	 * @deprecated use getCursor()
 	 * @return the cursor
 	 */
+	@Deprecated
 	public Cursor getDragCursor() {
 		return getCursor();
 	}
@@ -189,6 +190,7 @@ public abstract class AbstractHandle extends Figure implements Handle, AncestorL
 	 * @throws Exception a bogus excpetion declaration
 	 * @deprecated use setCursor()
 	 */
+	@Deprecated
 	public void setDragCursor(Cursor c) throws Exception {
 		setCursor(c);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionEndHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionEndHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.gef.ConnectionEditPart;
  *
  * @deprecated use {@link ConnectionEndpointHandle}
  */
+@Deprecated
 public final class ConnectionEndHandle extends ConnectionEndpointHandle {
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionStartHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionStartHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.gef.ConnectionEditPart;
  *
  * @deprecated use {@link ConnectionEndpointHandle}
  */
+@Deprecated
 public final class ConnectionStartHandle extends ConnectionEndpointHandle {
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/CornerTriangleBorder.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/CornerTriangleBorder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,6 +39,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 *
 	 * @param isPrimary Determines this border's color.
 	 */
+	@Deprecated
 	public CornerTriangleBorder(boolean isPrimary) {
 		this.isPrimary = isPrimary;
 	}
@@ -49,6 +50,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 * @see org.eclipse.draw2d.Border#isOpaque()
 	 */
 	@Override
+	@Deprecated
 	public boolean isOpaque() {
 		return true;
 	}
@@ -57,6 +59,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 * @see org.eclipse.draw2d.Border#getInsets(org.eclipse.draw2d.IFigure)
 	 */
 	@Override
+	@Deprecated
 	public Insets getInsets(IFigure figure) {
 		return new Insets(1);
 	}
@@ -70,6 +73,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 * @param insets   The <code>Insets</code>.
 	 */
 	@Override
+	@Deprecated
 	public void paint(IFigure figure, Graphics graphics, Insets insets) {
 		// Don't paint the center of the figure.
 		int width = 1;
@@ -135,6 +139,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 *
 	 * @return The outline color.
 	 */
+	@Deprecated
 	protected Color getBorderColor() {
 		return (isPrimary()) ? ColorConstants.white : ColorConstants.black;
 	}
@@ -144,6 +149,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 *
 	 * @return The fill color.
 	 */
+	@Deprecated
 	protected Color getFillColor() {
 		return (isPrimary()) ? ColorConstants.black : ColorConstants.white;
 	}
@@ -154,6 +160,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 *
 	 * @return Whether or not this is a primary border.
 	 */
+	@Deprecated
 	public boolean isPrimary() {
 		return isPrimary;
 	}
@@ -164,6 +171,7 @@ public final class CornerTriangleBorder extends AbstractBorder {
 	 * @param isPrimary True if this border is for the primary object in the
 	 *                  selection.
 	 */
+	@Deprecated
 	public void setPrimary(boolean isPrimary) {
 		this.isPrimary = isPrimary;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,6 +32,7 @@ public class MoveHandle extends AbstractHandle {
 	 *
 	 * @deprecated subclasses should not reference this field.
 	 */
+	@Deprecated
 	protected static final int INNER_PAD = 2;
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,7 @@ import org.eclipse.gef.tools.DragEditPartsTracker;
  *
  * @deprecated this handle type is no longer used
  */
+@Deprecated
 public class NonResizableHandle extends MoveHandle {
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/palette/CreationToolEntry.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/palette/CreationToolEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,6 +32,7 @@ public class CreationToolEntry extends ToolEntry {
 	 *             factory is being provided to the tool via the
 	 *             {@link ToolEntry#setToolProperty(Object, Object)} method.
 	 */
+	@Deprecated
 	protected final CreationFactory factory;
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/requests/ChangeBoundsRequest.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/requests/ChangeBoundsRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,6 +60,7 @@ public class ChangeBoundsRequest extends GroupRequest implements DropRequest {
 	 * @deprecated Use {@link #getLocation() }
 	 * @return The location of the mouse pointer.
 	 */
+	@Deprecated
 	public Point getMouseLocation() {
 		return getLocation();
 	}
@@ -196,6 +197,7 @@ public class ChangeBoundsRequest extends GroupRequest implements DropRequest {
 	 * @deprecated Use {@link #setLocation(Point)}
 	 * @param p The location of the mouse pointer.
 	 */
+	@Deprecated
 	public void setMouseLocation(Point p) {
 		setLocation(p);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyRetargetAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,6 +23,7 @@ import org.eclipse.gef.internal.GEFMessages;
  * @author Eric Bordeau
  * @deprecated Use org.eclipse.ui.actions.ActionFactory instead
  */
+@Deprecated
 public class CopyRetargetAction extends RetargetAction {
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteRetargetAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,6 +23,7 @@ import org.eclipse.gef.internal.GEFMessages;
  * @author Eric Bordeau
  * @deprecated Use org.eclipse.ui.actions.ActionFactory instead
  */
+@Deprecated
 public class PasteRetargetAction extends RetargetAction {
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewerPreferences.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteViewerPreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -59,6 +59,7 @@ public interface PaletteViewerPreferences {
 	/**
 	 * @deprecated Use LAYOUT_COLUMNS instead.
 	 */
+	@Deprecated
 	int LAYOUT_FOLDER = LAYOUT_COLUMNS;
 
 	/**
@@ -102,6 +103,7 @@ public interface PaletteViewerPreferences {
 	/**
 	 * @deprecated Use PREFERENCE_COLUMNS_ICON_SIZE instead.
 	 */
+	@Deprecated
 	String PREFERENCE_FOLDER_ICON_SIZE = PREFERENCE_COLUMNS_ICON_SIZE;
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java
@@ -472,6 +472,7 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 		/** Map from ImageDescriptor to Image */
 		private final Map<ImageDescriptor, Image> images = new HashMap<>(11);
 
+		@Deprecated
 		Image getImage(ImageDescriptor desc) {
 			if (desc == null) {
 				return null;
@@ -479,10 +480,12 @@ public abstract class PaletteEditPart extends AbstractGraphicalEditPart implemen
 			return images.computeIfAbsent(desc, ImageDescriptor::createImage);
 		}
 
+		@Deprecated
 		Image getMissingImage() {
 			return getImage(ImageDescriptor.getMissingImageDescriptor());
 		}
 
+		@Deprecated
 		void dispose() {
 			images.values().forEach(Image::dispose);
 			images.clear();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/ConstraintAdapter.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/ConstraintAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2006, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2006, 2025 CHISEL Group, University of Victoria, Victoria,
  *                           BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -36,6 +36,7 @@ public interface ConstraintAdapter {
 	 * @param object
 	 * @param constraint
 	 */
+	@Deprecated
 	public void populateConstraint(Object object, LayoutConstraint constraint);
 
 }

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/GraphConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024, CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2010, 2025, CHISEL Group, University of Victoria, Victoria,
  *                            BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -767,34 +767,41 @@ public class GraphConnection extends GraphItem {
 	@Deprecated(since = "1.12", forRemoval = true)
 	class GraphLayoutConnection implements LayoutRelationship {
 
+		@Deprecated
 		Object layoutInformation = null;
 
 		@Override
+		@Deprecated
 		public void clearBendPoints() {
 			connectionFigure.getPoints().removeAllPoints();
 		}
 
 		@Override
+		@Deprecated
 		public LayoutEntity getDestinationInLayout() {
 			return getDestination().getLayoutEntity();
 		}
 
 		@Override
+		@Deprecated
 		public Object getLayoutInformation() {
 			return layoutInformation;
 		}
 
 		@Override
+		@Deprecated
 		public LayoutEntity getSourceInLayout() {
 			return getSource().getLayoutEntity();
 		}
 
 		@Override
+		@Deprecated
 		public void populateLayoutConstraint(LayoutConstraint constraint) {
 			graphModel.invokeConstraintAdapters(GraphConnection.this, constraint);
 		}
 
 		@Override
+		@Deprecated
 		public void setBendPoints(LayoutBendPoint[] bendPoints) {
 			PointList points = new PointList();
 
@@ -815,16 +822,19 @@ public class GraphConnection extends GraphItem {
 		}
 
 		@Override
+		@Deprecated
 		public void setLayoutInformation(Object layoutInformation) {
 			this.layoutInformation = layoutInformation;
 		}
 
 		@Override
+		@Deprecated
 		public Object getGraphData() {
 			return GraphConnection.this;
 		}
 
 		@Override
+		@Deprecated
 		public void setGraphData(Object o) {
 
 		}

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/RevealListener.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/RevealListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria,
  *                           BC, Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Control;
 @Deprecated(since = "2.0", forRemoval = true)
 public interface RevealListener {
 
+	@Deprecated
 	public void revealed(Control c);
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Filter.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Filter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -34,5 +34,6 @@ public interface Filter {
 	/**
 	 * Returns true if the object is filtered, or false if it's not filtered.
 	 */
+	@Deprecated
 	public boolean isObjectFiltered(LayoutItem object);
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/InvalidLayoutConfiguration.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/InvalidLayoutConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -24,6 +24,7 @@ package org.eclipse.zest.layouts;
 @Deprecated(since = "2.0", forRemoval = true)
 public class InvalidLayoutConfiguration extends Exception {
 
+	@Deprecated
 	static final long serialVersionUID = 0;
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutAlgorithm.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010 CHISEL Group, University of Victoria, Victoria,
- *                     BC, Canada and others.
+ * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria,
+ *                           BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -63,6 +63,7 @@ public interface LayoutAlgorithm {
 		 *                                can place the entities.
 		 * @param asynchronous            Should the algorithm run Asynchronously
 		 */
+		@Deprecated
 		public void applyLayout(LayoutEntity[] entitiesToLayout, LayoutRelationship[] relationshipsToConsider, double x,
 				double y, double width, double height, boolean asynchronous, boolean continuous)
 				throws InvalidLayoutConfiguration;
@@ -72,6 +73,7 @@ public interface LayoutAlgorithm {
 		 *
 		 * @return True if a layout algorithm is currenly running, false otherwise
 		 */
+		@Deprecated
 		public boolean isRunning();
 
 		/**
@@ -79,11 +81,13 @@ public interface LayoutAlgorithm {
 		 * algorithms force a specific order, in which case this comparator will be
 		 * ignored.
 		 */
+		@Deprecated
 		public void setComparator(Comparator comparator);
 
 		/**
 		 * Filters the entities and relationships to apply the layout on
 		 */
+		@Deprecated
 		public void setFilter(Filter filter);
 
 		/**
@@ -91,6 +95,7 @@ public interface LayoutAlgorithm {
 		 * is responsible for ensuring this ratio is used. Note: By default the layout
 		 * will use a ratio of 1.0 for each entity.
 		 */
+		@Deprecated
 		public void setEntityAspectRatio(double ratio);
 
 		/**
@@ -98,6 +103,7 @@ public interface LayoutAlgorithm {
 		 * entities. Note: By default the layout will use a ratio of 1.0 for each
 		 * entity.
 		 */
+		@Deprecated
 		public double getEntityAspectRatio();
 
 		/**
@@ -105,17 +111,20 @@ public interface LayoutAlgorithm {
 		 * relieve some of the mystery, the layout algorithm will notify each
 		 * ProgressListener of its progress.
 		 */
+		@Deprecated
 		public void addProgressListener(ProgressListener listener);
 
 		/**
 		 * Removes the given progress listener, preventing it from receiving any more
 		 * updates.
 		 */
+		@Deprecated
 		public void removeProgressListener(ProgressListener listener);
 
 		/**
 		 * Makes a request to this layout algorithm to stop running.
 		 */
+		@Deprecated
 		public void stop();
 
 		/**
@@ -124,18 +133,25 @@ public interface LayoutAlgorithm {
 		 *
 		 * @param style
 		 */
+		@Deprecated
 		public void setStyle(int style);
 
+		@Deprecated
 		public int getStyle();
 
+		@Deprecated
 		public void addEntity(LayoutEntity entity);
 
+		@Deprecated
 		public void addRelationship(LayoutRelationship relationship);
 
+		@Deprecated
 		public void removeEntity(LayoutEntity entity);
 
+		@Deprecated
 		public void removeRelationship(LayoutRelationship relationship);
 
+		@Deprecated
 		public void removeRelationships(List<? extends LayoutRelationship> relationships);
 	}
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutBendPoint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutBendPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2006, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2006, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -25,9 +25,12 @@ package org.eclipse.zest.layouts;
  */
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutBendPoint {
+	@Deprecated
 	public double getX();
 
+	@Deprecated
 	public double getY();
 
+	@Deprecated
 	public boolean getIsControlPoint();
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutEntity.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -32,27 +32,38 @@ import org.eclipse.zest.layouts.interfaces.NodeLayout;
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutEntity extends Comparable, LayoutItem {
 
+	@Deprecated
 	public final static String ATTR_PREFERRED_WIDTH = "tree-preferred-width"; //$NON-NLS-1$
+	@Deprecated
 	public final static String ATTR_PREFERRED_HEIGHT = "tree-preferred-height"; //$NON-NLS-1$
 
+	@Deprecated
 	public void setLocationInLayout(double x, double y);
 
+	@Deprecated
 	public void setSizeInLayout(double width, double height);
 
+	@Deprecated
 	public double getXInLayout();
 
+	@Deprecated
 	public double getYInLayout();
 
+	@Deprecated
 	public double getWidthInLayout();
 
+	@Deprecated
 	public double getHeightInLayout();
 
+	@Deprecated
 	public Object getLayoutInformation();
 
+	@Deprecated
 	public void setLayoutInformation(Object internalEntity);
 
 	/**
 	 * Classes should update the specified layout constraint if recognized
 	 */
+	@Deprecated
 	public void populateLayoutConstraint(LayoutConstraint constraint);
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutGraph.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutGraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -34,6 +34,7 @@ public interface LayoutGraph {
 	 *
 	 * @param node The new node.
 	 */
+	@Deprecated
 	public void addEntity(LayoutEntity node);
 
 	/**
@@ -41,6 +42,7 @@ public interface LayoutGraph {
 	 *
 	 * @param relationship
 	 */
+	@Deprecated
 	public void addRelationship(LayoutRelationship relationship);
 
 	/**
@@ -49,6 +51,7 @@ public interface LayoutGraph {
 	 *
 	 * @return List A List of LayoutEntity objects.
 	 */
+	@Deprecated
 	public List getEntities();
 
 	/**
@@ -57,6 +60,7 @@ public interface LayoutGraph {
 	 *
 	 * @return List A List of LayoutRelationship objects.
 	 */
+	@Deprecated
 	public List getRelationships();
 
 	/**
@@ -64,6 +68,7 @@ public interface LayoutGraph {
 	 *
 	 * @return boolean If the graph is bidirectional.
 	 */
+	@Deprecated
 	public boolean isBidirectional();
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutItem.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -27,8 +27,10 @@ import org.eclipse.zest.layouts.interfaces.EntityLayout;
 @Deprecated(since = "2.0", forRemoval = true)
 public interface LayoutItem {
 
+	@Deprecated
 	public void setGraphData(Object o);
 
+	@Deprecated
 	public Object getGraphData();
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutIterationEvent.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutIterationEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -36,6 +36,7 @@ public class LayoutIterationEvent {
 	/**
 	 * Return the relationships used in this layout.
 	 */
+	@Deprecated
 	public List getRelationshipsToLayout() {
 		return relationshipsToLayout;
 	}
@@ -43,6 +44,7 @@ public class LayoutIterationEvent {
 	/**
 	 * Return the entities used in this layout.
 	 */
+	@Deprecated
 	public List getEntitiesToLayout() {
 		return entitiesToLayout;
 	}
@@ -50,6 +52,7 @@ public class LayoutIterationEvent {
 	/**
 	 * Return the iteration of the layout algorithm that was just completed.
 	 */
+	@Deprecated
 	public int getIterationCompleted() {
 		return iterationCompleted;
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutRelationship.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -36,6 +36,7 @@ public interface LayoutRelationship extends LayoutItem {
 	 *
 	 * @return The sourceEntity.
 	 */
+	@Deprecated
 	public LayoutEntity getSourceInLayout();
 
 	/**
@@ -44,6 +45,7 @@ public interface LayoutRelationship extends LayoutItem {
 	 *
 	 * @return The destinationEntity of this SimpleRelation.
 	 */
+	@Deprecated
 	public LayoutEntity getDestinationInLayout();
 
 	/**
@@ -51,6 +53,7 @@ public interface LayoutRelationship extends LayoutItem {
 	 *
 	 * @param layoutInformation
 	 */
+	@Deprecated
 	public void setLayoutInformation(Object layoutInformation);
 
 	/**
@@ -58,6 +61,7 @@ public interface LayoutRelationship extends LayoutItem {
 	 *
 	 * @return Object
 	 */
+	@Deprecated
 	public Object getLayoutInformation();
 
 	/**
@@ -76,16 +80,19 @@ public interface LayoutRelationship extends LayoutItem {
 	 *                   positioning of bendpoints relative to the source and
 	 *                   destination points when drawing the graph.
 	 */
+	@Deprecated
 	public void setBendPoints(LayoutBendPoint[] bendPoints);
 
 	/**
 	 * Clear bend points and related bounds If you are updating an existing
 	 * application you can just implement this method to do nothing.
 	 */
+	@Deprecated
 	public void clearBendPoints();
 
 	/**
 	 * Classes should update the specified layout constraint if recognized
 	 */
+	@Deprecated
 	public void populateLayoutConstraint(LayoutConstraint constraint);
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutStyles.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/LayoutStyles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -27,18 +27,21 @@ import org.eclipse.zest.layouts.algorithms.TreeLayoutAlgorithm;
 public interface LayoutStyles {
 
 	/** Default layout style constant. */
+	@Deprecated
 	public final static int NONE = 0x00;
 
 	/**
 	 * Layout constant indicating that the layout algorithm should NOT resize any of
 	 * the nodes.
 	 */
+	@Deprecated
 	public final static int NO_LAYOUT_NODE_RESIZING = 0x01;
 
 	/**
 	 * Some layouts may prefer to expand their bounds beyond those of the requested
 	 * bounds. This flag asks the layout not to do so.
 	 */
+	@Deprecated
 	public static final int ENFORCE_BOUNDS = 0X02;
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/NestedLayoutEntity.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/NestedLayoutEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -31,12 +31,15 @@ import org.eclipse.zest.layouts.interfaces.SubgraphLayout;
 public interface NestedLayoutEntity extends LayoutEntity {
 
 	/** Returns the parent entity. */
+	@Deprecated
 	NestedLayoutEntity getParent();
 
 	/** Returns the list of children. */
+	@Deprecated
 	List getChildren();
 
 	/** Returns true if this entity has children. */
+	@Deprecated
 	boolean hasChildren();
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Stoppable.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/Stoppable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -28,8 +28,10 @@ public interface Stoppable {
 	/**
 	 * This ends the runnable
 	 */
+	@Deprecated
 	public void stop();
 
+	@Deprecated
 	public void addProgressListener(ProgressListener listener);
 
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
@@ -65,20 +65,25 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static abstract class Zest1 implements LayoutAlgorithm.Zest1, Stoppable {
 
+		@Deprecated
 		public void removeRelationships(Collection<? extends LayoutRelationship> collection) {
 
 		}
 
+		@Deprecated
 		public static final int MIN_ENTITY_SIZE = 5;
 		private static final int MIN_TIME_DELAY_BETWEEN_PROGRESS_EVENTS = 1;
 
 		private Thread creationThread = null;
+		@Deprecated
 		protected Comparator comparator;
+		@Deprecated
 		protected Filter filter;
 		private final List<ProgressListener> progressListeners = new CopyOnWriteArrayList<>();
 		private Calendar lastProgressEventFired;
 		private double widthToHeightRatio;
 
+		@Deprecated
 		class InternalComparator implements Comparator<InternalNode> {
 			Comparator<LayoutEntity> externalComparator = null;
 
@@ -102,7 +107,9 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		private double internalY;
 		private double internalWidth;
 		private double internalHeight;
+		@Deprecated
 		protected boolean internalContinuous;
+		@Deprecated
 		protected boolean internalAsynchronous;
 
 		/*
@@ -119,11 +126,14 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		/** A list of LayoutRelationship objects to be added. */
 		private final List<LayoutRelationship> relationshipsToAdd = new ArrayList<>();
 
+		@Deprecated
 		protected boolean layoutStopped = true;
 
+		@Deprecated
 		protected int layout_styles = 0;
 
 		// Child classes can set to false to retain node shapes and sizes
+		@Deprecated
 		protected boolean resizeEntitiesAfterLayout = true;
 
 		/**
@@ -131,6 +141,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 *
 		 * @see LayoutStyles
 		 */
+		@Deprecated
 		public Zest1(int styles) {
 			this.creationThread = Thread.currentThread();
 			this.lastProgressEventFired = Calendar.getInstance();
@@ -146,6 +157,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param entity
 		 */
 		@Override
+		@Deprecated
 		public void addEntity(LayoutEntity entity) {
 			if ((entity != null) && !entitiesToAdd.contains(entity)) {
 				entitiesToAdd.add(entity);
@@ -159,6 +171,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param relationship
 		 */
 		@Override
+		@Deprecated
 		public void addRelationship(LayoutRelationship relationship) {
 			if ((relationship != null) && !relationshipsToAdd.contains(relationship)) {
 				relationshipsToAdd.add(relationship);
@@ -172,6 +185,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param entity The entity to remove
 		 */
 		@Override
+		@Deprecated
 		public void removeEntity(LayoutEntity entity) {
 			if ((entity != null) && !entitiesToRemove.contains(entity)) {
 				entitiesToRemove.add(entity);
@@ -185,6 +199,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param relationship The relationship to remove.
 		 */
 		@Override
+		@Deprecated
 		public void removeRelationship(LayoutRelationship relationship) {
 			if ((relationship != null) && !relationshipsToRemove.contains(relationship)) {
 				relationshipsToRemove.add(relationship);
@@ -197,6 +212,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param relationships
 		 */
 		@Override
+		@Deprecated
 		public void removeRelationships(List<? extends LayoutRelationship> relationships) {
 			// note we don't check if the relationshipsToRemove contains
 			// any of the objects in relationships.
@@ -210,6 +226,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param style
 		 */
 		@Override
+		@Deprecated
 		public void setStyle(int style) {
 			this.layout_styles = style;
 		}
@@ -220,10 +237,12 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @return the layout styles for this layout
 		 */
 		@Override
+		@Deprecated
 		public int getStyle() {
 			return this.layout_styles;
 		}
 
+		@Deprecated
 		public abstract void setLayoutArea(double x, double y, double width, double height);
 
 		/**
@@ -232,6 +251,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param asynchronous
 		 * @param continuous
 		 */
+		@Deprecated
 		protected abstract boolean isValidConfiguration(boolean asynchronous, boolean continuous);
 
 		/**
@@ -250,6 +270,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param boundsHeight            The height of the bounds in which the layout
 		 *                                can place the entities.
 		 */
+		@Deprecated
 		protected abstract void applyLayoutInternal(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider, double boundsX, double boundsY, double boundsWidth,
 				double boundsHeight);
@@ -261,6 +282,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param entities the current entities
 		 * @return the updated entities array
 		 */
+		@Deprecated
 		protected InternalNode[] updateEntities(InternalNode[] entities) {
 			if (!entitiesToRemove.isEmpty() || !entitiesToAdd.isEmpty()) {
 				List<InternalNode> internalNodesList = new ArrayList<>(Arrays.asList(entities));
@@ -308,6 +330,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param relationships the current relationships
 		 * @return the update relationships array
 		 */
+		@Deprecated
 		protected InternalRelationship[] updateRelationships(InternalRelationship[] relationships) {
 			if (!relationshipsToRemove.isEmpty() || !relationshipsToAdd.isEmpty()) {
 				List<InternalRelationship> internalRelsList = new ArrayList<>(Arrays.asList(relationships));
@@ -356,6 +379,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @return boolean if the layout algorithm is running
 		 */
 		@Override
+		@Deprecated
 		public synchronized boolean isRunning() {
 			return !layoutStopped;
 		}
@@ -365,6 +389,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * constantly check isLayoutRunning
 		 */
 		@Override
+		@Deprecated
 		public synchronized void stop() {
 			layoutStopped = true;
 			postLayoutAlgorithm(internalNodes, internalRelationships);
@@ -396,29 +421,34 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		/**
 		 * Code called before the layout algorithm starts
 		 */
+		@Deprecated
 		protected abstract void preLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider, double x, double y, double width, double height);
 
 		/**
 		 * Code called after the layout algorithm ends
 		 */
+		@Deprecated
 		protected abstract void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider);
 
 		/**
 		 * Gets the total number of steps in this layout
 		 */
+		@Deprecated
 		protected abstract int getTotalNumberOfLayoutSteps();
 
 		/**
 		 * Gets the current layout step
 		 */
+		@Deprecated
 		protected abstract int getCurrentLayoutStep();
 
 		/**
 		 * This actually applies the layout
 		 */
 		@Override
+		@Deprecated
 		public synchronized void applyLayout(final LayoutEntity[] entitiesToLayout,
 				final LayoutRelationship[] relationshipsToConsider, final double x, final double y, final double width,
 				final double height, boolean asynchronous, boolean continuous) throws InvalidLayoutConfiguration {
@@ -481,6 +511,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 *
 		 * @param relationshipsToConsider
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		protected void updateBendPoints(InternalRelationship[] relationshipsToConsider) {
 			for (InternalRelationship relationship : relationshipsToConsider) {
@@ -569,6 +600,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * Filters the entities and relationships to apply the layout on
 		 */
 		@Override
+		@Deprecated
 		public void setFilter(Filter filter) {
 			this.filter = filter;
 		}
@@ -578,6 +610,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * algorithms force a specific order.
 		 */
 		@Override
+		@Deprecated
 		public void setComparator(Comparator comparator) {
 			this.comparator = new InternalComparator(comparator);
 		}
@@ -587,6 +620,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * entitiesToLayout list. Allows other classes in this package to use this
 		 * method to verify the input
 		 */
+		@Deprecated
 		public static boolean verifyInput(LayoutEntity[] entitiesToLayout, LayoutRelationship[] relationshipsToConsider) {
 			boolean stillValid = true;
 			for (LayoutRelationship relationship : relationshipsToConsider) {
@@ -615,6 +649,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param x
 		 * @param y
 		 */
+		@Deprecated
 		protected DisplayIndependentPoint getLocalLocation(InternalNode[] entitiesToLayout, double x, double y,
 				DisplayIndependentRectangle realBounds) {
 
@@ -632,6 +667,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * Child classes should set flag reresizeEntitiesAfterLayout to false if they
 		 * want to preserve node sizes.
 		 */
+		@Deprecated
 		protected void defaultFitWithinBounds(InternalNode[] entitiesToLayout, DisplayIndependentRectangle realBounds) {
 			defaultFitWithinBounds(entitiesToLayout, new InternalRelationship[0], realBounds);
 		}
@@ -642,6 +678,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * Child classes should set flag reresizeEntitiesAfterLayout to false if they
 		 * want to preserve node sizes.
 		 */
+		@Deprecated
 		protected void defaultFitWithinBounds(InternalNode[] entitiesToLayout, InternalRelationship[] relationships,
 				DisplayIndependentRectangle realBounds) {
 
@@ -836,6 +873,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * nodes or not. If the size is not included, the bounds will only be guaranteed
 		 * to include the center of each node.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		protected DisplayIndependentRectangle getLayoutBounds(InternalNode[] entitiesToLayout, boolean includeNodeSize) {
 			double rightSide = Double.MIN_VALUE;
@@ -908,6 +946,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * Set the width to height ratio you want the entities to use
 		 */
 		@Override
+		@Deprecated
 		public void setEntityAspectRatio(double ratio) {
 			widthToHeightRatio = ratio;
 		}
@@ -917,6 +956,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * entities.
 		 */
 		@Override
+		@Deprecated
 		public double getEntityAspectRatio() {
 			return widthToHeightRatio;
 		}
@@ -927,6 +967,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * ProgressListener of its progress.
 		 */
 		@Override
+		@Deprecated
 		public void addProgressListener(ProgressListener listener) {
 			if (!progressListeners.contains(listener)) {
 				progressListeners.add(listener);
@@ -938,6 +979,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * updates.
 		 */
 		@Override
+		@Deprecated
 		public void removeProgressListener(ProgressListener listener) {
 			if (progressListeners.contains(listener)) {
 				progressListeners.remove(listener);
@@ -948,6 +990,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * Updates the layout locations so the external nodes know about the new
 		 * locations
 		 */
+		@Deprecated
 		protected void updateLayoutLocations(InternalNode[] nodes) {
 			for (InternalNode node : nodes) {
 				if (!node.hasPreferredLocation()) {
@@ -961,11 +1004,13 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 			}
 		}
 
+		@Deprecated
 		protected void fireProgressStarted(int totalNumberOfSteps) {
 			ProgressEvent event = new ProgressEvent(0, totalNumberOfSteps);
 			List.copyOf(progressListeners).forEach(listener -> listener.progressStarted(event));
 		}
 
+		@Deprecated
 		protected void fireProgressEnded(int totalNumberOfSteps) {
 			ProgressEvent event = new ProgressEvent(totalNumberOfSteps, totalNumberOfSteps);
 			List.copyOf(progressListeners).forEach(listener -> listener.progressEnded(event));
@@ -974,6 +1019,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		/**
 		 * @since 1.5
 		 */
+		@Deprecated
 		protected void fireProgressUpdated(int currentStep, int totalNumberOfSteps) {
 			ProgressEvent event = new ProgressEvent(currentStep, totalNumberOfSteps);
 			List.copyOf(progressListeners).forEach(listener -> listener.progressUpdated(event));
@@ -986,6 +1032,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @param currentStep        The current step completed.
 		 * @param totalNumberOfSteps The total number of steps in the algorithm.
 		 */
+		@Deprecated
 		protected void fireProgressEvent(int currentStep, int totalNumberOfSteps) {
 			// Update the layout locations to the external nodes
 			Calendar now = Calendar.getInstance();
@@ -997,6 +1044,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 			}
 		}
 
+		@Deprecated
 		protected int getNumberOfProgressListeners() {
 			return progressListeners.size();
 		}
@@ -1011,6 +1059,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @since 2.0
 		 */
 		@Override
+		@Deprecated
 		public void setLayoutContext(LayoutContext context) {
 			throw new UnsupportedOperationException("Not supported in Zest 1.x"); //$NON-NLS-1$
 		}
@@ -1019,6 +1068,7 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 		 * @since 2.0
 		 */
 		@Override
+		@Deprecated
 		public void applyLayout(boolean clean) {
 			throw new UnsupportedOperationException("Not supported in Zest 1.x"); //$NON-NLS-1$
 		}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/CompositeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/CompositeLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria,
  *                           BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -35,18 +35,22 @@ public class CompositeLayoutAlgorithm implements LayoutAlgorithm {
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm.Zest1 {
 
+		@Deprecated
 		LayoutAlgorithm.Zest1[] algorithms = null;
 
+		@Deprecated
 		public Zest1(int styles, LayoutAlgorithm.Zest1[] algoirthms) {
 			super(styles);
 			this.algorithms = algoirthms;
 		}
 
+		@Deprecated
 		public Zest1(LayoutAlgorithm.Zest1[] algoirthms) {
 			this(0, algoirthms);
 		}
 
 		@Override
+		@Deprecated
 		protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 
@@ -66,24 +70,28 @@ public class CompositeLayoutAlgorithm implements LayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected int getCurrentLayoutStep() {
 			// TODO Auto-generated method stub
 			return 0;
 		}
 
 		@Override
+		@Deprecated
 		protected int getTotalNumberOfLayoutSteps() {
 			// TODO Auto-generated method stub
 			return 0;
 		}
 
 		@Override
+		@Deprecated
 		protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
 			// TODO Auto-generated method stub
 			return true;
 		}
 
 		@Override
+		@Deprecated
 		protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider) {
 			// TODO Auto-generated method stub
@@ -91,6 +99,7 @@ public class CompositeLayoutAlgorithm implements LayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double x, double y, double width, double height) {
 			// TODO Auto-generated method stub
@@ -98,6 +107,7 @@ public class CompositeLayoutAlgorithm implements LayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		public void setLayoutArea(double x, double y, double width, double height) {
 			// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/ContinuousLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/ContinuousLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -29,8 +29,10 @@ import org.eclipse.zest.layouts.dataStructures.InternalRelationship;
 @Deprecated(since = "2.0", forRemoval = true)
 public abstract class ContinuousLayoutAlgorithm extends AbstractLayoutAlgorithm.Zest1 {
 
+	@Deprecated
 	double x, y, widht, height;
 
+	@Deprecated
 	public ContinuousLayoutAlgorithm(int styles) {
 		super(styles);
 	}
@@ -38,11 +40,13 @@ public abstract class ContinuousLayoutAlgorithm extends AbstractLayoutAlgorithm.
 	/**
 	 * The logic to determine if a layout should continue running or not
 	 */
+	@Deprecated
 	protected abstract boolean performAnotherNonContinuousIteration();
 
 	/**
 	 * Computes a single iteration of the layout algorithm
 	 */
+	@Deprecated
 	protected abstract void computeOneIteration(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider, double x, double y, double width, double height);
 
@@ -57,15 +61,18 @@ public abstract class ContinuousLayoutAlgorithm extends AbstractLayoutAlgorithm.
 	}
 
 	@Override
+	@Deprecated
 	public void setLayoutArea(double x, double y, double width, double height) {
 		this.setBounds(x, y, width, height);
 
 	}
 
+	@Deprecated
 	public synchronized DisplayIndependentRectangle getBounds() {
 		return new DisplayIndependentRectangle(this.x, this.y, this.widht, this.height);
 	}
 
+	@Deprecated
 	public synchronized void setBounds(double x, double y, double width, double height) {
 		this.x = x;
 		this.y = y;
@@ -78,6 +85,7 @@ public abstract class ContinuousLayoutAlgorithm extends AbstractLayoutAlgorithm.
 	 * layout using the given relationships.
 	 */
 	@Override
+	@Deprecated
 	protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/DirectedGraphLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria,
  *                           BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -49,11 +49,13 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Zest1 extends AbstractLayoutAlgorithm.Zest1 {
 
+		@Deprecated
 		public Zest1(int styles) {
 			super(styles);
 		}
 
 		@Override
+		@Deprecated
 		protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 			Map<InternalNode, Node> mapping = new HashMap<>(entitiesToLayout.length);
@@ -87,24 +89,28 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected int getCurrentLayoutStep() {
 			// TODO Auto-generated method stub
 			return 0;
 		}
 
 		@Override
+		@Deprecated
 		protected int getTotalNumberOfLayoutSteps() {
 			// TODO Auto-generated method stub
 			return 0;
 		}
 
 		@Override
+		@Deprecated
 		protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
 			// TODO Auto-generated method stub
 			return true;
 		}
 
 		@Override
+		@Deprecated
 		protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider) {
 			// TODO Auto-generated method stub
@@ -112,6 +118,7 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double x, double y, double width, double height) {
 			// TODO Auto-generated method stub
@@ -119,6 +126,7 @@ public class DirectedGraphLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		public void setLayoutArea(double x, double y, double width, double height) {
 			// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/GridLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria,
  *                           BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -46,16 +46,22 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 
 		private static final double PADDING_PERCENTAGE = 0.95;
 
+		@Deprecated
 		protected int rowPadding = 0;
 
 		@Override
+		@Deprecated
 		public void setLayoutArea(double x, double y, double width, double height) {
 			throw new RuntimeException("Operation not implemented"); //$NON-NLS-1$
 		}
 
+		@Deprecated
 		int rows, cols, numChildren;
+		@Deprecated
 		double colWidth, rowHeight, offsetX, offsetY;
+		@Deprecated
 		int totalProgress;
+		@Deprecated
 		double h, w;
 
 		/**
@@ -64,6 +70,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * @param styles
 		 * @see LayoutStyles
 		 */
+		@Deprecated
 		public Zest1(int styles) {
 			super(styles);
 		}
@@ -71,17 +78,20 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Inititalizes the grid layout with no style.
 		 */
+		@Deprecated
 		public Zest1() {
 			this(LayoutStyles.NONE);
 		}
 
 		@Override
+		@Deprecated
 		protected int getCurrentLayoutStep() {
 			// TODO: This isn't right
 			return 0;
 		}
 
 		@Override
+		@Deprecated
 		protected int getTotalNumberOfLayoutSteps() {
 			return totalProgress;
 		}
@@ -90,6 +100,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 */
 		@Override
+		@Deprecated
 		protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double x, double y, double width, double height) {
 
@@ -150,6 +161,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *                          relationshipsToConsider
 		 */
 		@Override
+		@Deprecated
 		protected synchronized void applyLayoutInternal(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider, double boundsX, double boundsY, double boundsWidth,
 				double boundsHeight) {
@@ -173,6 +185,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider) {
 
@@ -182,6 +195,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * Calculates and returns an array containing the number of columns, followed by
 		 * the number of rows
 		 */
+		@Deprecated
 		protected int[] calculateNumberOfRowsAndCols(int numChildren, double boundX, double boundY, double boundWidth,
 				double boundHeight) {
 			if (getEntityAspectRatio() == 1.0) {
@@ -191,6 +205,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 			}
 		}
 
+		@Deprecated
 		@SuppressWarnings("static-method")
 		protected int[] calculateNumberOfRowsAndCols_square(int numChildren, double boundX, double boundY,
 				double boundWidth, double boundHeight) {
@@ -241,6 +256,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 			return result;
 		}
 
+		@Deprecated
 		@SuppressWarnings("static-method")
 		protected int[] calculateNumberOfRowsAndCols_rectangular(int numChildren) {
 			int rows = Math.max(1, (int) Math.ceil(Math.sqrt(numChildren)));
@@ -249,6 +265,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 			return result;
 		}
 
+		@Deprecated
 		protected double[] calculateNodeSize(double colWidth, double rowHeight) {
 			double childW = Math.max(MIN_ENTITY_SIZE, PADDING_PERCENTAGE * colWidth);
 			double childH = Math.max(MIN_ENTITY_SIZE, PADDING_PERCENTAGE * (rowHeight - rowPadding));
@@ -267,6 +284,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param rowPadding Value will not be set if less than 0.
 		 */
+		@Deprecated
 		public void setRowPadding(int rowPadding) {
 			if (rowPadding < 0) {
 				return;
@@ -275,6 +293,7 @@ public class GridLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 			if (asynchronous && continueous) {
 				return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -29,6 +29,7 @@ import org.eclipse.zest.layouts.LayoutStyles;
 @Deprecated(since = "2.0", forRemoval = true)
 public class HorizontalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 
+	@Deprecated
 	public HorizontalLayoutAlgorithm(int styles) {
 		super(styles);
 	}
@@ -36,6 +37,7 @@ public class HorizontalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 	/**
 	 * Horizontal Layout Algorithm constructor. Sets the Style to none.
 	 */
+	@Deprecated
 	public HorizontalLayoutAlgorithm() {
 		this(LayoutStyles.NONE);
 	}
@@ -45,6 +47,7 @@ public class HorizontalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 	 * the number of rows
 	 */
 	@Override
+	@Deprecated
 	protected int[] calculateNumberOfRowsAndCols(int numChildren, double boundX, double boundY, double boundWidth,
 			double boundHeight) {
 		int rows = 1;
@@ -54,6 +57,7 @@ public class HorizontalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 	}
 
 	@Override
+	@Deprecated
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous) {
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2006, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2006, 2025 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
@@ -36,11 +36,13 @@ public class HorizontalShift extends AbstractLayoutAlgorithm.Zest1 {
 	private static final double DELTA = 10;
 	private static final double VSPACING = 2;
 
+	@Deprecated
 	public HorizontalShift(int styles) {
 		super(styles);
 	}
 
 	@Override
+	@Deprecated
 	protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 
@@ -93,30 +95,35 @@ public class HorizontalShift extends AbstractLayoutAlgorithm.Zest1 {
 	}
 
 	@Override
+	@Deprecated
 	protected int getCurrentLayoutStep() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
 	@Override
+	@Deprecated
 	protected int getTotalNumberOfLayoutSteps() {
 		// TODO Auto-generated method stub
 		return 0;
 	}
 
 	@Override
+	@Deprecated
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continuous) {
 		// TODO Auto-generated method stub
 		return true;
 	}
 
 	@Override
+	@Deprecated
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		// TODO Auto-generated method stub
 	}
 
 	@Override
+	@Deprecated
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
@@ -124,6 +131,7 @@ public class HorizontalShift extends AbstractLayoutAlgorithm.Zest1 {
 	}
 
 	@Override
+	@Deprecated
 	public void setLayoutArea(double x, double y, double width, double height) {
 		// TODO Auto-generated method stub
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalTreeLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -37,6 +37,7 @@ public class HorizontalTreeLayoutAlgorithm extends TreeLayoutAlgorithm.Zest1 {
 	/**
 	 * Creates a horizontal tree layout with no style
 	 */
+	@Deprecated
 	public HorizontalTreeLayoutAlgorithm() {
 		this(LayoutStyles.NONE);
 	}
@@ -44,11 +45,13 @@ public class HorizontalTreeLayoutAlgorithm extends TreeLayoutAlgorithm.Zest1 {
 	/**
 	 *
 	 */
+	@Deprecated
 	public HorizontalTreeLayoutAlgorithm(int styles) {
 		super(styles);
 	}
 
 	@Override
+	@Deprecated
 	protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 			double x, double y, double width, double height) {
 		// NOTE: width and height are swtiched here when calling super method
@@ -56,6 +59,7 @@ public class HorizontalTreeLayoutAlgorithm extends TreeLayoutAlgorithm.Zest1 {
 	}
 
 	@Override
+	@Deprecated
 	protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 			InternalRelationship[] relationshipsToConsider) {
 		// swap x->y and width->height
@@ -67,6 +71,7 @@ public class HorizontalTreeLayoutAlgorithm extends TreeLayoutAlgorithm.Zest1 {
 	}
 
 	@Override
+	@Deprecated
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous) {
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/RadialLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria, BC,
  *                           Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
@@ -55,12 +55,14 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Creates a radial layout with no style.
 		 */
+		@Deprecated
 		public Zest1() {
 			this(LayoutStyles.NONE);
 		}
 
 		// TODO: This is a really strange pattern. It extends tree layout and it
 		// contains a tree layout ?
+		@Deprecated
 		public Zest1(int styles) {
 			super(styles);
 			treeLayout = new TreeLayoutAlgorithm.Zest1(styles);
@@ -69,18 +71,22 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		public void setLayoutArea(double x, double y, double width, double height) {
 			throw new RuntimeException("Operation not implemented"); //$NON-NLS-1$
 		}
 
 		@Override
+		@Deprecated
 		protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 			return !continueous;
 		}
 
+		@Deprecated
 		DisplayIndependentRectangle layoutBounds = null;
 
 		@Override
+		@Deprecated
 		protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double x, double y, double width, double height) {
 			layoutBounds = new DisplayIndependentRectangle(x, y, width, height);
@@ -88,6 +94,7 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider) {
 			roots = treeLayout.getRoots();
@@ -103,6 +110,7 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * Set the range the radial layout will use when applyLayout is called. Both
 		 * values must be in radians.
 		 */
+		@Deprecated
 		public void setRangeToLayout(double startDegree, double endDegree) {
 			this.startDegree = startDegree;
 			this.endDegree = endDegree;
@@ -113,6 +121,7 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * each entity in terms of its percentage in the tree layout. Then apply that
 		 * percentage to the radius and distance from the center.
 		 */
+		@Deprecated
 		protected void computeRadialPositions(InternalNode[] entities, DisplayIndependentRectangle bounds2) {
 			DisplayIndependentRectangle bounds = new DisplayIndependentRectangle(getLayoutBounds(entities, true));
 			bounds.height = bounds2.height;
@@ -136,6 +145,7 @@ public class RadialLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * to include the center of each node.
 		 */
 		@Override
+		@Deprecated
 		protected DisplayIndependentRectangle getLayoutBounds(InternalNode[] entitiesToLayout, boolean includeNodeSize) {
 			DisplayIndependentRectangle layoutBounds = super.getLayoutBounds(entitiesToLayout, includeNodeSize);
 			DisplayIndependentPoint centerPoint = (roots != null) ? determineCenterPoint(roots)

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SpringLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/SpringLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005.2010, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005.2010, 2025 CHISEL Group, University of Victoria, Victoria, BC,
  *                           Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
@@ -61,46 +61,55 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * The default value for the spring layout number of interations.
 		 */
+		@Deprecated
 		public static final int DEFAULT_SPRING_ITERATIONS = 1000;
 
 		/**
 		 * the default value for the time algorithm runs.
 		 */
+		@Deprecated
 		public static final long MAX_SPRING_TIME = 10000;
 
 		/**
 		 * The default value for positioning nodes randomly.
 		 */
+		@Deprecated
 		public static final boolean DEFAULT_SPRING_RANDOM = true;
 
 		/**
 		 * The default value for ignoring unconnected nodes.
 		 */
+		@Deprecated
 		public static final boolean DEFAULT_SPRING_IGNORE_UNCON = true;
 
 		/**
 		 * The default value for separating connected components.
 		 */
+		@Deprecated
 		public static final boolean DEFAULT_SPRING_SEPARATE_COMPONENTS = true;
 
 		/**
 		 * The default value for the spring layout move-control.
 		 */
+		@Deprecated
 		public static final double DEFAULT_SPRING_MOVE = 1.0f;
 
 		/**
 		 * The default value for the spring layout strain-control.
 		 */
+		@Deprecated
 		public static final double DEFAULT_SPRING_STRAIN = 1.0f;
 
 		/**
 		 * The default value for the spring layout length-control.
 		 */
+		@Deprecated
 		public static final double DEFAULT_SPRING_LENGTH = 1.0f;
 
 		/**
 		 * The default value for the spring layout gravitation-control.
 		 */
+		@Deprecated
 		public static final double DEFAULT_SPRING_GRAVITATION = 1.0f;
 
 		/**
@@ -123,11 +132,13 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Minimum distance considered between nodes
 		 */
+		@Deprecated
 		protected static final double MIN_DISTANCE = 0.001d;
 
 		/**
 		 * An arbitrarily small value in mathematics.
 		 */
+		@Deprecated
 		protected static final double EPSILON = 0.001d;
 
 		/**
@@ -191,11 +202,13 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 
 		private DisplayIndependentRectangle bounds = null;
 
+		@Deprecated
 		Date date = null;
 
 		/**
 		 * Constructor.
 		 */
+		@Deprecated
 		public Zest1(int styles) {
 			super(styles);
 			srcDestToNumRelsMap = new HashMap<>();
@@ -207,11 +220,13 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * Creates a sprint layout algoirthm with no style
 		 *
 		 */
+		@Deprecated
 		public Zest1() {
 			this(LayoutStyles.NONE);
 		}
 
 		@Override
+		@Deprecated
 		public void setLayoutArea(double x, double y, double width, double height) {
 			bounds = new DisplayIndependentRectangle(x, y, width, height);
 		}
@@ -221,6 +236,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param move The move-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setSpringMove(double move) {
 			sprMove = move;
@@ -232,6 +248,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @return The move-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public double getSpringMove() {
 			return sprMove;
@@ -242,6 +259,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param strain The strain-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setSpringStrain(double strain) {
 			sprStrain = strain;
@@ -253,6 +271,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @return The strain-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public double getSpringStrain() {
 			return sprStrain;
@@ -263,6 +282,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param length The length-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setSpringLength(double length) {
 			sprLength = length;
@@ -271,6 +291,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Gets the max time this algorithm will run for
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public long getSpringTimeout() {
 			return maxTimeMS;
@@ -281,6 +302,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param timeout
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setSpringTimeout(long timeout) {
 			maxTimeMS = timeout;
@@ -292,6 +314,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @return The length-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public double getSpringLength() {
 			return sprLength;
@@ -302,6 +325,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param gravitation The gravitation-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setSpringGravitation(double gravitation) {
 			sprGravitation = gravitation;
@@ -313,6 +337,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @return The gravitation-control value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public double getSpringGravitation() {
 			return sprGravitation;
@@ -323,6 +348,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param iterations The number of iterations.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setIterations(int iterations) {
 			sprIterations = iterations;
@@ -333,6 +359,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @return The number of iterations.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public int getIterations() {
 			return sprIterations;
@@ -344,6 +371,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *
 		 * @param random The random placement value.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setRandom(boolean random) {
 			sprRandom = random;
@@ -353,16 +381,19 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * Returns whether or not this SpringLayoutAlgorithm will layout the nodes
 		 * randomly before beginning iterations.
 		 */
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public boolean getRandom() {
 			return sprRandom;
 		}
 
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public void setWeight(String relType, double weight) {
 			relTypeToWeightMap.put(relType, Double.valueOf(weight));
 		}
 
+		@Deprecated
 		@SuppressWarnings("static-method")
 		public double getWeight(String relType) {
 			Double weight = relTypeToWeightMap.get(relType);
@@ -372,6 +403,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Sets the default conditions.
 		 */
+		@Deprecated
 		public void setDefaultConditions() {
 			// sprMove = DEFAULT_SPRING_MOVE;
 			// sprStrain = DEFAULT_SPRING_STRAIN;
@@ -400,6 +432,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		private long startTime = 0;
 
 		@Override
+		@Deprecated
 		protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double x, double y, double width, double height) {
 			// TODO: Filter out any non-wanted entities and relationships
@@ -427,6 +460,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider) {
 			reset(entitiesToLayout);
@@ -492,6 +526,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		// TODO: This is a complete Clone! (and not in a good way)
+		@Deprecated
 		protected DisplayIndependentRectangle getLayoutBoundsTemp(InternalNode[] entitiesToLayout,
 				boolean includeNodeSize) {
 			double rightSide = Double.MIN_VALUE;
@@ -511,6 +546,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 			return new DisplayIndependentRectangle(leftSide, topSide, rightSide - leftSide, bottomSide - topSide);
 		}
 
+		@Deprecated
 		protected void convertNodePositionsBack(int i, InternalNode entityToConvert, double px, double py,
 				double screenWidth, double screenHeight, DisplayIndependentRectangle layoutBounds) {
 
@@ -577,22 +613,26 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected boolean performAnotherNonContinuousIteration() {
 			setSprIterationsBasedOnTime();
 			return iteration <= sprIterations && largestMovement >= sprMove;
 		}
 
 		@Override
+		@Deprecated
 		protected int getCurrentLayoutStep() {
 			return iteration;
 		}
 
 		@Override
+		@Deprecated
 		protected int getTotalNumberOfLayoutSteps() {
 			return sprIterations;
 		}
 
 		@Override
+		@Deprecated
 		protected void computeOneIteration(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double x, double y, double width, double height) {
 			if (bounds == null) {
@@ -616,6 +656,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Puts vertices in random places, all between (0,0) and (1,1).
 		 */
+		@Deprecated
 		public void placeRandomly(InternalNode[] entitiesToLayout) {
 			// If only one node in the data repository, put it in the middle
 			if (entitiesToLayout.length == 1) {
@@ -646,6 +687,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * Computes the force for each node in this SpringLayoutAlgorithm. The computed
 		 * force will be stored in the data repository
 		 */
+		@Deprecated
 		protected void computeForces(InternalNode[] entitiesToLayout) {
 
 			// initialize all forces to zero
@@ -726,6 +768,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * computed position will be stored in the data repository. position = position
 		 * + sprMove * force
 		 */
+		@Deprecated
 		protected void computePositions(InternalNode[] entitiesToLayout) {
 			for (int i = 0; i < entitiesToLayout.length; i++) {
 				if (!anchors[i] || entitiesToLayout[i].hasPreferredLocation()) {
@@ -765,6 +808,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * coordinates in double precision. The computed positions will be still stored
 		 * in the data repository.
 		 */
+		@Deprecated
 		protected void convertToUnitCoordinates(InternalNode[] entitiesToLayout) {
 			double minX = Double.MAX_VALUE;
 			double maxX = Double.MIN_VALUE;
@@ -823,6 +867,7 @@ public class SpringLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 			return asynchronous || !continueous;
 		}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/TreeLayoutAlgorithm.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2005-2010, 2024 CHISEL Group, University of Victoria, Victoria, BC,
- *                      Canada, Johannes Kepler University Linz and others.
+ * Copyright 2005-2010, 2025 CHISEL Group, University of Victoria, Victoria, BC,
+ *                           Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -88,6 +88,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Constructs a new TreeLayoutAlgorithm object.
 		 */
+		@Deprecated
 		public Zest1(int styles) {
 			super(styles);
 		}
@@ -96,6 +97,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 * Tree layout algorithm Constructor with NO Style
 		 *
 		 */
+		@Deprecated
 		public Zest1() {
 			this(LayoutStyles.NONE);
 		}
@@ -105,16 +107,19 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/////////////////////////////////////////////////////////////////////////
 
 		@Override
+		@Deprecated
 		public void setLayoutArea(double x, double y, double width, double height) {
 			throw new RuntimeException();
 		}
 
 		@Override
+		@Deprecated
 		protected int getCurrentLayoutStep() {
 			return 0;
 		}
 
 		@Override
+		@Deprecated
 		protected int getTotalNumberOfLayoutSteps() {
 			return 4;
 		}
@@ -140,6 +145,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		 *                          relationshipsToConsider
 		 */
 		@Override
+		@Deprecated
 		protected void preLayoutAlgorithm(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double x, double y, double width, double height) {
 			// Filter unwanted entities and relationships
@@ -166,6 +172,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected void applyLayoutInternal(InternalNode[] entitiesToLayout, InternalRelationship[] relationshipsToConsider,
 				double boundsX, double boundsY, double boundsWidth, double boundsHeight) {
 
@@ -184,6 +191,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected void postLayoutAlgorithm(InternalNode[] entitiesToLayout,
 				InternalRelationship[] relationshipsToConsider) {
 			updateLayoutLocations(entitiesToLayout);
@@ -193,6 +201,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		/**
 		 * Returns the last found roots
 		 */
+		@Deprecated
 		public List getRoots() {
 			return treeRoots;
 		}
@@ -593,6 +602,7 @@ public class TreeLayoutAlgorithm extends AbstractLayoutAlgorithm {
 		}
 
 		@Override
+		@Deprecated
 		protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 			return !continueous;
 		}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/VerticalLayoutAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -33,10 +33,12 @@ public class VerticalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 	 * Veertical Layout Algorithm constructor with no styles.
 	 *
 	 */
+	@Deprecated
 	public VerticalLayoutAlgorithm() {
 		this(LayoutStyles.NONE);
 	}
 
+	@Deprecated
 	public VerticalLayoutAlgorithm(int styles) {
 		super(styles);
 	}
@@ -46,6 +48,7 @@ public class VerticalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 	 * the number of rows
 	 */
 	@Override
+	@Deprecated
 	protected int[] calculateNumberOfRowsAndCols(int numChildren, double boundX, double boundY, double boundWidth,
 			double boundHeight) {
 		int cols = 1;
@@ -55,6 +58,7 @@ public class VerticalLayoutAlgorithm extends GridLayoutAlgorithm.Zest1 {
 	}
 
 	@Override
+	@Deprecated
 	protected boolean isValidConfiguration(boolean asynchronous, boolean continueous) {
 		if (asynchronous && continueous) {
 			return false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/CycleChecker.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/CycleChecker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
@@ -48,6 +48,7 @@ public class CycleChecker {
 	 * @return <code>true</code> if there is a directed circle. Otherwise,
 	 *         <code>false</code>.
 	 */
+	@Deprecated
 	public static boolean hasDirectedCircles(LayoutEntity[] entities, LayoutRelationship[] relationships,
 			List<LayoutEntity> cycle) {
 		if (!AbstractLayoutAlgorithm.Zest1.verifyInput(entities, relationships)) {

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
@@ -35,11 +35,16 @@ public class DynamicScreen {
 
 	private DisplayIndependentRectangle screenBounds = null;
 
+	@Deprecated
 	double minX = 0.0;
+	@Deprecated
 	double minY = 0.0;
+	@Deprecated
 	double maxX = 0.0;
+	@Deprecated
 	double maxY = 0.0;
 
+	@Deprecated
 	public void cleanScreen() {
 		minX = 0.0;
 		minY = 0.0;
@@ -47,6 +52,7 @@ public class DynamicScreen {
 		maxY = 0.0;
 	}
 
+	@Deprecated
 	class XComparator implements Comparator<InternalNode> {
 		@Override
 		public int compare(InternalNode n1, InternalNode n2) {
@@ -60,6 +66,7 @@ public class DynamicScreen {
 		}
 	}
 
+	@Deprecated
 	class YComparator implements Comparator<InternalNode> {
 		@Override
 		public int compare(InternalNode n1, InternalNode n2) {
@@ -74,20 +81,24 @@ public class DynamicScreen {
 		}
 	}
 
+	@Deprecated
 	public DynamicScreen(int x, int y, int width, int height) {
 		this.screenBounds = new DisplayIndependentRectangle(x, y, width, height);
 	}
 
+	@Deprecated
 	public void removeNode(InternalNode node) {
 		xCoords.remove(node);
 		yCoords.remove(node);
 	}
 
+	@Deprecated
 	public void addNode(InternalNode node) {
 		xCoords.add(node);
 		yCoords.add(node);
 	}
 
+	@Deprecated
 	public DisplayIndependentPoint getScreenLocation(InternalNode node) {
 
 		DisplayIndependentRectangle layoutBounds = calculateBounds();
@@ -101,6 +112,7 @@ public class DynamicScreen {
 		return new DisplayIndependentPoint(x, y);
 	}
 
+	@Deprecated
 	public DisplayIndependentPoint getVirtualLocation(DisplayIndependentPoint point) {
 
 		DisplayIndependentRectangle layoutBounds = calculateBounds();

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEdgeConstraints.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEdgeConstraints.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -25,7 +25,9 @@ package org.eclipse.zest.layouts.constraints;
 public class BasicEdgeConstraints implements LayoutConstraint {
 
 	// These should all be accessed directly.
+	@Deprecated
 	public boolean isBiDirectional = false;
+	@Deprecated
 	public int weight = 1;
 
 	/*
@@ -34,6 +36,7 @@ public class BasicEdgeConstraints implements LayoutConstraint {
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
 	@Override
+	@Deprecated
 	public void clear() {
 		this.isBiDirectional = false;
 		this.weight = 1;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEntityConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/BasicEntityConstraint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -25,15 +25,22 @@ package org.eclipse.zest.layouts.constraints;
 @Deprecated(since = "2.0", forRemoval = true)
 public class BasicEntityConstraint implements LayoutConstraint {
 
+	@Deprecated
 	public boolean hasPreferredLocation = false;
 
+	@Deprecated
 	public double preferredX;
+	@Deprecated
 	public double preferredY;
 
+	@Deprecated
 	public boolean hasPreferredSize = false;
+	@Deprecated
 	public double preferredWidth;
+	@Deprecated
 	public double preferredHeight;
 
+	@Deprecated
 	public BasicEntityConstraint() {
 		clear();
 	}
@@ -44,6 +51,7 @@ public class BasicEntityConstraint implements LayoutConstraint {
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
 	@Override
+	@Deprecated
 	public void clear() {
 		this.hasPreferredLocation = false;
 		this.hasPreferredSize = false;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/EntityPriorityConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/EntityPriorityConstraint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -27,6 +27,7 @@ public class EntityPriorityConstraint implements LayoutConstraint {
 
 	// A priority that can be set for nodes. This could be used
 	// for a treemap layout
+	@Deprecated
 	public double priority = 1.0;
 
 	/*
@@ -35,6 +36,7 @@ public class EntityPriorityConstraint implements LayoutConstraint {
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
 	@Override
+	@Deprecated
 	public void clear() {
 		this.priority = 1.0;
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LabelLayoutConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LabelLayoutConstraint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -25,7 +25,9 @@ package org.eclipse.zest.layouts.constraints;
 public class LabelLayoutConstraint implements LayoutConstraint {
 
 	// These should be accessed directly
+	@Deprecated
 	public String label;
+	@Deprecated
 	public int pointSize;
 
 	/*
@@ -34,6 +36,7 @@ public class LabelLayoutConstraint implements LayoutConstraint {
 	 * @see org.eclipse.zest.layouts.constraints.LayoutConstraint#clear()
 	 */
 	@Override
+	@Deprecated
 	public void clear() {
 		label = null;
 		pointSize = 1;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LayoutConstraint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/constraints/LayoutConstraint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -30,5 +30,6 @@ public interface LayoutConstraint {
 	 * This method clears all the fields of the layout constraints. This should not
 	 * be called outside the layout package
 	 */
+	@Deprecated
 	public void clear();
 }

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/BendPoint.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/BendPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2006, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2006, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -30,34 +30,41 @@ public class BendPoint extends DisplayIndependentPoint implements LayoutBendPoin
 
 	private boolean isControlPoint = false; // is this a control point (for use in curves)
 
+	@Deprecated
 	public BendPoint(double x, double y) {
 		super(x, y);
 	}
 
+	@Deprecated
 	public BendPoint(double x, double y, boolean isControlPoint) {
 		this(x, y);
 		this.isControlPoint = isControlPoint;
 	}
 
 	@Override
+	@Deprecated
 	public double getX() {
 		return x;
 	}
 
 	@Override
+	@Deprecated
 	public double getY() {
 		return y;
 	}
 
+	@Deprecated
 	public void setX(double x) {
 		this.x = x;
 	}
 
+	@Deprecated
 	public void setY(double y) {
 		this.y = y;
 	}
 
 	@Override
+	@Deprecated
 	public boolean getIsControlPoint() {
 		return isControlPoint;
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -33,8 +33,10 @@ public class InternalNode implements Comparable, LayoutEntity {
 
 	private LayoutEntity entity = null;
 	private final Map<Object, Object> attributeMap = new HashMap<>();
+	@Deprecated
 	BasicEntityConstraint basicEntityConstraint = new BasicEntityConstraint();
 
+	@Deprecated
 	public InternalNode(LayoutEntity entity) {
 		this.entity = entity;
 		this.entity.setLayoutInformation(this);
@@ -43,62 +45,80 @@ public class InternalNode implements Comparable, LayoutEntity {
 		entity.populateLayoutConstraint(basicEntityConstraint);
 	}
 
+	@Deprecated
 	public LayoutEntity getLayoutEntity() {
 		return this.entity;
 	}
 
+	@Deprecated
 	public double getPreferredX() {
 		return basicEntityConstraint.preferredX;
 
 	}
 
+	@Deprecated
 	public double getPreferredY() {
 		return basicEntityConstraint.preferredY;
 	}
 
+	@Deprecated
 	public boolean hasPreferredLocation() {
 		return basicEntityConstraint.hasPreferredLocation;
 	}
 
+	@Deprecated
 	double dx, dy;
 
+	@Deprecated
 	public void setDx(double x) {
 		this.dx = x;
 	}
 
+	@Deprecated
 	public void setDy(double y) {
 		this.dy = y;
 	}
 
+	@Deprecated
 	public double getDx() {
 		return this.dx;
 	}
 
+	@Deprecated
 	public double getDy() {
 		return this.dy;
 	}
 
+	@Deprecated
 	public double getCurrentX() {
 		return entity.getXInLayout();
 	}
 
+	@Deprecated
 	public double getCurrentY() {
 		return entity.getYInLayout();
 	}
 
+	@Deprecated
 	public void setLocation(double x, double y) {
 		entity.setLocationInLayout(x, y);
 	}
 
+	@Deprecated
 	public void setSize(double width, double height) {
 		entity.setSizeInLayout(width, height);
 	}
 
+	@Deprecated
 	double normalizedX = 0.0;
+	@Deprecated
 	double normalizedY = 0.0;
+	@Deprecated
 	double normalizedWidth = 0.0;
+	@Deprecated
 	double normalizedHeight = 0.0;
 
+	@Deprecated
 	public void setInternalLocation(double x, double y) {
 		// entity.setLocationInLayout(x,y);
 
@@ -107,29 +127,35 @@ public class InternalNode implements Comparable, LayoutEntity {
 
 	}
 
+	@Deprecated
 	public DisplayIndependentPoint getInternalLocation() {
 		return new DisplayIndependentPoint(getInternalX(), getInternalY());
 	}
 
+	@Deprecated
 	public void setInternalSize(double width, double height) {
 		normalizedWidth = width;
 		normalizedHeight = height;
 	}
 
+	@Deprecated
 	public double getInternalX() {
 		// return entity.getXInLayout();
 		return normalizedX;
 	}
 
+	@Deprecated
 	public double getInternalY() {
 		// return entity.getYInLayout();
 		return normalizedY;
 	}
 
+	@Deprecated
 	public double getInternalWidth() {
 		return normalizedWidth;
 	}
 
+	@Deprecated
 	public double getInternalHeight() {
 		return normalizedHeight;
 	}
@@ -138,6 +164,7 @@ public class InternalNode implements Comparable, LayoutEntity {
 	 * An algorithm may require a place to store information. Use this structure for
 	 * that purpose.
 	 */
+	@Deprecated
 	public void setAttributeInLayout(Object attribute, Object value) {
 		attributeMap.put(attribute, value);
 	}
@@ -146,18 +173,21 @@ public class InternalNode implements Comparable, LayoutEntity {
 	 * An algorithm may require a place to store information. Use this structure for
 	 * that purpose.
 	 */
+	@Deprecated
 	public Object getAttributeInLayout(Object attribute) {
 		return attributeMap.get(attribute);
 	}
 
 	// TODO: Fix all these preferred stuff!!!!! NOW!
 
+	@Deprecated
 	@SuppressWarnings("static-method")
 	public boolean hasPreferredWidth() {
 		return false;
 		// return enity.getAttributeInLayout(LayoutEntity.ATTR_PREFERRED_WIDTH) != null;
 	}
 
+	@Deprecated
 	@SuppressWarnings("static-method")
 	public double getPreferredWidth() {
 		return 0.0;
@@ -168,6 +198,7 @@ public class InternalNode implements Comparable, LayoutEntity {
 //	    }
 	}
 
+	@Deprecated
 	@SuppressWarnings("static-method")
 	public boolean hasPreferredHeight() {
 		return false;
@@ -175,6 +206,7 @@ public class InternalNode implements Comparable, LayoutEntity {
 		// null;
 	}
 
+	@Deprecated
 	@SuppressWarnings("static-method")
 	public double getPreferredHeight() {
 		return 0.0;
@@ -191,6 +223,7 @@ public class InternalNode implements Comparable, LayoutEntity {
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 */
 	@Override
+	@Deprecated
 	public int compareTo(Object arg0) {
 		return 0;
 	}
@@ -201,59 +234,73 @@ public class InternalNode implements Comparable, LayoutEntity {
 	 * @see java.lang.Object#toString()
 	 */
 	@Override
+	@Deprecated
 	public String toString() {
 		return (entity != null ? entity.toString() : ""); //$NON-NLS-1$
 	}
 
+	@Deprecated
 	double layoutHeight;
+	@Deprecated
 	double layoutWidth;
+	@Deprecated
 	double layoutX;
+	@Deprecated
 	double layoutY;
+	@Deprecated
 	Object layoutInfo;
 
 	@Override
+	@Deprecated
 	public double getHeightInLayout() {
 		// TODO Auto-generated method stub
 		return layoutHeight;
 	}
 
 	@Override
+	@Deprecated
 	public Object getLayoutInformation() {
 		// TODO Auto-generated method stub
 		return this.layoutInfo;
 	}
 
 	@Override
+	@Deprecated
 	public double getWidthInLayout() {
 		// TODO Auto-generated method stub
 		return layoutWidth;
 	}
 
 	@Override
+	@Deprecated
 	public double getXInLayout() {
 		// TODO Auto-generated method stub
 		return layoutX;
 	}
 
 	@Override
+	@Deprecated
 	public double getYInLayout() {
 		// TODO Auto-generated method stub
 		return layoutY;
 	}
 
 	@Override
+	@Deprecated
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
 		// TODO Auto-generated method stub
 
 	}
 
 	@Override
+	@Deprecated
 	public void setLayoutInformation(Object internalEntity) {
 		this.layoutInfo = internalEntity;
 
 	}
 
 	@Override
+	@Deprecated
 	public void setLocationInLayout(double x, double y) {
 		// TODO Auto-generated method stub
 		this.layoutX = x;
@@ -262,17 +309,20 @@ public class InternalNode implements Comparable, LayoutEntity {
 	}
 
 	@Override
+	@Deprecated
 	public void setSizeInLayout(double width, double height) {
 		this.layoutWidth = width;
 		this.layoutHeight = height;
 	}
 
 	@Override
+	@Deprecated
 	public Object getGraphData() {
 		return null;
 	}
 
 	@Override
+	@Deprecated
 	public void setGraphData(Object o) {
 		// TODO Auto-generated method stub
 

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/dataStructures/InternalRelationship.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -38,8 +38,10 @@ public class InternalRelationship implements LayoutRelationship {
 	private final InternalNode destination;
 	private Object layoutInfo;
 	private final List<BendPoint> bendPoints = new LinkedList<>();
+	@Deprecated
 	BasicEdgeConstraints basicEdgeConstraints = new BasicEdgeConstraints();
 
+	@Deprecated
 	public InternalRelationship(LayoutRelationship externalRelationship, InternalNode source,
 			InternalNode destination) {
 		this.externalRelationship = externalRelationship;
@@ -49,10 +51,12 @@ public class InternalRelationship implements LayoutRelationship {
 		this.externalRelationship.populateLayoutConstraint(basicEdgeConstraints);
 	}
 
+	@Deprecated
 	public LayoutRelationship getLayoutRelationship() {
 		return externalRelationship;
 	}
 
+	@Deprecated
 	public InternalNode getSource() {
 		if (this.source == null) {
 			throw new RuntimeException("Source is null"); //$NON-NLS-1$
@@ -60,6 +64,7 @@ public class InternalRelationship implements LayoutRelationship {
 		return this.source;
 	}
 
+	@Deprecated
 	public InternalNode getDestination() {
 		if (this.destination == null) {
 			throw new RuntimeException("Dest is null"); //$NON-NLS-1$
@@ -67,10 +72,12 @@ public class InternalRelationship implements LayoutRelationship {
 		return this.destination;
 	}
 
+	@Deprecated
 	public double getWeight() {
 		return this.basicEdgeConstraints.weight;
 	}
 
+	@Deprecated
 	public boolean isBidirectional() {
 		return this.basicEdgeConstraints.isBiDirectional;
 	}
@@ -81,6 +88,7 @@ public class InternalRelationship implements LayoutRelationship {
 	 * @param x
 	 * @param y
 	 */
+	@Deprecated
 	public void addBendPoint(double x, double y) {
 		bendPoints.add(new BendPoint(x, y));
 	}
@@ -93,62 +101,73 @@ public class InternalRelationship implements LayoutRelationship {
 	 * @param y
 	 * @param isControlPoint
 	 */
+	@Deprecated
 	public void addBendPoint(double x, double y, boolean isControlPoint) {
 		bendPoints.add(new BendPoint(x, y, isControlPoint));
 	}
 
+	@Deprecated
 	public List getBendPoints() {
 		return this.bendPoints;
 	}
 
 	@Override
+	@Deprecated
 	public void clearBendPoints() {
 		// TODO Auto-generated method stub
 
 	}
 
 	@Override
+	@Deprecated
 	public LayoutEntity getDestinationInLayout() {
 		// TODO Auto-generated method stub
 		return destination;
 	}
 
 	@Override
+	@Deprecated
 	public Object getLayoutInformation() {
 		// TODO Auto-generated method stub
 		return layoutInfo;
 	}
 
 	@Override
+	@Deprecated
 	public LayoutEntity getSourceInLayout() {
 		// TODO Auto-generated method stub
 		return source;
 	}
 
 	@Override
+	@Deprecated
 	public void populateLayoutConstraint(LayoutConstraint constraint) {
 		// TODO Auto-generated method stub
 
 	}
 
 	@Override
+	@Deprecated
 	public void setBendPoints(LayoutBendPoint[] bendPoints) {
 		// TODO Auto-generated method stub
 
 	}
 
 	@Override
+	@Deprecated
 	public void setLayoutInformation(Object layoutInformation) {
 		this.layoutInfo = layoutInformation;
 
 	}
 
 	@Override
+	@Deprecated
 	public Object getGraphData() {
 		return null;
 	}
 
 	@Override
+	@Deprecated
 	public void setGraphData(Object o) {
 
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressEvent.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -27,7 +27,9 @@ package org.eclipse.zest.layouts.progress;
  */
 @Deprecated(since = "2.0", forRemoval = true)
 public class ProgressEvent {
+	@Deprecated
 	int stepsCompleted;
+	@Deprecated
 	int totalSteps;
 
 	/**
@@ -37,6 +39,7 @@ public class ProgressEvent {
 	 * @param totalNumberOfSteps The number used to indicate when the algorithm will
 	 *                           finish
 	 */
+	@Deprecated
 	public ProgressEvent(int stepsCompleted, int totalNumberOfSteps) {
 		this.stepsCompleted = stepsCompleted;
 		this.totalSteps = totalNumberOfSteps;
@@ -45,6 +48,7 @@ public class ProgressEvent {
 	/**
 	 * Returns the number of steps already completed.
 	 */
+	@Deprecated
 	public int getStepsCompleted() {
 		return stepsCompleted;
 	}
@@ -52,6 +56,7 @@ public class ProgressEvent {
 	/**
 	 * Returns the total number of steps to complete.
 	 */
+	@Deprecated
 	public int getTotalNumberOfSteps() {
 		return totalSteps;
 	}

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/progress/ProgressListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2024 CHISEL Group, University of Victoria, Victoria,
+ * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria,
  *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
@@ -39,14 +39,17 @@ public interface ProgressListener {
 	@Deprecated(since = "2.0", forRemoval = true)
 	public static class Stub implements ProgressListener {
 		@Override
+		@Deprecated
 		public void progressStarted(ProgressEvent e) {
 		}
 
 		@Override
+		@Deprecated
 		public void progressUpdated(ProgressEvent e) {
 		}
 
 		@Override
+		@Deprecated
 		public void progressEnded(ProgressEvent e) {
 		}
 	}
@@ -55,16 +58,19 @@ public interface ProgressListener {
 	 *
 	 * @param e
 	 */
+	@Deprecated
 	public void progressStarted(ProgressEvent e);
 
 	/**
 	 * Called when the progress of a layout changes
 	 */
+	@Deprecated
 	public void progressUpdated(ProgressEvent e);
 
 	/**
 	 *
 	 * @param e
 	 */
+	@Deprecated
 	public void progressEnded(ProgressEvent e);
 }


### PR DESCRIPTION
Due to recent changes to JDT, members of a deprecated class are no longer implicitly deprecated and require a separate `@Deprecated` annotation.

In addition, this change also adds the `@Deprecated` annotation to all methods and classes that have a `@deprecated` JavaDoc tag.

See eclipse-jdt/eclipse.jdt.core#4572