### PR TITLE
Implement getAbsoluteScale for SWT Graphics

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
@@ -680,6 +680,26 @@ public class SWTGraphics extends Graphics {
 		return ((currentState.graphicHints & AA_MASK) >> AA_SHIFT) - AA_WHOLE_NUMBER;
 	}
 
+	private final float[] transformElements = new float[6];
+
+	/**
+	 * Returns a stable, direction-independent estimate of the current graphics
+	 * scaling, computed as the square root of the absolute determinant of the
+	 * transformation matrix.
+	 *
+	 * @see org.eclipse.draw2d.Graphics#getAbsoluteScale()
+	 */
+	@Override
+	public double getAbsoluteScale() {
+		if (transform == null) {
+			return super.getAbsoluteScale();
+		}
+		transform.getElements(transformElements);
+
+		return Math.sqrt(
+				Math.abs(transformElements[0] * transformElements[3] - transformElements[1] * transformElements[2]));
+	}
+
 	@Override
 	public boolean getAdvanced() {
 		return (currentState.graphicHints & ADVANCED_GRAPHICS_MASK) != 0;


### PR DESCRIPTION
As SWT Graphics allows different scale factors in x and y, rotations, and shear which is all stored in the transformation matrix it is not as easy to get a single value for the current absolute scale. This implementation derives an approximation from the determinate of the matrix. This represents an average scale factor. For non rotated uniform x/y scaling it is the exact scale factor.

Even if it is an approximation it is suitable for level of detail checking code.

Implements: https://bugs.eclipse.org/bugs/show_bug.cgi?id=267462

An example of how to use this can be seen in https://github.com/azoitl/gef-classic/commit/7522bbc202b7abd26fb313e5218ea7ff75f51dfb

This is especially interesting for outline figures of large diagrams. I could see a significant improvement when testing that with 4diac IDE. 

