### PR TITLE
DrawableFlowUtilities should override `getAverageCharWidth()`

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/TextUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/TextUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2024 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,10 @@ package org.eclipse.draw2d;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontMetrics;
 
+import org.eclipse.pde.api.tools.annotations.NoReference;
+
 import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.internal.DrawableTextUtilities;
 
 /**
  * Provides miscellaneous text operations. Clients may subclass this class if
@@ -63,9 +66,8 @@ public class TextUtilities {
 	 * @param font
 	 * @return the font's ascent
 	 */
-	@SuppressWarnings("static-method")
 	public int getAscent(Font font) {
-		FontMetrics fm = FigureUtilities.getFontMetrics(font);
+		FontMetrics fm = getFontMetrics(font);
 		return fm.getHeight() - fm.getDescent();
 	}
 
@@ -75,9 +77,8 @@ public class TextUtilities {
 	 * @param font
 	 * @return the font's descent
 	 */
-	@SuppressWarnings("static-method")
 	public int getDescent(Font font) {
-		return FigureUtilities.getFontMetrics(font).getDescent();
+		return getFontMetrics(font).getDescent();
 	}
 
 	/**
@@ -90,7 +91,7 @@ public class TextUtilities {
 	 * @return the largest substring that fits in the given width
 	 */
 	public int getLargestSubstringConfinedTo(String s, Font f, int availableWidth) {
-		FontMetrics metrics = FigureUtilities.getFontMetrics(f);
+		FontMetrics metrics = getFontMetrics(f);
 		int min = 0;
 		int max = s.length() + 1;
 		double avg = metrics.getAverageCharacterWidth();
@@ -123,5 +124,22 @@ public class TextUtilities {
 			}
 		}
 		return min;
+	}
+
+	/**
+	 * Returns the FontMetrics associated with the passed Font.
+	 * <p>
+	 * <strong>Important:</strong> This method is not intended to be called by
+	 * clients. It only exists to be overridden by {@link DrawableTextUtilities}.
+	 * </p>
+	 *
+	 * @noreference This method is not intended to be referenced by clients.
+	 * @param font the font
+	 * @return the FontMetrics for the given font
+	 */
+	@NoReference
+	@SuppressWarnings("static-method")
+	public FontMetrics getFontMetrics(Font font) {
+		return FigureUtilities.getFontMetrics(font);
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableTextUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableTextUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Yatta and others.
+ * Copyright (c) 2025, 2026 Yatta and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.draw2d.internal;
 
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.widgets.Control;
 
 import org.eclipse.draw2d.TextUtilities;
@@ -58,25 +59,14 @@ public class DrawableTextUtilities extends TextUtilities {
 	}
 
 	/**
-	 * Gets the font's ascent.
+	 * Returns the FontMetrics associated with the passed Font.
 	 *
-	 * @param font
-	 * @return the font's ascent
+	 * @param f the font
+	 * @return the FontMetrics for the given font
+	 * @see GC#getFontMetrics()
 	 */
 	@Override
-	public int getAscent(Font font) {
-		FontMetrics fm = figureUtilities.getFontMetrics(font);
-		return fm.getHeight() - fm.getDescent();
-	}
-
-	/**
-	 * Gets the font's descent.
-	 *
-	 * @param font
-	 * @return the font's descent
-	 */
-	@Override
-	public int getDescent(Font font) {
-		return figureUtilities.getFontMetrics(font).getDescent();
+	public FontMetrics getFontMetrics(Font f) {
+		return figureUtilities.getFontMetrics(f);
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/text/FlowUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,7 +23,6 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.widgets.Display;
 
-import org.eclipse.draw2d.FigureUtilities;
 import org.eclipse.draw2d.TextUtilities;
 
 /**
@@ -99,12 +98,11 @@ public class FlowUtilities {
 	 *                 are true.
 	 * @return the average character width
 	 */
-	@SuppressWarnings("static-method")
 	protected float getAverageCharWidth(TextFragmentBox fragment, Font font) {
 		if (fragment.getWidth() > 0 && fragment.length != 0) {
 			return fragment.getWidth() / (float) fragment.length;
 		}
-		return (float) FigureUtilities.getFontMetrics(font).getAverageCharacterWidth();
+		return (float) getTextUtilities().getFontMetrics(font).getAverageCharacterWidth();
 	}
 
 	static int getBorderAscent(InlineFlow owner) {


### PR DESCRIPTION
This method is calling `FigureUtilities` to get the `FontMetrics`, instead `DrawableFigureUtilities`, causing a mismatch between the calculated and actual character width.

By adding a `getFontMetrics()` method to the `TextUtilities` class, we can simply override it in `DrawableTextUtilities` and use it to clean up a lot of code duplication and inject the correct `FontMetrics` instance in the `FlowUtilities`.