### PR TITLE
Use "menu background selected" color for Marquee selection rectangle

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/tools/MarqueeSelectionTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,7 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.viewers.StructuredSelection;
 
-import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.ColorProvider;
 import org.eclipse.draw2d.Connection;
 import org.eclipse.draw2d.Cursors;
 import org.eclipse.draw2d.Figure;
@@ -91,10 +91,10 @@ public class MarqueeSelectionTool extends AbstractTool {
 			Rectangle bounds = getBounds().getCopy();
 			graphics.translate(getLocation());
 
-			graphics.setXORMode(true);
-			graphics.setForegroundColor(ColorConstants.white);
-			graphics.setBackgroundColor(ColorConstants.black);
+			graphics.setForegroundColor(
+					ColorProvider.SystemColorFactory.getColorProvider().getMenuBackgroundSelected());
 			graphics.setLineStyle(Graphics.LINE_DOT);
+			graphics.setLineWidth(3);
 
 			int[] points = new int[6];
 


### PR DESCRIPTION
Instead of using XOR to create a constract between the marquee rectangle and the background, we now use one of the "selection" colors defined by the GEF theme. In light mode, this will be a dark color and a light color, when using dark mode.

On Windows, XOR mode doesn't work reliably when using it together with the advanced mode, leading to an almost invisible rectangle because its outline as painted white.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/964