### PR TITLE
Mark `VirtualNode` for removal

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RouteEdges.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/RouteEdges.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2025 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -55,8 +55,7 @@ class RouteEdges extends GraphVisitor {
 		router.addPath(path);
 		Rectangle o;
 		Insets padding;
-		for (Node element : edge.vNodes) {
-			VirtualNode node = (VirtualNode) element;
+		for (Node node : edge.vNodes) {
 			Node neighbor;
 			if (node.left != null) {
 				neighbor = node.left;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/TransposeMetrics.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/TransposeMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2025 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -67,8 +67,7 @@ class TransposeMetrics extends GraphVisitor {
 			if (bends == null) {
 				continue;
 			}
-			for (Node bend : bends) {
-				VirtualNode vnode = (VirtualNode) bend;
+			for (Node vnode : bends) {
 				temp = vnode.y;
 				vnode.y = vnode.x;
 				vnode.x = temp;

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNode.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2025 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,11 +15,12 @@ package org.eclipse.draw2d.graph;
 import org.eclipse.draw2d.geometry.Insets;
 
 /**
- * @deprecated virtual nodes of an edge should be cast to Node.
+ * @deprecated virtual nodes of an edge should be cast to Node. This class will
+ *             be made package-private after the 2028-03 release.
  * @author Randy Hudson
  * @since 2.1.2
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2026-03")
 public class VirtualNode extends Node {
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/graph/VirtualNodeCreation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,7 +37,7 @@ class VirtualNodeCreation extends RevertableChange {
 	 * @param edge  The edge to convert
 	 * @param graph the graph containing the edge
 	 */
-	@SuppressWarnings("removal")
+	@SuppressWarnings({ "removal", "deprecation" })
 	public VirtualNodeCreation(Edge edge, DirectedGraph graph) {
 		this.edge = edge;
 		this.graph = graph;


### PR DESCRIPTION
This class was deprecated with fb1a1a272e28d3f710a31be7c2d69ee318d9a780 and should be treated exactly as any other Node. By marking it as "for removal", it can be made package-private after the 2028-03 release.