### PR TITLE
[Zest] Fix implicit narrowing conversion in compound assignment

### DIFF
--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/layouts/CustomLayout.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2005, 2025 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2005, 2026 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada.
  *
  * This program and the accompanying materials are made available under the
@@ -61,7 +61,7 @@ public class CustomLayout {
 				EntityLayout[] entitiesToLayout = context.getEntities();
 				int totalSteps = entitiesToLayout.length;
 				double distance = context.getBounds().width / totalSteps;
-				int xLocation = 0;
+				double xLocation = 0;
 
 				for (EntityLayout layoutEntity : entitiesToLayout) {
 					layoutEntity.setLocation(xLocation, layoutEntity.getLocation().y);

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/swt/CustomLayout.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright 2008, CHISEL Group, University of Victoria, Victoria,
- *                 BC, Canada and others.
+ * Copyright 2008, 2026 CHISEL Group, University of Victoria, Victoria,
+ *                      BC, Canada and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -59,7 +59,7 @@ public class CustomLayout {
 				EntityLayout[] entitiesToLayout = context.getEntities();
 				int totalSteps = entitiesToLayout.length;
 				double distance = context.getBounds().width / totalSteps;
-				int xLocation = 0;
+				double xLocation = 0;
 				for (EntityLayout layoutEntity : entitiesToLayout) {
 					layoutEntity.setLocation(xLocation, layoutEntity.getLocation().y);
 					xLocation += distance;

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShift.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2006, 2025 CHISEL Group, University of Victoria, Victoria, BC,
+ * Copyright 2006, 2026 CHISEL Group, University of Victoria, Victoria, BC,
  *                      Canada, Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
@@ -52,7 +52,7 @@ public class HorizontalShift extends AbstractLayoutAlgorithm.Zest1 {
 			addToRowList(element, row);
 		}
 
-		int heightSoFar = 0;
+		double heightSoFar = 0;
 
 		Collections.sort(row, (arg0, arg1) -> {
 			LayoutEntity node0 = arg0.get(0).getLayoutEntity();
@@ -64,7 +64,7 @@ public class HorizontalShift extends AbstractLayoutAlgorithm.Zest1 {
 			Collections.sort(currentRow, (arg0,
 					arg1) -> (int) (arg1.getLayoutEntity().getYInLayout() - arg0.getLayoutEntity().getYInLayout()));
 			int i = 0;
-			int width = (int) ((boundsWidth / 2) - currentRow.size() * 75);
+			double width = (boundsWidth / 2) - currentRow.size() * 75;
 
 			heightSoFar += currentRow.get(0).getLayoutEntity().getHeightInLayout() + VSPACING * 8;
 			for (InternalNode currentNode : currentRow) {

--- a/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShiftAlgorithm.java
+++ b/org.eclipse.zest.layouts/src/org/eclipse/zest/layouts/algorithms/HorizontalShiftAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005-2010, 2024 The Chisel Group and others.
+ * Copyright (c) 2005-2010, 2026 The Chisel Group and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -54,13 +54,13 @@ public class HorizontalShiftAlgorithm extends AbstractLayoutAlgorithm {
 
 		Comparator<EntityLayout> entityComparator = (o1, o2) -> (int) (o1.getLocation().y - o2.getLocation().y);
 		DisplayIndependentRectangle bounds = context.getBounds();
-		int heightSoFar = 0;
+		double heightSoFar = 0;
 
 		for (List<EntityLayout> currentRow : rowsList) {
 			Collections.sort(currentRow, entityComparator);
 
 			int i = 0;
-			int width = (int) (bounds.width / 2 - currentRow.size() * 75);
+			double width = bounds.width / 2 - currentRow.size() * 75;
 
 			heightSoFar += currentRow.get(0).getSize().height + VSPACING;
 			for (EntityLayout entity : currentRow) {


### PR DESCRIPTION
Compound assignment statements of the form x += y or x *= y perform an implicit narrowing conversion if the type of x is narrower than the type of y.