### PR TITLE
Remove redundant GC.dispose() calls for Image objects

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/GhostImageFigure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/GhostImageFigure.java
@@ -72,7 +72,6 @@ public class GhostImageFigure extends Figure {
 
 		offscreenImage.dispose();
 		swtGraphics.dispose();
-		gc.dispose();
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ImageUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ImageUtilities.java
@@ -56,7 +56,6 @@ public class ImageUtilities {
 		gc.fillRectangle(srcImage.getBounds());
 		gc.drawString(string, 0, 0);
 		Image result = createRotatedImage(srcImage);
-		gc.dispose();
 		srcImage.dispose();
 		return result;
 	}


### PR DESCRIPTION
This minor refactoring eliminates unnecessary calls to GC.dispose() since disposing an Image automatically disposes its associated GC. There is no visual impact from this change.