### PR TITLE
Use PDE API annotations in Draw2D

### DIFF
--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Export-Package: org.eclipse.draw2d,
  org.eclipse.draw2d.text,
  org.eclipse.draw2d.widgets,
  org.eclipse.draw2d.zoom
+Import-Package: org.eclipse.pde.api.tools.annotations;resolution:=optional
 Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
@@ -13,13 +13,14 @@
 
 package org.eclipse.draw2d;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * <b>IMPORTANT:</b> This class is <em>not</em> part of the GEF public API. It
  * is marked public only so that it can be by other GEF plugins and should never
  * be accessed from application code.
- *
- * @noreference This class is not intended to be referenced by clients.
  */
+@NoReference
 public class AutoscaleFreeformViewport extends FreeformViewport {
 
 	@SuppressWarnings("removal")

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Container.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Container.java
@@ -13,6 +13,10 @@
 
 package org.eclipse.draw2d;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * Lightweight Container which just draws the children according to the given
  * layout.
@@ -23,11 +27,13 @@ package org.eclipse.draw2d;
  *
  * A Container can not have any border and does not draw any background.
  *
- * This class is currently in development its API may
- * change: @noreference, @noextend and @noinstantiate
+ * This class is currently in development its API may change.
  *
  * @since 3.16
  */
+@NoExtend
+@NoReference
+@NoInstantiate
 public class Container extends Figure {
 
 	public Container(LayoutManager manager) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -30,6 +30,9 @@ import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 
+import org.eclipse.pde.api.tools.annotations.NoOverride;
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
@@ -2157,10 +2160,9 @@ public class Figure implements IFigure {
 	 *
 	 * @return {@code false}.
 	 * @since 3.21
-	 * @noreference This method is not intended to be referenced by clients.
-	 * @nooverride This method is not intended to be re-implemented or extended by
-	 *             clients.
 	 */
+	@NoOverride
+	@NoReference
 	@SuppressWarnings("static-method")
 	protected boolean useDoublePrecision() {
 		// This method should only be used internally and is not part of the interface

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Graphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Graphics.java
@@ -23,6 +23,8 @@ import org.eclipse.swt.graphics.Path;
 import org.eclipse.swt.graphics.Pattern;
 import org.eclipse.swt.graphics.TextLayout;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -31,9 +33,8 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * The Graphics class allows you to draw to a surface. The drawXxx() methods
  * that pertain to shapes draw an outline of the shape, whereas the fillXxx()
  * methods fill in the shape. Also provides for drawing text, lines and images.
- *
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public abstract class Graphics {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IFigure.java
@@ -20,6 +20,8 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Font;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Point;
@@ -30,9 +32,10 @@ import org.eclipse.draw2d.geometry.Translatable;
  * A lightweight graphical object. Figures are rendered to a {@link Graphics}
  * object. Figures can be composed to create complex graphics.
  *
- * @noimplement This interface is not intended to be implemented by clients. Use
- *              {@link Figure}.
+ * WARNING: This interface is not intended to be implemented by clients. Use
+ * {@link Figure}.
  */
+@NoImplement
 public interface IFigure {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/IImageFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/IImageFigure.java
@@ -15,16 +15,18 @@ package org.eclipse.draw2d;
 
 import org.eclipse.swt.graphics.Image;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+
 /**
  * Interface for image figures
  *
  * <P>
  * WARNING: This interface is not intended to be implemented by clients. Extend
  * {@link AbstractImageFigure} instead.
- *
- * @noimplement
+ * 
  * @since 3.6
  */
+@NoImplement
 public interface IImageFigure extends IFigure {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/OrderedLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/OrderedLayout.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.draw2d;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 import org.eclipse.draw2d.geometry.Transposer;
 
 /**
@@ -71,9 +73,8 @@ public abstract class OrderedLayout extends AbstractHintLayout {
 	 * Transposer object that may be used in layout calculations. Will be
 	 * automatically enabled/disabled dependent on the default and the actual
 	 * orientation.
-	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 */
+	@NoReference
 	protected Transposer transposer = new Transposer();
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
@@ -15,6 +15,8 @@ package org.eclipse.draw2d;
 
 import org.eclipse.swt.widgets.Canvas;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
@@ -29,9 +31,8 @@ import org.eclipse.draw2d.internal.InternalDraw2dUtils;
  * the other GEF plugins. This class must <b>not</b> be used together with a
  * {@link Viewport}. Otherwise the scrollbar and content are always rendered as
  * if at 100% zoom (at least on Windows}.
- *
- * @noreference This class is not intended to be referenced by clients.
  */
+@NoReference
 public class ScalableLightweightSystem extends LightweightSystem {
 
 	@Override

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Dimension.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * Stores an integer width and height. This class provides various methods for
  * manipulating this Dimension or creating new derived Objects.
@@ -215,9 +217,9 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	 * @param p the Point supplying the dimensional values
 	 * @return <code>this</code> for convenience
 	 * @since 2.0
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #expand(int, int)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public Dimension expand(Point p) {
 		return expand(p.x(), p.y());
@@ -250,9 +252,9 @@ public class Dimension implements Cloneable, java.io.Serializable, Translatable 
 	 * @param d the dimension being compared
 	 * @return a new dimension representing the difference
 	 * @since 2.0
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #getShrinked(Dimension)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public Dimension getDifference(Dimension d) {
 		return getShrinked(d);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Point.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 import org.eclipse.draw2d.PositionConstants;
 
 /**
@@ -74,9 +76,9 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 * @param x x value
 	 * @param y y value
 	 * @since 2.0
-	 * @noreference This constructor is not intended to be referenced by clients.
 	 * @deprecated Use {@link PrecisionPoint} or {@link #Point(int, int)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public Point(double x, double y) {
 		this.x = (int) x;
@@ -197,9 +199,9 @@ public class Point implements Cloneable, java.io.Serializable, Translatable {
 	 * @param p The reference Point
 	 * @return distance<sup>2</sup>
 	 * @since 2.0
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #getDistanceSquared(Point)}.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public int getDistance2(Point p) {
 		return getDistanceSquared(p);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionDimension.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * @author Randy Hudson
  */
@@ -22,20 +24,20 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * The height in double precision.
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseHeight(double)} and
 	 *             {@link #preciseHeight()} instead. This field will become private
 	 *             in the future.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseHeight;
 	/**
 	 * The width in double precision.
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseWidth(double)} and {@link #preciseWidth()}
 	 *             instead. This field will become private in the future.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseWidth;
 
@@ -351,7 +353,6 @@ public class PrecisionDimension extends Dimension {
 	/**
 	 * Updates the integer fields using the precise versions.
 	 *
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated This method should not be accessed by clients any more (it will
 	 *             be made private in future releases). The update of integer and
 	 *             precision fields is performed automatically if
@@ -359,6 +360,7 @@ public class PrecisionDimension extends Dimension {
 	 *             not manipulated directly, but only via respective methods offered
 	 *             by this class.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public final void updateInts() {
 		updateWidthInt();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPoint.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * @author danlee
  */
@@ -22,20 +24,20 @@ public class PrecisionPoint extends Point {
 	/**
 	 * Double value for X
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} and {@link #preciseX()} instead.
 	 *             This field will become private in future versions.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseX;
 
 	/**
 	 * Double value for Y
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseY(double)} and {@link #preciseY()} instead.
 	 *             This field will become private in future versions.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseY;
 
@@ -330,13 +332,13 @@ public class PrecisionPoint extends Point {
 	/**
 	 * Updates the integer fields using the precise versions.
 	 *
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated This method should not be accessed by clients any more (it will
 	 *             be made private in future releases). The update of integer and
 	 *             precision fields is performed automatically if {@link #preciseX}
 	 *             and {@link #preciseY} field values are not manipulated directly,
 	 *             but only via respective methods offered by this class.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public final void updateInts() {
 		updateXInt();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPointList.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionPointList.java
@@ -15,6 +15,8 @@ package org.eclipse.draw2d.geometry;
 
 import java.util.Arrays;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * A PointList implementation using floating point values. The use of floating
  * point prevents rounding errors from accumulating. For the sake of
@@ -227,8 +229,8 @@ public final class PrecisionPointList extends PointList {
 	 * changing the original PointList.
 	 *
 	 * @return the double array of decimal fractions by reference
-	 * @noreference This method is not intended to be referenced by clients.
 	 */
+	@NoReference
 	public double[] toDoubleArray() {
 		int arraySize = arraySize();
 		if (decimalFractions.length != arraySize) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/PrecisionRectangle.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * A Rectangle implementation using floating point values which are truncated
  * into the inherited integer fields. The use of floating point prevents
@@ -26,41 +28,41 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * Double value for height
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseHeight(double)} and
 	 *             {@link #preciseHeight()} instead. This field will become private
 	 *             in the future.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseHeight;
 
 	/**
 	 * Double value for width
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseWidth(double)} and {@link #preciseWidth()}
 	 *             instead. This field will become private in the future.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseWidth;
 
 	/**
 	 * Double value for X
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} and {@link #preciseX()} instead.
 	 *             This field will become private in the future.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseX;
 
 	/**
 	 * Double value for Y
 	 *
-	 * @noreference This field is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} and {@link #preciseY()} instead.
 	 *             This field will become private in the future.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public double preciseY;
 
@@ -487,9 +489,9 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the height.
 	 *
 	 * @param value the new height
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseHeight(double)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public void setHeight(double value) {
 		setPreciseHeight(value);
@@ -663,9 +665,9 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the width.
 	 *
 	 * @param value the new width
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseWidth(double)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public void setWidth(double value) {
 		setPreciseWidth(value);
@@ -683,9 +685,9 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the x value.
 	 *
 	 * @param value the new x value
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public void setX(double value) {
 		setPreciseX(value);
@@ -703,9 +705,9 @@ public final class PrecisionRectangle extends Rectangle {
 	 * Sets the y value.
 	 *
 	 * @param value the new y value
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #setPreciseX(double)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public void setY(double value) {
 		setPreciseY(value);
@@ -886,9 +888,9 @@ public final class PrecisionRectangle extends Rectangle {
 	 * @since 3.0
 	 * @param rect the rectangle being unioned
 	 * @return <code>this</code> for convenience
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #union(Rectangle)} instead
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public PrecisionRectangle union(PrecisionRectangle rect) {
 		if (rect == null || rect.isEmpty()) {
@@ -977,7 +979,6 @@ public final class PrecisionRectangle extends Rectangle {
 	/**
 	 * Updates the integer values based on the current precise values.
 	 *
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated This method should not be accessed by clients any more (it will
 	 *             be made private in future releases). The update of integer and
 	 *             precision fields is performed automatically if {@link #preciseX},
@@ -987,6 +988,7 @@ public final class PrecisionRectangle extends Rectangle {
 	 *
 	 * @since 3.0
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public void updateInts() {
 		updateXInt();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Ray.java
@@ -10,14 +10,16 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 /**
  * Represents a 2-dimensional directional Vector, or Ray.
  * {@link java.util.Vector} is commonly imported, so the name Ray was chosen.
  *
  * @deprecated Use {@link Vector} instead, which offers double precision instead
  *             of integer precision.
- * @noreference This class is not intended to be referenced by clients.
  */
+@NoReference
 @Deprecated(since = "3.5", forRemoval = true)
 public final class Ray {
 

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/geometry/Rectangle.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.geometry;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 import org.eclipse.draw2d.PositionConstants;
 
 /**
@@ -188,9 +190,9 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @param insets Insets to be removed from the Rectangle
 	 * @return <code>this</code> for convenience
 	 * @since 2.0
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Use {@link #shrink(Insets)} instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public Rectangle crop(Insets insets) {
 		return shrink(insets);
@@ -353,8 +355,8 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @param insets Insets being cropped from the Rectangle
 	 * @return Cropped new Rectangle
 	 * @deprecated Use {@link #getShrinked(Insets)} instead.
-	 * @noreference This method is not intended to be referenced by clients.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public Rectangle getCropped(Insets insets) {
 		return getShrinked(insets);
@@ -1284,12 +1286,12 @@ public class Rectangle implements Cloneable, java.io.Serializable, Translatable 
 	 * @param d Dimension being unioned
 	 * @return <code>this</code> for convenience
 	 * @since 2.0
-	 * @noreference This method is not intended to be referenced by clients.
 	 * @deprecated Union with a dimension generally does not make much sense, thus
 	 *             deprecating this. Use {@link Dimension#max(Dimension, Dimension)}
 	 *             and {@link #setSize(Dimension)} to implement the desired behavior
 	 *             instead.
 	 */
+	@NoReference
 	@Deprecated(since = "3.7", forRemoval = true)
 	public Rectangle union(Dimension d) {
 		width = Math.max(width, d.width);

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -30,6 +30,33 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/gef/internal/ui/palette/editparts/PaletteStackEditPart.java" type="org.eclipse.gef.internal.ui.palette.editparts.PaletteStackEditPart">
+        <filter id="571519004">
+            <message_arguments>
+                <message_argument value="org.eclipse.gef.internal.ui.palette.editparts.PaletteStackEditPart.createFigure()"/>
+                <message_argument value="Container"/>
+            </message_arguments>
+        </filter>
+        <filter id="572522506">
+            <message_arguments>
+                <message_argument value="Container"/>
+                <message_argument value="PaletteStackEditPart"/>
+            </message_arguments>
+        </filter>
+        <filter id="640708718">
+            <message_arguments>
+                <message_argument value="Container(LayoutManager)"/>
+                <message_argument value="PaletteStackEditPart"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="Figure"/>
+                <message_argument value="PaletteStackEditPart"/>
+                <message_argument value="getPreferredSize(int, int)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/gef/ui/actions/AlignmentRetargetAction.java" type="org.eclipse.gef.ui.actions.AlignmentRetargetAction">
         <filter id="571473929">
             <message_arguments>


### PR DESCRIPTION
Using the Java annotations over the JavaDoc tags has the advantage that they can be processed, even if the source files are not available, thus making the warnings more reliable.

The required package is only marked as optional because they are only relevant at compilation time, not at runtime.