### PR TITLE
Directly provide positions in label drawings

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
@@ -493,19 +493,19 @@ public class Label extends Figure implements PositionConstants {
 			super.paintFigure(graphics);
 		}
 		Rectangle bounds = getBounds();
-		graphics.translate(bounds.x, bounds.y);
 		if (icon != null) {
-			graphics.drawImage(icon, getIconLocation());
+			Point iconLoc = getIconLocation();
+			graphics.drawImage(icon, bounds.x + iconLoc.x, bounds.y + iconLoc.y);
 		}
+		Point curTextLocation = getTextLocation();
+		final int tx = bounds.x + curTextLocation.x;
+		final int ty = bounds.y + curTextLocation.y;
 		if (!isEnabled()) {
-			graphics.translate(1, 1);
 			graphics.setForegroundColor(ColorConstants.buttonLightest);
-			graphics.drawText(getSubStringText(), getTextLocation());
-			graphics.translate(-1, -1);
+			graphics.drawText(getSubStringText(), tx + 1, ty + 1);
 			graphics.setForegroundColor(ColorConstants.buttonDarker);
 		}
-		graphics.drawText(getSubStringText(), getTextLocation());
-		graphics.translate(-bounds.x, -bounds.y);
+		graphics.drawText(getSubStringText(), tx, ty);
 	}
 
 	/**


### PR DESCRIPTION
PaintFigure is heavily using Graphics#translate. This is an overkill and cost more performance then what it gains in readability and maintainability.

Especially when having many labels (a few 1000) and with SWT Graphics this can have a significant memory (mainly garbage) and performance gain. 