### PR TITLE
Use SWT Path for painting And/OR and XOR Gate Figures

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
@@ -13,17 +13,26 @@
 package org.eclipse.gef.examples.logicdesigner.figures;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Path;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
  * @author danlee
  */
 public class AndGateFigure extends GateFigure {
-	private static final int CORNER_ARC = 6; // Must be divisible by 2 to be symmetric
 	public static final Dimension SIZE = new Dimension(30, 34);
+	private static final Path GATE_OUTLINE = new Path(null);
+
+	static {
+		GATE_OUTLINE.addArc(4, 5, 6, 6, 180, -90);
+		GATE_OUTLINE.lineTo(20, 5);
+		GATE_OUTLINE.addArc(20, 5, 6, 6, 90, -90);
+		GATE_OUTLINE.lineTo(26, 11);
+		GATE_OUTLINE.addArc(4, 11, 22, 18, 0, -180);
+		GATE_OUTLINE.lineTo(4, 8);
+	}
 
 	/**
 	 * Constructor for AndGateFigure.
@@ -46,41 +55,20 @@ public class AndGateFigure extends GateFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		Rectangle r = getBounds().getCopy();
-		r.translate(4, 5);
-		r.setSize(22, 18);
-
 		g.setAntialias(SWT.ON);
 		g.setLineWidth(2);
 
-		// Draw terminals, 2 at top
-		g.drawLine(r.x + 4, r.y, r.x + 4, r.y - 6);
-		g.drawLine(r.right() - 5, r.y, r.right() - 5, r.y - 5);
+		// Draw terminals, 2 at top and 1 at bottom
+		g.translate(getLocation());
+		g.drawLine(8, 0, 8, 5);
+		g.drawLine(22, 0, 22, 5);
+		g.drawLine(15, 29, 15, 29 + 4);
 
-		r.height = 15;
-		// draw main area
 		g.setAlpha(getAlpha());
-		g.fillArc(r.x, r.y, CORNER_ARC, CORNER_ARC, 180, -90);
-		g.fillArc(r.right() - CORNER_ARC, r.y, CORNER_ARC, CORNER_ARC, 90, -90);
-		g.fillRectangle(r.x + CORNER_ARC / 2, r.y, r.width - CORNER_ARC, CORNER_ARC / 2);
-		g.fillRectangle(r.x, r.y + CORNER_ARC / 2, r.width, r.height - CORNER_ARC / 2);
+		g.fillPath(GATE_OUTLINE);
 		g.setAlpha(ALPHA_OPAQUE);
-
-		// outline main area
-		g.drawArc(r.x, r.y, CORNER_ARC, CORNER_ARC, 180, -90);
-		g.drawArc(r.right() - CORNER_ARC, r.y, CORNER_ARC, CORNER_ARC, 90, -90);
-		g.drawLine(r.x + CORNER_ARC / 2, r.y, r.right() - CORNER_ARC / 2, r.y);
-		g.drawLine(r.x, r.y + CORNER_ARC / 2, r.x, r.bottom());
-		g.drawLine(r.right(), r.y + CORNER_ARC / 2, r.right(), r.bottom());
-
-		// draw and outline the arc
-		r.y += 6;
-		r.height = 18;
-		g.setAlpha(getAlpha());
-		g.fillArc(r, 180, 180);
-		g.setAlpha(ALPHA_OPAQUE);
-		g.drawArc(r, 180, 180);
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
+		g.drawPath(GATE_OUTLINE);
+		g.translate(getLocation().getNegated());
 	}
 
 }

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
@@ -13,29 +13,29 @@
 package org.eclipse.gef.examples.logicdesigner.figures;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Path;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
-import org.eclipse.draw2d.geometry.PointList;
-import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
  * @author danlee
  */
 public class OrGateFigure extends GateFigure {
 	public static final Dimension SIZE = new Dimension(30, 34);
-	protected static final PointList GATE_OUTLINE = new PointList();
+	private static final Path GATE_OUTLINE = new Path(null);
 
 	static {
-		GATE_OUTLINE.addPoint(5, 20);
-		GATE_OUTLINE.addPoint(5, 4);
-		GATE_OUTLINE.addPoint(9, 8);
-		GATE_OUTLINE.addPoint(13, 10);
-		GATE_OUTLINE.addPoint(15, 10);
-		GATE_OUTLINE.addPoint(17, 10);
-		GATE_OUTLINE.addPoint(21, 8);
-		GATE_OUTLINE.addPoint(25, 4);
-		GATE_OUTLINE.addPoint(25, 20);
+		GATE_OUTLINE.moveTo(5, 20);
+		GATE_OUTLINE.lineTo(5, 4);
+		GATE_OUTLINE.lineTo(9, 8);
+		GATE_OUTLINE.lineTo(13, 10);
+		GATE_OUTLINE.lineTo(15, 10);
+		GATE_OUTLINE.lineTo(17, 10);
+		GATE_OUTLINE.lineTo(21, 8);
+		GATE_OUTLINE.lineTo(25, 4);
+		GATE_OUTLINE.lineTo(25, 20);
+		GATE_OUTLINE.addArc(5, 11, 20, 18, 0, -180);
 	}
 
 	/**
@@ -59,34 +59,19 @@ public class OrGateFigure extends GateFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		Rectangle r = getBounds().getCopy();
-		r.translate(5, 4);
-		r.setSize(22, 18);
-
 		g.setAntialias(SWT.ON);
 		g.setLineWidth(2);
 
-		// Draw terminals, 2 at top
-		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
-		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
-
-		// Draw the bottom arc of the gate
-		r.y += 7;
-
-		r.width -= 2;
-		g.setAlpha(getAlpha());
-		g.fillArc(r, 180, 180);
-		g.setAlpha(ALPHA_OPAQUE);
-
-		g.drawArc(r, 180, 180);
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
-
-		// draw gate
+		// Draw terminals, 2 at top and one at bottom
 		g.translate(getLocation());
+		g.drawLine(9, 0, 9, 8);
+		g.drawLine(21, 0, 21, 8);
+		g.drawLine(15, 29, 15, 33);
+
 		g.setAlpha(getAlpha());
-		g.fillPolygon(GATE_OUTLINE);
+		g.fillPath(GATE_OUTLINE);
 		g.setAlpha(ALPHA_OPAQUE);
-		g.drawPolyline(GATE_OUTLINE);
+		g.drawPath(GATE_OUTLINE);
 		g.translate(getLocation().getNegated());
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
@@ -13,11 +13,11 @@
 package org.eclipse.gef.examples.logicdesigner.figures;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Path;
 
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.PointList;
-import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
  * @author danlee
@@ -25,20 +25,21 @@ import org.eclipse.draw2d.geometry.Rectangle;
 public class XOrGateFigure extends GateFigure {
 
 	public static final Dimension SIZE = new Dimension(30, 34);
-	protected static final PointList GATE_OUTLINE = new PointList();
+	protected static final Path GATE_OUTLINE = new Path(null);
 	protected static final PointList GATE_TOP = new PointList();
 
 	static {
 		// setup gate outline
-		GATE_OUTLINE.addPoint(5, 20);
-		GATE_OUTLINE.addPoint(5, 8);
-		GATE_OUTLINE.addPoint(9, 12);
-		GATE_OUTLINE.addPoint(13, 14);
-		GATE_OUTLINE.addPoint(15, 14);
-		GATE_OUTLINE.addPoint(17, 14);
-		GATE_OUTLINE.addPoint(21, 12);
-		GATE_OUTLINE.addPoint(25, 8);
-		GATE_OUTLINE.addPoint(25, 20);
+		GATE_OUTLINE.moveTo(5, 20);
+		GATE_OUTLINE.lineTo(5, 8);
+		GATE_OUTLINE.lineTo(9, 12);
+		GATE_OUTLINE.lineTo(13, 14);
+		GATE_OUTLINE.lineTo(15, 14);
+		GATE_OUTLINE.lineTo(17, 14);
+		GATE_OUTLINE.lineTo(21, 12);
+		GATE_OUTLINE.lineTo(25, 8);
+		GATE_OUTLINE.lineTo(25, 20);
+		GATE_OUTLINE.addArc(5, 11, 20, 18, 0, -180);
 
 		// setup top curve of gate
 		GATE_TOP.addPoint(5, 4);
@@ -71,34 +72,20 @@ public class XOrGateFigure extends GateFigure {
 	 */
 	@Override
 	protected void paintFigure(Graphics g) {
-		Rectangle r = getBounds().getCopy();
-		r.translate(5, 4);
-		r.setSize(22, 18);
-
 		g.setAntialias(SWT.ON);
 		g.setLineWidth(2);
 
-		// Draw terminals, 2 at top
-		g.drawLine(r.x + 4, r.y + 4, r.x + 4, r.y - 4);
-		g.drawLine(r.right() - 6, r.y + 4, r.right() - 6, r.y - 4);
-
-		// Draw the bottom arc
-		r.y += 7;
-
-		r.width -= 2;
-		g.setAlpha(getAlpha());
-		g.fillArc(r, 180, 180);
-		g.setAlpha(ALPHA_OPAQUE);
-		g.drawArc(r, 180, 180);
-		g.drawLine(r.x + r.width / 2, r.bottom(), r.x + r.width / 2, r.bottom() + 4);
-
-		// Draw the gate outline and top curve
+		// Draw terminals, 2 at top and one at bottom
 		g.translate(getLocation());
-		g.drawPolyline(GATE_TOP);
+		g.drawLine(9, 0, 9, 8);
+		g.drawLine(21, 0, 21, 8);
+		g.drawLine(15, 29, 15, 33);
+
 		g.setAlpha(getAlpha());
-		g.fillPolygon(GATE_OUTLINE);
+		g.fillPath(GATE_OUTLINE);
 		g.setAlpha(ALPHA_OPAQUE);
-		g.drawPolyline(GATE_OUTLINE);
+		g.drawPolyline(GATE_TOP);
+		g.drawPath(GATE_OUTLINE);
 		g.translate(getLocation().negate());
 	}
 


### PR DESCRIPTION
The Gate figures are created by combining arcs and lines to create round corners. Doing so makes the figures susceptible to rounding errors, especially when anti-alias is enabled. These errors are visible when painting the images.

Instead of using a combination of shapes, the outline of those figures is represented with an SWT Path. The advantage is that this path describes the entire figure, thus making the structure more readable.