### PR TITLE
Revert "Replacing usages of Device#getDPI" #944

### DIFF
--- a/org.eclipse.draw2d.examples/sandbox/swt/bugs/Bug81467.java
+++ b/org.eclipse.draw2d.examples/sandbox/swt/bugs/Bug81467.java
@@ -15,6 +15,7 @@ package swt.bugs;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.printing.Printer;
+import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.PrinterGraphics;
 import org.eclipse.draw2d.SWTGraphics;
@@ -22,7 +23,6 @@ import org.eclipse.draw2d.SWTGraphics;
 public class Bug81467 {
 
 	public static void main(String[] args) {
-		final float DOTS_PER_INCH = 96.0f;
 		Font font = new Font(null, "Helvetica", 12, 0); //$NON-NLS-1$
 		Printer printer = new Printer();
 		printer.startJob("bugzilla 81467"); //$NON-NLS-1$
@@ -31,7 +31,7 @@ public class Bug81467 {
 		SWTGraphics graphics = new SWTGraphics(gc);
 		PrinterGraphics printGraphics = new PrinterGraphics(graphics, printer);
 
-		printGraphics.scale(printer.getDPI().x / DOTS_PER_INCH);
+		printGraphics.scale((double) printer.getDPI().x / Display.getDefault().getDPI().x);
 		printGraphics.setFont(font);
 		printGraphics.drawString("Hello world", 50, 50); //$NON-NLS-1$
 		printGraphics.dispose();

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/rulers/RulerFigure.java
@@ -13,6 +13,7 @@
 package org.eclipse.gef.internal.ui.rulers;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Figure;
@@ -51,7 +52,6 @@ public class RulerFigure extends Figure {
 	 * paintFigure(Graphics) method.
 	 */
 	private static final int BORDER_WIDTH = 3;
-	private static final float DOTS_PER_INCH = 96.0f;
 
 	private boolean horizontal;
 	private int unit;
@@ -78,7 +78,7 @@ public class RulerFigure extends Figure {
 			case RulerProvider.UNIT_PIXELS -> dpu = 1.0;
 			case RulerProvider.UNIT_CUSTOM -> dpu = rulerProvider.getCustomRulerDPU();
 			default -> {
-				dpu = DOTS_PER_INCH;
+				dpu = transposer.t(new Dimension(Display.getCurrent().getDPI())).height;
 				if (getUnit() == RulerProvider.UNIT_CENTIMETERS) {
 					dpu = dpu / 2.54;
 				}


### PR DESCRIPTION
This reverts commit ed40940b9769c3409feae58676cd2a1db5507f44.

Closes https://github.com/eclipse-gef/gef-classic/issues/944