### PR TITLE
Cleanup Gate figures in Logic Editor example

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFeedbackFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ public class AndGateFeedbackFigure extends AndGateFigure {
 	public AndGateFeedbackFigure() {
 		setBackgroundColor(LogicColorConstants.feedbackFill);
 		setForegroundColor(LogicColorConstants.feedbackOutline);
+		setAlpha(ALPHA_FEEDBACK);
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
  * @author danlee
  */
 public class AndGateFigure extends GateFigure {
-
+	private static final int CORNER_ARC = 6; // Must be divisible by 2 to be symmetric
 	public static final Dimension SIZE = new Dimension(30, 34);
 
 	/**
@@ -57,22 +57,28 @@ public class AndGateFigure extends GateFigure {
 		g.drawLine(r.x + 4, r.y, r.x + 4, r.y - 6);
 		g.drawLine(r.right() - 5, r.y, r.right() - 5, r.y - 5);
 
+		r.height = 15;
 		// draw main area
-		r.width++;
-		r.height++;
-		g.fillRoundRectangle(r, 5, 5);
+		g.setAlpha(getAlpha());
+		g.fillArc(r.x, r.y, CORNER_ARC, CORNER_ARC, 180, -90);
+		g.fillArc(r.right() - CORNER_ARC, r.y, CORNER_ARC, CORNER_ARC, 90, -90);
+		g.fillRectangle(r.x + CORNER_ARC / 2, r.y, r.width - CORNER_ARC, CORNER_ARC / 2);
+		g.fillRectangle(r.x, r.y + CORNER_ARC / 2, r.width, r.height - CORNER_ARC / 2);
+		g.setAlpha(ALPHA_OPAQUE);
 
 		// outline main area
-		Rectangle outlineRect = r.getCopy();
-		outlineRect.width--;
-		g.drawRoundRectangle(outlineRect, 5, 5);
+		g.drawArc(r.x, r.y, CORNER_ARC, CORNER_ARC, 180, -90);
+		g.drawArc(r.right() - CORNER_ARC, r.y, CORNER_ARC, CORNER_ARC, 90, -90);
+		g.drawLine(r.x + CORNER_ARC / 2, r.y, r.right() - CORNER_ARC / 2, r.y);
+		g.drawLine(r.x, r.y + CORNER_ARC / 2, r.x, r.bottom());
+		g.drawLine(r.right(), r.y + CORNER_ARC / 2, r.right(), r.bottom());
 
 		// draw and outline the arc
+		r.y += 6;
 		r.height = 18;
-		r.y += 7;
+		g.setAlpha(getAlpha());
 		g.fillArc(r, 180, 180);
-		r.width--;
-		r.height--;
+		g.setAlpha(ALPHA_OPAQUE);
 		g.drawArc(r, 180, 180);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 	}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/NodeFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/NodeFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,11 +18,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.swt.graphics.GC;
+
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.geometry.Point;
 
 public class NodeFigure extends Figure {
+	protected static final int ALPHA_OPAQUE = 255;
+	protected static final int ALPHA_FEEDBACK = 100;
+
+	private int alpha = ALPHA_OPAQUE;
 
 	protected Map<String, ConnectionAnchor> connectionAnchors = new HashMap<>(7);
 	protected List<ConnectionAnchor> inputConnectionAnchors = new ArrayList<>(2);
@@ -102,4 +108,27 @@ public class NodeFigure extends Figure {
 		return inputConnectionAnchors;
 	}
 
+	/**
+	 * Sets the transparency with which this figure is painted. <i>Note</i> The
+	 * transparency is a hint and may be ignored.
+	 *
+	 * @param alpha A value between 0 and 255.
+	 * @throws IllegalArgumentException If the value is outside the valid range.
+	 */
+	protected final void setAlpha(int alpha) throws IllegalArgumentException {
+		if (alpha < 0 || alpha > 255) {
+			throw new IllegalArgumentException("Alpha value must be between [0, 255]: %d".formatted(alpha)); //$NON-NLS-1$
+		}
+		this.alpha = alpha;
+	}
+
+	/**
+	 * Returns the transparency with which this figure is painted as a value between
+	 * {@code 0} (transparent) and {@code 255} (opaque).
+	 *
+	 * @see GC#getAlpha
+	 */
+	protected final int getAlpha() {
+		return alpha;
+	}
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFeedbackFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ public class OrGateFeedbackFigure extends OrGateFigure {
 	public OrGateFeedbackFigure() {
 		setBackgroundColor(LogicColorConstants.feedbackFill);
 		setForegroundColor(LogicColorConstants.feedbackOutline);
+		setAlpha(ALPHA_FEEDBACK);
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,15 +27,15 @@ public class OrGateFigure extends GateFigure {
 	protected static final PointList GATE_OUTLINE = new PointList();
 
 	static {
-		GATE_OUTLINE.addPoint(4, 20);
-		GATE_OUTLINE.addPoint(4, 4);
-		GATE_OUTLINE.addPoint(8, 8);
-		GATE_OUTLINE.addPoint(12, 10);
-		GATE_OUTLINE.addPoint(14, 10);
-		GATE_OUTLINE.addPoint(16, 10);
-		GATE_OUTLINE.addPoint(20, 8);
-		GATE_OUTLINE.addPoint(24, 4);
-		GATE_OUTLINE.addPoint(24, 20);
+		GATE_OUTLINE.addPoint(5, 20);
+		GATE_OUTLINE.addPoint(5, 4);
+		GATE_OUTLINE.addPoint(9, 8);
+		GATE_OUTLINE.addPoint(13, 10);
+		GATE_OUTLINE.addPoint(15, 10);
+		GATE_OUTLINE.addPoint(17, 10);
+		GATE_OUTLINE.addPoint(21, 8);
+		GATE_OUTLINE.addPoint(25, 4);
+		GATE_OUTLINE.addPoint(25, 20);
 	}
 
 	/**
@@ -60,7 +60,7 @@ public class OrGateFigure extends GateFigure {
 	@Override
 	protected void paintFigure(Graphics g) {
 		Rectangle r = getBounds().getCopy();
-		r.translate(4, 4);
+		r.translate(5, 4);
 		r.setSize(22, 18);
 
 		g.setAntialias(SWT.ON);
@@ -71,19 +71,21 @@ public class OrGateFigure extends GateFigure {
 		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
 
 		// Draw the bottom arc of the gate
-		r.y += 8;
+		r.y += 7;
 
-		r.width--;
-		g.fillOval(r);
-		r.width--;
-		r.height--;
+		r.width -= 2;
+		g.setAlpha(getAlpha());
+		g.fillArc(r, 180, 180);
+		g.setAlpha(ALPHA_OPAQUE);
 
-		g.drawOval(r);
+		g.drawArc(r, 180, 180);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 
 		// draw gate
 		g.translate(getLocation());
+		g.setAlpha(getAlpha());
 		g.fillPolygon(GATE_OUTLINE);
+		g.setAlpha(ALPHA_OPAQUE);
 		g.drawPolyline(GATE_OUTLINE);
 		g.translate(getLocation().getNegated());
 	}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFeedbackFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ public class XOrGateFeedbackFigure extends XOrGateFigure {
 	public XOrGateFeedbackFigure() {
 		setBackgroundColor(LogicColorConstants.feedbackFill);
 		setForegroundColor(LogicColorConstants.feedbackOutline);
+		setAlpha(ALPHA_FEEDBACK);
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,24 +30,24 @@ public class XOrGateFigure extends GateFigure {
 
 	static {
 		// setup gate outline
-		GATE_OUTLINE.addPoint(4, 20);
-		GATE_OUTLINE.addPoint(4, 8);
-		GATE_OUTLINE.addPoint(8, 12);
-		GATE_OUTLINE.addPoint(12, 14);
-		GATE_OUTLINE.addPoint(14, 14);
-		GATE_OUTLINE.addPoint(16, 14);
-		GATE_OUTLINE.addPoint(20, 12);
-		GATE_OUTLINE.addPoint(24, 8);
-		GATE_OUTLINE.addPoint(24, 20);
+		GATE_OUTLINE.addPoint(5, 20);
+		GATE_OUTLINE.addPoint(5, 8);
+		GATE_OUTLINE.addPoint(9, 12);
+		GATE_OUTLINE.addPoint(13, 14);
+		GATE_OUTLINE.addPoint(15, 14);
+		GATE_OUTLINE.addPoint(17, 14);
+		GATE_OUTLINE.addPoint(21, 12);
+		GATE_OUTLINE.addPoint(25, 8);
+		GATE_OUTLINE.addPoint(25, 20);
 
 		// setup top curve of gate
-		GATE_TOP.addPoint(4, 4);
-		GATE_TOP.addPoint(8, 8);
-		GATE_TOP.addPoint(12, 10);
-		GATE_TOP.addPoint(14, 10);
-		GATE_TOP.addPoint(16, 10);
-		GATE_TOP.addPoint(20, 8);
-		GATE_TOP.addPoint(24, 4);
+		GATE_TOP.addPoint(5, 4);
+		GATE_TOP.addPoint(9, 8);
+		GATE_TOP.addPoint(13, 10);
+		GATE_TOP.addPoint(15, 10);
+		GATE_TOP.addPoint(17, 10);
+		GATE_TOP.addPoint(21, 8);
+		GATE_TOP.addPoint(25, 4);
 	}
 
 	/**
@@ -72,7 +72,7 @@ public class XOrGateFigure extends GateFigure {
 	@Override
 	protected void paintFigure(Graphics g) {
 		Rectangle r = getBounds().getCopy();
-		r.translate(4, 4);
+		r.translate(5, 4);
 		r.setSize(22, 18);
 
 		g.setAntialias(SWT.ON);
@@ -82,32 +82,22 @@ public class XOrGateFigure extends GateFigure {
 		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
 		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
 
-		// Draw an oval that represents the bottom arc
-		r.y += 8;
+		// Draw the bottom arc
+		r.y += 7;
 
-		/*
-		 * Draw the bottom gate arc. This is done with an oval. The oval overlaps the
-		 * top arc of the gate, so this region is clipped.
-		 */
-		g.pushState();
-		Rectangle clipRect = r.getCopy();
-		clipRect.x -= 2;
-		clipRect.width += 2;
-		clipRect.y = r.y + 6;
-		g.clipRect(clipRect);
-		r.width--;
-
-		g.fillOval(r);
-		r.width--;
-		r.height--;
-		g.drawOval(r);
-		g.popState();
+		r.width -= 2;
+		g.setAlpha(getAlpha());
+		g.fillArc(r, 180, 180);
+		g.setAlpha(ALPHA_OPAQUE);
+		g.drawArc(r, 180, 180);
 		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
 
 		// Draw the gate outline and top curve
 		g.translate(getLocation());
 		g.drawPolyline(GATE_TOP);
+		g.setAlpha(getAlpha());
 		g.fillPolygon(GATE_OUTLINE);
+		g.setAlpha(ALPHA_OPAQUE);
 		g.drawPolyline(GATE_OUTLINE);
 		g.translate(getLocation().negate());
 	}


### PR DESCRIPTION
This updates the AND, OR and XOR figures so that:

1) The feedback figures are transparent again, similar to the other figures of the logic editor. Because the editor is now using an `SWTGraphics` instance for painting (with advanced mode), the transparency needs to be explicitly set. This requires that the individual shapes of the figures don't overlap one another.

2) The figures are now properly centered so that they look good when selected.