### PR TITLE
Implement zoomTo(Rectangle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
     - ScalableRootEditPart
     - ScalableLightweightSystem
 - Added `Rectangle.getBounds()`
+- Implemented AbstractZoomManager.zoomTo(Rectangle): This allows to implement features 
+  as zoom to selection or any given bounding box (e.g., Marquee selected box). 
+  This feature was originally request in [Bug 172463](https://bugs.eclipse.org/bugs/show_bug.cgi?id=172463)   
 
 ## GEF
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
@@ -516,11 +516,31 @@ public abstract class AbstractZoomManager {
 	}
 
 	/**
-	 * Currently does nothing.
+	 * Zooms to maximize the given rectangle and center it in the view port.
 	 *
 	 * @param rect a rectangle
 	 */
 	public void zoomTo(Rectangle rect) {
+		final double oldZoom = zoom;
+		final Point oldViewLocation = getViewport().getViewLocation();
+		setZoom(getZoomFactor(rect));
+		setViewLocation(getScrollLocation(rect.getCopy(), oldZoom, oldViewLocation));
+	}
+
+	private double getZoomFactor(final Rectangle zoomBounds) {
+		final Dimension available = getViewport().getClientArea().getSize();
+		final double scaleX = Math.min(available.width * getZoom() / zoomBounds.width, getMaxZoom());
+		final double scaleY = Math.min(available.height * getZoom() / zoomBounds.height, getMaxZoom());
+		return Math.min(scaleX, scaleY);
+	}
+
+	private Point getScrollLocation(final Rectangle zoomBounds, double oldZoom, Point oldViewLocation) {
+		// correct rectangle for zoom dependent data
+		zoomBounds.performTranslate(oldViewLocation.x, oldViewLocation.y);
+		zoomBounds.scale(zoom / oldZoom);
+
+		final Dimension size = getViewport().getClientArea().getSize();
+		return zoomBounds.getCenter().translate(-size.width / 2, -size.height / 2);
 	}
 
 	// private void performAnimatedZoom(Rectangle rect, boolean zoomIn, int


### PR DESCRIPTION
The missing rectangle zoom is implemented such that the rectangle is maximized in the viewport and that the center of the rectangle is in the center of the viewport.

Implements: https://bugs.eclipse.org/bugs/show_bug.cgi?id=172463