### PR TITLE
Add missing PDE API annotations to Draw2D classes

### DIFF
--- a/org.eclipse.draw2d/.settings/.api_filters
+++ b/org.eclipse.draw2d/.settings/.api_filters
@@ -64,14 +64,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="src/org/eclipse/draw2d/SWTGraphics.java" type="org.eclipse.draw2d.SWTGraphics">
-        <filter id="576778288">
-            <message_arguments>
-                <message_argument value="Graphics"/>
-                <message_argument value="SWTGraphics"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/draw2d/ScalableFigure.java" type="org.eclipse.draw2d.ScalableFigure">
         <filter id="576720909">
             <message_arguments>

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/LightweightSystem.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/LightweightSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,6 +37,8 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
+
+import org.eclipse.pde.api.tools.annotations.NoOverride;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -88,6 +90,7 @@ public class LightweightSystem {
 	 *
 	 * @since 2.0
 	 */
+	@NoOverride
 	protected void addListeners() {
 		EventHandler handler = createEventHandler();
 		canvas.getAccessible().addAccessibleListener(handler);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/SWTGraphics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,6 +30,8 @@ import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.graphics.Transform;
 import org.eclipse.swt.widgets.Display;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -42,6 +44,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * <P>
  * WARNING: This class is not intended to be subclassed.
  */
+@NoExtend
 public class SWTGraphics extends Graphics {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProcessor.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BidiProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,6 +19,8 @@ import java.util.ServiceLoader;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.TextLayout;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 import org.eclipse.draw2d.text.BidiProvider.DefaultBidiProvider;
 
 /**
@@ -30,6 +32,7 @@ import org.eclipse.draw2d.text.BidiProvider.DefaultBidiProvider;
  * @author Pratik Shah
  * @since 3.1
  */
+@NoReference
 public final class BidiProcessor {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,8 @@ package org.eclipse.draw2d.text;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
+
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
@@ -39,6 +41,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author hudsonr
  * @since 2.1
  */
+@NoExtend
 public class BlockFlow extends FlowFigure {
 
 	private final BlockBox blockBox;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlowLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/BlockFlowLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,8 @@ import java.util.List;
 
 import org.eclipse.swt.SWT;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
@@ -30,6 +32,7 @@ import org.eclipse.draw2d.geometry.Insets;
  * @author hudsonr
  * @since 2.1
  */
+@NoExtend
 public class BlockFlowLayout extends FlowContainerLayout {
 
 	BlockBox blockBox;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/CaretInfo.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/CaretInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 
 package org.eclipse.draw2d.text;
+
+import org.eclipse.pde.api.tools.annotations.NoReference;
 
 import org.eclipse.draw2d.geometry.Translatable;
 
@@ -40,6 +42,7 @@ public class CaretInfo implements Translatable {
 	 * @param lineAscent  the ascent of the line on which the caret is placed
 	 * @param lineDescent the descent of the line on which the caret is placed
 	 */
+	@NoReference
 	protected CaretInfo(int x, int y, int ascent, int descent, int lineAscent, int lineDescent) {
 		this.x = x;
 		this.baseline = y + ascent;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowAdapter.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2010 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.text;
+
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -28,6 +30,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author Pratik Shah
  * @since 3.1
  */
+@NoExtend
 public class FlowAdapter extends FlowFigure {
 
 	private FlowContext context;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowContainerLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowContainerLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.text;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 import org.eclipse.draw2d.IFigure;
 
 /**
@@ -23,6 +25,7 @@ import org.eclipse.draw2d.IFigure;
  * @author hudsonr
  * @since 2.1
  */
+@NoExtend
 public abstract class FlowContainerLayout extends FlowFigureLayout implements FlowContext {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowContext.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.draw2d.text;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+
 /**
  * The context that a {@link FlowFigureLayout} uses to perform its layout.
  *
@@ -19,6 +21,7 @@ package org.eclipse.draw2d.text;
  * WARNING: This interface is not intended to be implemented by clients. It
  * exists to define the API between the layout and its context.
  */
+@NoImplement
 public interface FlowContext {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.text;
+
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
@@ -28,6 +30,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author hudsonr
  * @since 2.1
  */
+@NoExtend
 public abstract class FlowFigure extends Figure {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigureLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowFigureLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.text;
+
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.LayoutManager;
@@ -25,6 +27,7 @@ import org.eclipse.draw2d.geometry.Dimension;
  * @author hudsonr
  * @since 2.1
  */
+@NoExtend
 public abstract class FlowFigureLayout implements LayoutManager {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowPage.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.draw2d.text;
+
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -26,6 +28,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * <P>
  * WARNING: This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class FlowPage extends BlockFlow {
 
 	private final Dimension pageSize = new Dimension();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
+
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.ColorConstants;
@@ -37,6 +39,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author Randy Hudson
  * @since 2.0
  */
+@NoExtend
 public class InlineFlow extends FlowFigure {
 
 	List<FlowBox> fragments = new ArrayList<>(1);

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlowLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/InlineFlowLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,8 @@ package org.eclipse.draw2d.text;
 
 import java.util.List;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 import org.eclipse.draw2d.IFigure;
 
 /**
@@ -25,6 +27,7 @@ import org.eclipse.draw2d.IFigure;
  * @author hudsonr
  * @since 2.1
  */
+@NoExtend
 public class InlineFlowLayout extends FlowContainerLayout {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/PageFlowLayout.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/PageFlowLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,12 +12,15 @@
  *******************************************************************************/
 package org.eclipse.draw2d.text;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 /**
  * A block layout which requires no FlowContext to perform its layout. This
  * class is used by {@link FlowPage}.
  * <p>
  * WARNING: This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class PageFlowLayout extends BlockFlowLayout {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,8 @@ import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.TextLayout;
+
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
@@ -36,6 +38,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author Pratik Shah
  * @since 2.1
  */
+@NoExtend
 public class TextFlow extends InlineFlow {
 
 	static final String ELLIPSIS = "..."; //$NON-NLS-1$

--- a/org.eclipse.gef/.settings/.api_filters
+++ b/org.eclipse.gef/.settings/.api_filters
@@ -207,6 +207,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/gef/ui/palette/editparts/PaletteEditPart.java" type="org.eclipse.gef.ui.palette.editparts.PaletteEditPart">
+        <filter id="571519004">
+            <message_arguments>
+                <message_argument value="org.eclipse.gef.ui.palette.editparts.PaletteEditPart.createToolTip()"/>
+                <message_argument value="FlowPage"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/gef/ui/properties/UndoablePropertySheetPage.java" type="org.eclipse.gef.ui.properties.UndoablePropertySheetPage">
         <filter id="571473929">
             <message_arguments>


### PR DESCRIPTION
Several Draw2D classes specify in their JavaDoc how they should be used
by clients. This now adds the relevant PDE annotations.