### PR TITLE
Set GEFColorProvider via an OSGi service #970

### DIFF
--- a/org.eclipse.gef/.project
+++ b/org.eclipse.gef/.project
@@ -25,6 +25,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/org.eclipse.gef/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef/META-INF/MANIFEST.MF
@@ -40,4 +40,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.gef
 Require-Capability: eclipse.swt;filter:="(image.format=svg)";resolution:=optional
+Service-Component: OSGI-INF/org.eclipse.gef.internal.ColorProviderService.xml
 

--- a/org.eclipse.gef/OSGI-INF/org.eclipse.gef.internal.ColorProviderService.xml
+++ b/org.eclipse.gef/OSGI-INF/org.eclipse.gef.internal.ColorProviderService.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.gef.internal.ColorProviderService">
+   <reference bind="setWorkbench" interface="org.eclipse.ui.IWorkbench" name="Workbench"/>
+   <implementation class="org.eclipse.gef.internal.ColorProviderService"/>
+</scr:component>

--- a/org.eclipse.gef/build.properties
+++ b/org.eclipse.gef/build.properties
@@ -17,7 +17,8 @@ bin.includes = about.*,\
                css/,\
                icons/,\
                .,\
-               META-INF/
+               META-INF/,\
+               OSGI-INF/
 source.. = src/
 src.includes = src/org/eclipse/gef/internal/icons/,\
                about.html

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ColorProviderService.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ColorProviderService.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.gef.internal;
+
+import org.eclipse.ui.IWorkbench;
+
+import org.eclipse.draw2d.BasicColorProvider;
+import org.eclipse.draw2d.ColorProvider;
+
+import org.eclipse.gef.GEFColorProvider;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class ColorProviderService {
+	@Reference
+	@SuppressWarnings("static-method")
+	public void setWorkbench(IWorkbench workbench) {
+		// Overloads the basic color provider with customizable one
+		if (ColorProvider.SystemColorFactory.getColorProvider() instanceof BasicColorProvider) {
+			ColorProvider.SystemColorFactory.setColorProvider(new GEFColorProvider());
+		}
+	}
+}

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2025 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,16 +31,12 @@ import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 
-import org.eclipse.draw2d.BasicColorProvider;
-import org.eclipse.draw2d.ColorProvider;
 import org.eclipse.draw2d.ToolTipHelper;
 
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartListener;
-import org.eclipse.gef.GEFColorProvider;
 import org.eclipse.gef.ui.parts.DomainEventDispatcher;
 import org.eclipse.gef.util.IToolTipHelperFactory;
 
@@ -67,11 +63,6 @@ public class InternalGEFPlugin extends AbstractUIPlugin {
 	public void start(BundleContext bc) throws Exception {
 		super.start(bc);
 		context = bc;
-		// Overloads the basic color provider with customizable one
-		if (ColorProvider.SystemColorFactory.getColorProvider() instanceof BasicColorProvider
-				&& PlatformUI.isWorkbenchRunning() && !PlatformUI.getWorkbench().isClosing()) {
-			ColorProvider.SystemColorFactory.setColorProvider(new GEFColorProvider());
-		}
 		toolTipProviders = new ArrayList<>();
 		toolTipProviderRefs = bc.getServiceReferences(IToolTipHelperFactory.class, null);
 		for (ServiceReference<IToolTipHelperFactory> toolTipProviderRef : toolTipProviderRefs) {


### PR DESCRIPTION
The GEF activator is not guaranteed to be called after the workbench has been created. In such a case, the GEF-specific color provider is never set. Instead, this provider should be set via an OSGi service.

Closes https://github.com/eclipse-gef/gef-classic/issues/970