### PR TITLE
Add remaining `@Deprecated` annotations

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SubordinateUpdateManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SubordinateUpdateManager.java
@@ -23,17 +23,20 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	/**
 	 * A root figure.
 	 */
+	@Deprecated
 	protected IFigure root;
 
 	/**
 	 * A graphics source
 	 */
+	@Deprecated
 	protected GraphicsSource graphicsSource;
 
 	/**
 	 * @see UpdateManager#addDirtyRegion(IFigure, int, int, int, int)
 	 */
 	@Override
+	@Deprecated
 	public void addDirtyRegion(IFigure f, int x, int y, int w, int h) {
 		if (getSuperior() == null) {
 			return;
@@ -45,6 +48,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	 * @see UpdateManager#addInvalidFigure(IFigure)
 	 */
 	@Override
+	@Deprecated
 	public void addInvalidFigure(IFigure f) {
 		UpdateManager um = getSuperior();
 		if (um == null) {
@@ -58,6 +62,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	 *
 	 * @return the host figure
 	 */
+	@Deprecated
 	protected abstract IFigure getHost();
 
 	/**
@@ -65,6 +70,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	 *
 	 * @return the superior
 	 */
+	@Deprecated
 	protected UpdateManager getSuperior() {
 		if (getHost().getParent() == null) {
 			return null;
@@ -76,6 +82,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	 * @see UpdateManager#performUpdate()
 	 */
 	@Override
+	@Deprecated
 	public void performUpdate() {
 		UpdateManager um = getSuperior();
 		if (um == null) {
@@ -88,6 +95,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	 * @see UpdateManager#performUpdate(Rectangle)
 	 */
 	@Override
+	@Deprecated
 	public void performUpdate(Rectangle rect) {
 		UpdateManager um = getSuperior();
 		if (um == null) {
@@ -100,6 +108,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	 * @see UpdateManager#setRoot(IFigure)
 	 */
 	@Override
+	@Deprecated
 	public void setRoot(IFigure f) {
 		root = f;
 	}
@@ -108,6 +117,7 @@ public abstract class SubordinateUpdateManager extends UpdateManager {
 	 * @see UpdateManager#setGraphicsSource(GraphicsSource)
 	 */
 	@Override
+	@Deprecated
 	public void setGraphicsSource(GraphicsSource gs) {
 		graphicsSource = gs;
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/GEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/GEFPlugin.java
@@ -43,6 +43,7 @@ public final class GEFPlugin extends AbstractUIPlugin {
 	 *
 	 * @return the default GEFPlugin singleton
 	 */
+	@Deprecated
 	public static GEFPlugin getDefault() {
 		if (singleton == null) {
 			singleton = new GEFPlugin();
@@ -50,6 +51,7 @@ public final class GEFPlugin extends AbstractUIPlugin {
 		return singleton;
 	}
 
+	@Deprecated
 	GEFPlugin() {
 		try {
 			start(InternalGEFPlugin.getContext());

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/GraphicalRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/GraphicalRootEditPart.java
@@ -49,10 +49,12 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	/**
 	 * The contents
 	 */
+	@Deprecated
 	protected EditPart contents;
 	/**
 	 * the viewer
 	 */
+	@Deprecated
 	protected EditPartViewer viewer;
 	private LayeredPane innerLayers;
 	private LayeredPane printableLayers;
@@ -61,6 +63,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.editparts.AbstractEditPart#createEditPolicies()
 	 */
 	@Override
+	@Deprecated
 	protected void createEditPolicies() {
 	}
 
@@ -68,6 +71,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.editparts.AbstractGraphicalEditPart#createFigure()
 	 */
 	@Override
+	@Deprecated
 	protected IFigure createFigure() {
 		innerLayers = new LayeredPane();
 		printableLayers = new LayeredPane();
@@ -103,6 +107,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.EditPart#getCommand(org.eclipse.gef.Request)
 	 */
 	@Override
+	@Deprecated
 	public Command getCommand(Request req) {
 		return UnexecutableCommand.INSTANCE;
 	}
@@ -111,6 +116,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.RootEditPart#getContents()
 	 */
 	@Override
+	@Deprecated
 	public EditPart getContents() {
 		return contents;
 	}
@@ -121,6 +127,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.EditPart#getDragTracker(org.eclipse.gef.Request)
 	 */
 	@Override
+	@Deprecated
 	public DragTracker getDragTracker(Request req) {
 		// The drawing cannot be dragged.
 		return new MarqueeDragTracker();
@@ -130,6 +137,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see LayerManager#getLayer(java.lang.Object)
 	 */
 	@Override
+	@Deprecated
 	public IFigure getLayer(Object key) {
 		if (innerLayers == null) {
 			return null;
@@ -148,6 +156,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.GraphicalEditPart#getContentPane()
 	 */
 	@Override
+	@Deprecated
 	public IFigure getContentPane() {
 		return getLayer(PRIMARY_LAYER);
 	}
@@ -156,6 +165,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.EditPart#getModel()
 	 */
 	@Override
+	@Deprecated
 	public Object getModel() {
 		return LayerManager.ID;
 	}
@@ -166,6 +176,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.EditPart#getRoot()
 	 */
 	@Override
+	@Deprecated
 	public RootEditPart getRoot() {
 		return this;
 	}
@@ -174,6 +185,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.EditPart#getViewer()
 	 */
 	@Override
+	@Deprecated
 	public EditPartViewer getViewer() {
 		return viewer;
 	}
@@ -184,6 +196,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see AbstractEditPart#refreshChildren()
 	 */
 	@Override
+	@Deprecated
 	protected void refreshChildren() {
 	}
 
@@ -191,6 +204,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.RootEditPart#setContents(org.eclipse.gef.EditPart)
 	 */
 	@Override
+	@Deprecated
 	public void setContents(EditPart editpart) {
 		if (contents != null) {
 			removeChild(contents);
@@ -205,6 +219,7 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 	 * @see org.eclipse.gef.RootEditPart#setViewer(org.eclipse.gef.EditPartViewer)
 	 */
 	@Override
+	@Deprecated
 	public void setViewer(EditPartViewer newViewer) {
 		if (viewer == newViewer) {
 			return;
@@ -218,7 +233,9 @@ public class GraphicalRootEditPart extends AbstractGraphicalEditPart
 		}
 	}
 
+	@Deprecated
 	class FeedbackLayer extends Layer {
+		@Deprecated
 		FeedbackLayer() {
 			setEnabled(false);
 		}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionEndHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionEndHandle.java
@@ -31,6 +31,7 @@ public final class ConnectionEndHandle extends ConnectionEndpointHandle {
 	 *
 	 * @param owner the ConnectionEditPart owner
 	 */
+	@Deprecated
 	public ConnectionEndHandle(ConnectionEditPart owner) {
 		super(owner, ConnectionLocator.TARGET);
 	}
@@ -42,6 +43,7 @@ public final class ConnectionEndHandle extends ConnectionEndpointHandle {
 	 * @param owner the ConnectionEditPart owner
 	 * @param fixed if true, handle cannot be dragged
 	 */
+	@Deprecated
 	public ConnectionEndHandle(ConnectionEditPart owner, boolean fixed) {
 		super(owner, fixed, ConnectionLocator.TARGET);
 	}
@@ -49,6 +51,7 @@ public final class ConnectionEndHandle extends ConnectionEndpointHandle {
 	/**
 	 * Creates a new ConnectionEndHandle.
 	 */
+	@Deprecated
 	public ConnectionEndHandle() {
 		super(ConnectionLocator.TARGET);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionStartHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/ConnectionStartHandle.java
@@ -31,6 +31,7 @@ public final class ConnectionStartHandle extends ConnectionEndpointHandle {
 	 *
 	 * @param owner the ConnectionEditPart owner
 	 */
+	@Deprecated
 	public ConnectionStartHandle(ConnectionEditPart owner) {
 		super(owner, ConnectionLocator.TARGET);
 	}
@@ -42,6 +43,7 @@ public final class ConnectionStartHandle extends ConnectionEndpointHandle {
 	 * @param owner the ConnectionEditPart owner
 	 * @param fixed if true, handle cannot be dragged.
 	 */
+	@Deprecated
 	public ConnectionStartHandle(ConnectionEditPart owner, boolean fixed) {
 		super(owner, fixed, ConnectionLocator.SOURCE);
 	}
@@ -49,6 +51,7 @@ public final class ConnectionStartHandle extends ConnectionEndpointHandle {
 	/**
 	 * Creates a new ConnectionStartHandle.
 	 */
+	@Deprecated
 	public ConnectionStartHandle() {
 		super(ConnectionLocator.TARGET);
 	}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/NonResizableHandle.java
@@ -30,6 +30,7 @@ public class NonResizableHandle extends MoveHandle {
 	/**
 	 * The border
 	 */
+	@Deprecated
 	protected CornerTriangleBorder border;
 
 	/**
@@ -38,6 +39,7 @@ public class NonResizableHandle extends MoveHandle {
 	 *
 	 * @param owner The GraphicalEditPart to be moved by this handle.
 	 */
+	@Deprecated
 	public NonResizableHandle(GraphicalEditPart owner) {
 		this(owner, new MoveHandleLocator(owner.getFigure()));
 	}
@@ -49,6 +51,7 @@ public class NonResizableHandle extends MoveHandle {
 	 * @param owner The GraphicalEditPart to be moved by this handle.
 	 * @param loc   The Locator used to place the handle.
 	 */
+	@Deprecated
 	public NonResizableHandle(GraphicalEditPart owner, Locator loc) {
 		super(owner, loc);
 	}
@@ -58,6 +61,7 @@ public class NonResizableHandle extends MoveHandle {
 	 * DragCursor.
 	 */
 	@Override
+	@Deprecated
 	protected void initialize() {
 		setOpaque(false);
 		border = new CornerTriangleBorder(false);
@@ -70,6 +74,7 @@ public class NonResizableHandle extends MoveHandle {
 	 * Updates the handle's color by setting the border's primary attribute.
 	 */
 	@Override
+	@Deprecated
 	public void validate() {
 		border.setPrimary(getOwner().getSelected() == EditPart.SELECTED_PRIMARY);
 		super.validate();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/CopyRetargetAction.java
@@ -29,6 +29,7 @@ public class CopyRetargetAction extends RetargetAction {
 	/**
 	 * Constructs a new CopyRetargetAction with the default ID, label and image.
 	 */
+	@Deprecated
 	public CopyRetargetAction() {
 		super(ActionFactory.COPY.getId(), GEFMessages.CopyAction_Label);
 		ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteRetargetAction.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/actions/PasteRetargetAction.java
@@ -29,6 +29,7 @@ public class PasteRetargetAction extends RetargetAction {
 	/**
 	 * Constructs a new PasteRetargetAction with the default ID, label and image.
 	 */
+	@Deprecated
 	public PasteRetargetAction() {
 		super(ActionFactory.PASTE.getId(), GEFMessages.PasteAction_Label);
 		ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/AbstractLayoutAlgorithm.java
@@ -85,12 +85,15 @@ public abstract class AbstractLayoutAlgorithm implements LayoutAlgorithm {
 
 		@Deprecated
 		class InternalComparator implements Comparator<InternalNode> {
+			@Deprecated
 			Comparator<LayoutEntity> externalComparator = null;
 
+			@Deprecated
 			public InternalComparator(Comparator<LayoutEntity> externalComparator) {
 				this.externalComparator = externalComparator;
 			}
 
+			@Deprecated
 			@Override
 			public int compare(InternalNode internalNode1, InternalNode internalNode2) {
 				return this.externalComparator.compare(internalNode1.getLayoutEntity(), internalNode2.getLayoutEntity());

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/internal/DynamicScreen.java
@@ -55,6 +55,7 @@ public class DynamicScreen {
 	@Deprecated
 	class XComparator implements Comparator<InternalNode> {
 		@Override
+		@Deprecated
 		public int compare(InternalNode n1, InternalNode n2) {
 			if (n1.getInternalX() > n2.getInternalX()) {
 				return +1;
@@ -69,6 +70,7 @@ public class DynamicScreen {
 	@Deprecated
 	class YComparator implements Comparator<InternalNode> {
 		@Override
+		@Deprecated
 		public int compare(InternalNode n1, InternalNode n2) {
 			if (n1.getInternalY() > n2.getInternalY()) {
 				return +1;


### PR DESCRIPTION
This is a continuation of 5f89fad5ff8f4c262a321275fe157118e027ea0e, because the cleanup-action doesn't automatically add the `@Deprecated` annotation to its members if it is added to the type itself.