### PR TITLE
Fix zoom error for fonts in ScaledGraphics

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -63,6 +63,26 @@ public class FigureUtilities {
 			metrics = getGC().getFontMetrics();
 		}
 		return metrics;
+	}
+
+	/**
+	 * Returns the FontMetrics associated with the passed Font in relation to the
+	 * given graphics context. The same font might have different font metrics,
+	 * depending on the graphics context (e.g. when using different device zoom
+	 * levels).
+	 *
+	 * @param f the font
+	 * @param g the graphics context
+	 * @return the FontMetrics for the given font
+	 */
+	/* package */ static FontMetrics getFontMetrics(Font f, Graphics g) {
+		Font oldFont = g.getFont();
+		try {
+			g.setFont(f);
+			return g.getFontMetrics();
+		} finally {
+			g.setFont(oldFont);
+		}
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScaledGraphics.java
@@ -625,7 +625,7 @@ public class ScaledGraphics extends Graphics {
 	@Deprecated
 	@Override
 	public FontMetrics getFontMetrics() {
-		return FigureUtilities.getFontMetrics(localFont);
+		return FigureUtilities.getFontMetrics(localFont, graphics);
 	}
 
 	/** @see Graphics#getForegroundColor() */
@@ -1162,7 +1162,7 @@ public class ScaledGraphics extends Graphics {
 	private Point zoomTextPoint(int x, int y) {
 		if (localCache.font != localFont) {
 			// Font is different, re-calculate its height
-			FontMetrics metric = FigureUtilities.getFontMetrics(localFont);
+			FontMetrics metric = FigureUtilities.getFontMetrics(localFont, graphics);
 			localCache.height = metric.getHeight() - metric.getDescent();
 			localCache.font = localFont;
 		}


### PR DESCRIPTION
The native scaling in the internal `Shell` of the `FigureUtilities` class is always disabled when running on Windows. This means that calling `FigureUtilities.getFontMetrics()` always returns the metrics of an *unscaled* font.

This method is called in the `ScaledGraphics` to determine, whether the internal font has been changed and calculates the zoomed location by comparing the local with the target font. The target font is using the font metrics of the internal `Graphics` object, which might be of a *scaled* font.

It is therefore possible that the same font has different heights (depending on the graphics context), which leads to an incorrect placement.

To avoid this a new `FigureUtilities.getFontMetrics(Font, Graphics)` method is added, which returns the font metrics with respect to the internal graphics context of the `ScaledGraphics` instance.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/945