### PR TITLE
Unify print result for all OS

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintFigureOperation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PrintFigureOperation.java
@@ -16,7 +16,6 @@ package org.eclipse.draw2d;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.printing.Printer;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 
@@ -181,7 +180,7 @@ public class PrintFigureOperation extends PrintOperation {
 	 * @param figure   The IFigure used to setup graphics
 	 */
 	protected void setupPrinterGraphicsFor(Graphics graphics, IFigure figure) {
-		double dpiScale = (double) getPrinter().getDPI().x / Display.getCurrent().getDPI().x;
+		double dpiScale = (double) getPrinter().getDPI().x / 96;
 
 		Rectangle printRegion = getPrintRegion();
 		// put the print region in display coordinates

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/PrinterGraphics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/PrinterGraphics.java
@@ -102,7 +102,8 @@ public class PrinterGraphics extends ScaledGraphics {
 
 	@Override
 	int zoomFontHeight(int height) {
-		return (int) (height * zoom * Display.getCurrent().getDPI().y / printer.getDPI().y + 0.0000001);
+		float dpiFactor = Display.getCurrent().getDPI().y / 96f;
+		return (int) (height * dpiFactor + 0.0000001);
 	}
 
 	/**


### PR DESCRIPTION
This PR unifies the print result for windows and macos. Until now calculation of the scale factor of the Graphics involved using the display DPI which lead to a bigger scale factor with macos and therefor a noticably difference in the result. For the calculation the fixed factor of 96 is arbitrary and chosen to change existing behavior only on one OS. 
The calculation for the scaled font height is simplified and adapted similarly.

We used the same diagram for this results. You will notice, Windows looks the same before and after - the figures in the Mac print result were way bigger.
[MacOS - master.pdf](https://github.com/user-attachments/files/24910899/MacOS.-.master.pdf)
[Windows - master.pdf](https://github.com/user-attachments/files/24911004/Windows.-.master.pdf)

[MacOS - new.pdf](https://github.com/user-attachments/files/24910898/MacOS.-.new.pdf)
[Windows - new.pdf](https://github.com/user-attachments/files/24911006/Windows.-.new.pdf)
