### PR TITLE
Fix: Palette width is different on Windows 100% and 200% scaling #965

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -64,7 +64,7 @@ public class InternalDraw2dUtils {
 		}
 		control.setData(InternalDraw2dUtils.DATA_AUTOSCALE_DISABLED, true);
 		control.addListener(SWT.ZoomChanged, e -> zoomConsumer.accept(e.detail / 100.0));
-		zoomConsumer.accept(InternalDraw2dUtils.calculateScale(control));
+		zoomConsumer.accept((double) InternalDraw2dUtils.calculateScale(control));
 	}
 
 	public static void setPropagateAutoScaleDisabled(Control control, boolean propagate) {
@@ -74,13 +74,20 @@ public class InternalDraw2dUtils {
 		control.setData(DATA_PROPOGATE_AUTOSCALE_DISABLED, propagate);
 	}
 
-	private static double calculateScale(Control control) {
+	/**
+	 * Returns the zoom of the given control or {@code 1.0}, if the control is
+	 * {@code null} or if the zoom can't be determined.
+	 *
+	 * @return The shell zoom of the given control.
+	 */
+	public static float calculateScale(Control control) {
 		int shellZoom;
 		try {
 			shellZoom = (int) control.getData(InternalDraw2dUtils.DATA_SHELL_ZOOM);
 		} catch (ClassCastException | NullPointerException e) {
 			shellZoom = 100;
 		}
-		return shellZoom / 100.0;
+		// returning float allows us to round it to int via Math.round(...)
+		return shellZoom / 100.0f;
 	}
 }

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -161,6 +161,7 @@ public class FlyoutPaletteComposite extends Composite {
 	private int cachedState = -1;
 	private int cachedLocation = -1;
 	private int cachedTitleHeight = 24; // give it a default value
+	private float scale;
 
 	private IPerspectiveListener perspectiveListener = new IPerspectiveListener() {
 		@Override
@@ -190,8 +191,8 @@ public class FlyoutPaletteComposite extends Composite {
 	public FlyoutPaletteComposite(Composite parent, int style, IWorkbenchPage page, PaletteViewerProvider pvProvider,
 			FlyoutPreferences preferences) {
 		super(parent, style | SWT.NO_BACKGROUND | SWT.NO_REDRAW_RESIZE | SWT.DOUBLE_BUFFERED);
-		InternalDraw2dUtils.configureForAutoscalingMode(this, scale -> {
-		});
+		InternalDraw2dUtils.configureForAutoscalingMode(this, newScale -> scale = newScale.floatValue());
+		scale = InternalDraw2dUtils.calculateScale(this);
 		provider = pvProvider;
 		prefs = preferences;
 		sash = createSash();
@@ -360,6 +361,7 @@ public class FlyoutPaletteComposite extends Composite {
 		maxWidth = Math.max(maxWidth, minWidth);
 		pWidth = Math.max(pWidth, minWidth);
 		pWidth = Math.min(pWidth, maxWidth);
+		pWidth = Math.round(pWidth * scale);
 
 		/*
 		 * Fix for Bug# 65892 Laying out only when necessary helps reduce flicker on GTK
@@ -622,7 +624,7 @@ public class FlyoutPaletteComposite extends Composite {
 					restorePaletteState(pViewer, capturedPaletteState);
 				}
 				capturedPaletteState = null;
-				minWidth = Math.max(pViewer.getControl().computeSize(0, 0).x, MIN_PALETTE_SIZE);
+				minWidth = Math.round(Math.max(pViewer.getControl().computeSize(0, 0).x * scale, MIN_PALETTE_SIZE));
 			}
 			/*
 			 * Fix for Bug# 63901 When the flyout collapses, if the palette has focus, throw
@@ -785,6 +787,7 @@ public class FlyoutPaletteComposite extends Composite {
 		private void handleSashDragged(int shiftAmount) {
 			int newSize = paletteContainer.getBounds().width
 					+ (dock == PositionConstants.EAST ? -shiftAmount : shiftAmount);
+			newSize = Math.round(newSize / scale);
 			setPaletteWidth(newSize);
 		}
 


### PR DESCRIPTION
Due to 671e2488d076ca2bc5bb1224fdf462536700c398, the flyout palette is no longer scaled with the monitor zoom. This means the width has to be explicitly scaled when performing the layout. Otherwise the palette size no longer matches once the monitor zoom is changed.

Closes https://github.com/eclipse-gef/gef-classic/issues/965