### PR TITLE
Use new SWT autoscale disabledment API

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureCanvas.java
@@ -161,7 +161,7 @@ public class FigureCanvas extends Canvas {
 		this.lws = lws;
 		lws.setControl(this);
 		hook();
-		InternalDraw2dUtils.setPropagateAutoScaleDisabled(this, false);
+		InternalDraw2dUtils.setPropagateAutoScaleDisabled(this);
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/AutoscalingAccess.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/AutoscalingAccess.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Yatta Solution and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.draw2d.internal;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+
+@SuppressWarnings("unchecked")
+class AutoscalingAccess {
+
+	/**
+	 * Internal flag for fetching the shell zoom
+	 */
+	@Deprecated(since = "2026-03", forRemoval = true)
+	private static final String DATA_SHELL_ZOOM = "SHELL_ZOOM"; //$NON-NLS-1$
+
+	/**
+	 * Data that can be set to scale this widget at 100%.
+	 */
+	@Deprecated(since = "2026-03", forRemoval = true)
+	private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED"; //$NON-NLS-1$
+
+	/**
+	 * Data that can be set to make a control not propagate autoScale disabling to
+	 * children.
+	 */
+	@Deprecated(since = "2026-03", forRemoval = true)
+	private static final String DATA_PROPOGATE_AUTOSCALE_DISABLED = "PROPOGATE_AUTOSCALE_DISABLED"; //$NON-NLS-1$
+
+	private static final Set<Control> propagationDisabledControls = new HashSet<>();
+
+	private static MethodHandle GETSHELLZOOM_HANDLE;
+	static {
+		try {
+			// Introduced with SWT 3.133
+			GETSHELLZOOM_HANDLE = MethodHandles.publicLookup().findVirtual(Shell.class, "getZoom", //$NON-NLS-1$
+					MethodType.methodType(int.class));
+		} catch (IllegalAccessException | NoSuchMethodException e) {
+			// ignore
+		}
+	}
+
+	private static MethodHandle SET_AUTOSCALINGMODE_HANDLE;
+	private static Object AUTOSCALING_MODE_DISABLED_INHERITED;
+	private static Object AUTOSCALING_MODE_DISABLED;
+	static {
+		try {
+			// Introduced with SWT 3.133
+			@SuppressWarnings("rawtypes")
+			Class<? extends Enum> autoscalingModeEnumClass = Class.forName("org.eclipse.swt.graphics.AutoscalingMode") //$NON-NLS-1$
+					.asSubclass(Enum.class);
+			Objects.requireNonNull(autoscalingModeEnumClass);
+			AUTOSCALING_MODE_DISABLED_INHERITED = Enum.valueOf(autoscalingModeEnumClass, "DISABLED_INHERITED"); //$NON-NLS-1$
+			Objects.requireNonNull(AUTOSCALING_MODE_DISABLED_INHERITED);
+			AUTOSCALING_MODE_DISABLED = Enum.valueOf(autoscalingModeEnumClass, "DISABLED"); //$NON-NLS-1$
+			Objects.requireNonNull(AUTOSCALING_MODE_DISABLED);
+			MethodType mt = MethodType.methodType(boolean.class, autoscalingModeEnumClass);
+			SET_AUTOSCALINGMODE_HANDLE = MethodHandles.publicLookup().findVirtual(Control.class, "setAutoscalingMode", //$NON-NLS-1$
+					mt);
+		} catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException e) {
+			// ignore
+		}
+	}
+
+	static void setAutoscaleDisabled(Control control) {
+		if (SET_AUTOSCALINGMODE_HANDLE != null) {
+			if (propagationDisabledControls.contains(control)) {
+				// When using the autoscale disablement API, disabling propagation has already
+				// disabled autoscaling itself. To avoid an unintended enabled of propagation,
+				// we must not change the disablement mode here again.
+				return;
+			}
+			try {
+				SET_AUTOSCALINGMODE_HANDLE.invoke(control, AUTOSCALING_MODE_DISABLED_INHERITED);
+			} catch (Throwable e) {
+				throw new SWTException(e.getMessage());
+			}
+		} else {
+			control.setData(DATA_AUTOSCALE_DISABLED, true);
+		}
+	}
+
+	static void disablePropagateAutoscale(Control control) {
+		if (SET_AUTOSCALINGMODE_HANDLE != null) {
+			try {
+				SET_AUTOSCALINGMODE_HANDLE.invoke(control, AUTOSCALING_MODE_DISABLED);
+			} catch (Throwable e) {
+				throw new SWTException(e.getMessage());
+			}
+		} else {
+			control.setData(DATA_PROPOGATE_AUTOSCALE_DISABLED, false);
+		}
+		propagationDisabledControls.add(control);
+		control.addDisposeListener(e -> propagationDisabledControls.remove(control));
+	}
+
+	static int getShellZoom(Control control) {
+		int shellZoom;
+		try {
+			if (GETSHELLZOOM_HANDLE != null) {
+				try {
+					shellZoom = (int) GETSHELLZOOM_HANDLE.invoke(control.getShell());
+				} catch (Throwable e) {
+					throw new SWTException(e.getMessage());
+				}
+			} else {
+				shellZoom = (int) control.getData(DATA_SHELL_ZOOM);
+			}
+		} catch (NullPointerException e) {
+			shellZoom = 100;
+		}
+		return shellZoom;
+	}
+
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -34,22 +34,6 @@ public class InternalDraw2dUtils {
 	 */
 	private static final String DRAW2D_ENABLE_AUTOSCALE = "draw2d.enableAutoscale"; //$NON-NLS-1$
 
-	/**
-	 * Internal flag for fetching the shell zoom
-	 */
-	private static final String DATA_SHELL_ZOOM = "SHELL_ZOOM"; //$NON-NLS-1$
-
-	/**
-	 * Data that can be set to scale this widget at 100%.
-	 */
-	private static final String DATA_AUTOSCALE_DISABLED = "AUTOSCALE_DISABLED"; //$NON-NLS-1$
-
-	/**
-	 * Data that can be set to make a control not propagate autoScale disabling to
-	 * children.
-	 */
-	private static final String DATA_PROPOGATE_AUTOSCALE_DISABLED = "PROPOGATE_AUTOSCALE_DISABLED"; //$NON-NLS-1$
-
 	private static final boolean enableAutoScale = "win32".equals(SWT.getPlatform()) //$NON-NLS-1$
 			&& Boolean.parseBoolean(System.getProperty(DRAW2D_ENABLE_AUTOSCALE, Boolean.TRUE.toString()))
 			&& SWT.getVersion() >= 4971; // SWT 2025-12 release or higher
@@ -62,16 +46,17 @@ public class InternalDraw2dUtils {
 		if (control == null || !isAutoScaleEnabled()) {
 			return;
 		}
-		control.setData(InternalDraw2dUtils.DATA_AUTOSCALE_DISABLED, true);
+		AutoscalingAccess.setAutoscaleDisabled(control);
+
 		control.addListener(SWT.ZoomChanged, e -> zoomConsumer.accept(e.detail / 100.0));
 		zoomConsumer.accept((double) InternalDraw2dUtils.calculateScale(control));
 	}
 
-	public static void setPropagateAutoScaleDisabled(Control control, boolean propagate) {
+	public static void setPropagateAutoScaleDisabled(Control control) {
 		if (control == null || !isAutoScaleEnabled()) {
 			return;
 		}
-		control.setData(DATA_PROPOGATE_AUTOSCALE_DISABLED, propagate);
+		AutoscalingAccess.disablePropagateAutoscale(control);
 	}
 
 	/**
@@ -81,12 +66,7 @@ public class InternalDraw2dUtils {
 	 * @return The shell zoom of the given control.
 	 */
 	public static float calculateScale(Control control) {
-		int shellZoom;
-		try {
-			shellZoom = (int) control.getData(InternalDraw2dUtils.DATA_SHELL_ZOOM);
-		} catch (ClassCastException | NullPointerException e) {
-			shellZoom = 100;
-		}
+		int shellZoom = AutoscalingAccess.getShellZoom(control);
 		// returning float allows us to round it to int via Math.round(...)
 		return shellZoom / 100.0f;
 	}


### PR DESCRIPTION
This PR uses the new autoscale disablement API added for SWT in the upcoming version 3.133. To be backwards compatible, it will use reflection and fall back to the previous implementation if an older version of SWT used. This can be cleaned up when GEF uses SWT 3.133 as minimal requirement.

The behavior should not be changed by this PR but just work as before. I utilizes `Shell.getZoom` and `Control.setAutoscalingMode`.