### PR TITLE
Build and test master against Java 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,9 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 21 ]
+        java: [ 21, 25 ]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        target: [master, 2024-09]
+        include:
+          - java: 21
+            target: 2024-09
+          - java: 25
+            target: master
     runs-on: ${{ matrix.os }} 
     name: OS ${{ matrix.os }} Target ${{ matrix.target }} compile
     steps:


### PR DESCRIPTION
This configures the GitHub workflow to test against the 2024-09 Eclipse release using Java 21 and against the latest release using Java 25.