### PR TITLE
Remove unnecessary import of PDE annotation

### DIFF
--- a/org.eclipse.draw2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.draw2d/META-INF/MANIFEST.MF
@@ -19,7 +19,6 @@ Export-Package: org.eclipse.draw2d,
  org.eclipse.draw2d.text,
  org.eclipse.draw2d.widgets,
  org.eclipse.draw2d.zoom
-Import-Package: org.eclipse.pde.api.tools.annotations;resolution:=optional
 Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.draw2d/build.properties
+++ b/org.eclipse.draw2d/build.properties
@@ -18,4 +18,5 @@ bin.includes = about.*,\
 source.. = src/
 src.includes = src/org/eclipse/draw2d/images/,\
                about.html
+additional.bundles = org.eclipse.pde.api.tools.annotations
 


### PR DESCRIPTION
The classes are automatically added by PDE/Tycho if the API Analysis nature has been added to the project.