### PR TITLE
Fix improper bounds calculation for MoveHandleLocator when zoomed in

### DIFF
--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -32,7 +32,8 @@ import org.junit.platform.suite.api.Suite;
 	GraphicalViewerTest.class,
 	PaletteColorProviderTest.class,
 	SWTBotTestSuite.class,
-	DirectEditManagerTest.class
+	DirectEditManagerTest.class,
+	MoveHandleLocatorTests.class
 })
 public class GEFTestSuite {
 }

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/MoveHandleLocatorTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/MoveHandleLocatorTests.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.IScalablePane;
+import org.eclipse.draw2d.Locator;
+import org.eclipse.draw2d.ScalableLayeredPane;
+import org.eclipse.draw2d.geometry.Rectangle;
+
+import org.eclipse.gef.handles.MoveHandleLocator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MoveHandleLocatorTests {
+	private IScalablePane root;
+	private IFigure figure;
+	private Locator locator;
+
+	@BeforeEach
+	public void setUp() {
+		root = new ScalableLayeredPane();
+		root.setScale(2.0);
+
+		figure = new Figure();
+		figure.setBounds(new Rectangle(10, 15, 100, 105));
+
+		root.add(figure);
+		locator = new MoveHandleLocator(figure);
+	}
+
+	@Test
+	public void testRelocateWithZoom() {
+		IFigure fig = new Figure();
+		locator.relocate(fig);
+
+		Rectangle bounds = fig.getBounds();
+		assertEquals(20, bounds.x);
+		assertEquals(30, bounds.y);
+		assertEquals(200, bounds.width);
+		assertEquals(210, bounds.height);
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandleLocator.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/handles/MoveHandleLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -61,8 +61,9 @@ public class MoveHandleLocator implements Locator {
 		} else {
 			bounds = getReference().getBounds();
 		}
-		bounds = new PrecisionRectangle(bounds.getResized(-1, -1));
+		bounds = new PrecisionRectangle(bounds);
 		getReference().translateToAbsolute(bounds);
+		bounds.resize(-1, -1);
 		target.translateToRelative(bounds);
 		bounds.translate(-insets.left, -insets.top);
 		bounds.resize(insets.getWidth() + 1, insets.getHeight() + 1);


### PR DESCRIPTION
The `MoveHandleLocator`shrinks the size of the target figure by one, handles the insets and then expands it by one again. The problem is that the first operation is done before translating the bounds to absolute coordinates. Instead of shrinking the size by one, it is therefore shrunk by one times the zoom factor.

As a result, the bounds of the target figure don't fully enclose the bounds of the figure owned by the locator.

To reproduce: Open the Logic editor and select e.g. a Gate. When selecting the element, the selection box doesn't fully enclose the right and bottom of the figure.