### PR TITLE
Fix text clipping if Draw2D-based scaling is disabled #957

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1092,6 +1092,17 @@ public class Figure implements IFigure {
 	public EventDispatcher internalGetEventDispatcher() {
 		if (getParent() != null) {
 			return getParent().internalGetEventDispatcher();
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the lightweight-system containing this figure.
+	 */
+	@NoReference
+	protected LightweightSystem internalGetLightweightSystem() {
+		if (getParent() instanceof Figure parent) {
+			return parent.internalGetLightweightSystem();
 		}
 		return null;
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Label.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -681,9 +681,12 @@ public class Label extends Figure implements PositionConstants {
 	 * @return a <code>TextUtilities</code> instance
 	 * @since 3.4
 	 */
-	@SuppressWarnings("static-method")
 	public TextUtilities getTextUtilities() {
-		return TextUtilities.INSTANCE;
+		LightweightSystem lws = internalGetLightweightSystem();
+		if (lws == null) {
+			return TextUtilities.INSTANCE;
+		}
+		return lws.internalGetTextUtilities();
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFigureUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Yatta and others.
+ * Copyright (c) 2025, 2026 Yatta and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@ package org.eclipse.draw2d.internal;
 
 import java.util.Objects;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
@@ -28,7 +29,7 @@ import org.eclipse.draw2d.geometry.Dimension;
  * All GC related operations are mirrored from {@code FigureUtilities}
  */
 public class DrawableFigureUtilities {
-	private final GC gc;
+	private GC gc;
 	private Font appliedFont;
 	private FontMetrics metrics;
 
@@ -36,6 +37,11 @@ public class DrawableFigureUtilities {
 		gc = new GC(source);
 		source.addDisposeListener(e -> {
 			gc.dispose();
+		});
+		source.addListener(SWT.ZoomChanged, event -> {
+			gc.dispose();
+			gc = new GC(source);
+			metrics = null;
 		});
 		appliedFont = gc.getFont();
 	}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFlowUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFlowUtilities.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.draw2d.internal;
+
+import org.eclipse.draw2d.TextUtilities;
+import org.eclipse.draw2d.text.FlowUtilities;
+
+/**
+ * Provides miscellaneous flow operations calculated with the zoom context of
+ * the {@code TextUtilities}.
+ */
+public class DrawableFlowUtilities extends FlowUtilities {
+	private final TextUtilities textUtilities;
+
+	public DrawableFlowUtilities(TextUtilities textUtilities) {
+		this.textUtilities = textUtilities;
+	}
+
+	@Override
+	protected TextUtilities getTextUtilities() {
+		return textUtilities;
+	}
+}

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/TextFlow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.LightweightSystem;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -724,9 +725,12 @@ public class TextFlow extends InlineFlow {
 	 * @return a <code>FlowUtilities</code> instance
 	 * @since 3.4
 	 */
-	@SuppressWarnings("static-method")
 	protected FlowUtilities getFlowUtilities() {
-		return FlowUtilities.INSTANCE;
+		LightweightSystem lws = internalGetLightweightSystem();
+		if (lws == null) {
+			return FlowUtilities.INSTANCE;
+		}
+		return lws.internalGetFlowUtilities();
 	}
 
 	/**
@@ -736,9 +740,12 @@ public class TextFlow extends InlineFlow {
 	 * @return a <code>TextUtilities</code> instance
 	 * @since 3.4
 	 */
-	@SuppressWarnings("static-method")
 	protected TextUtilities getTextUtilities() {
-		return TextUtilities.INSTANCE;
+		LightweightSystem lws = internalGetLightweightSystem();
+		if (lws == null) {
+			return TextUtilities.INSTANCE;
+		}
+		return lws.internalGetTextUtilities();
 	}
 
 }


### PR DESCRIPTION
The internal Shell used in the TextUtilities class is not notified by a change in monitor zoom. All string/text metrics returned by those classes are therefore relative to the monitor zoom of when the classes were loaded, not the current monitor zoom.

Instead of using those static classes, Figures may now access instances of the TextUtilities and FlowUtilities which are backed by the containing FigureCanvas. The GC in these instances is updated automatically on a zoom change.

Additionally, the figures inside a FigureCanvas need to be invalidated on a zoom change, as the bounds (if they are based on e.g. a Font) may no longer be accurate.

Closes https://github.com/eclipse-gef/gef-classic/issues/957