### PR TITLE
Make default Graphics implementation configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   
   As part of this deprecation also all methods and flags allowing to switch to between `SWTGraphics` and 
   `ScaledGraphics` are deprecated and the default behavior is changed to use `SWTGraphics`.
+  The default behavior can be switched back to use `ScaledGraphics` by setting the system property 
+  `draw2d.useScaledGraphicsByDefault` to `true`. Note that this is a temporary property that will
+  at latest be removed together with the `ScaledGraphics` itself.
   
   **Action Required:** If your application depends on `ScaledGraphics` you need to actively switch it on for the following classes:
     - ScaleableFreeformLayeredPane

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableFreeformLayeredPane.java
@@ -32,7 +32,7 @@ public class ScalableFreeformLayeredPane extends FreeformLayeredPane implements 
 	private final boolean useScaledGraphics;
 
 	public ScalableFreeformLayeredPane() {
-		this(false);
+		this(InternalDraw2dUtils.useScaledGraphicsByDefault());
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLayeredPane.java
@@ -35,7 +35,7 @@ public class ScalableLayeredPane extends LayeredPane implements IScalablePane {
 	private final boolean useScaledGraphics;
 
 	public ScalableLayeredPane() {
-		this(false);
+		this(InternalDraw2dUtils.useScaledGraphicsByDefault());
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ScalableLightweightSystem.java
@@ -85,7 +85,7 @@ public class ScalableLightweightSystem extends LightweightSystem {
 		@Deprecated(forRemoval = true, since = "2026-03")
 		@Override
 		public boolean useScaledGraphics() {
-			return false;
+			return InternalDraw2dUtils.useScaledGraphicsByDefault();
 		}
 
 		@Override

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/InternalDraw2dUtils.java
@@ -34,12 +34,27 @@ public class InternalDraw2dUtils {
 	 */
 	private static final String DRAW2D_ENABLE_AUTOSCALE = "draw2d.enableAutoscale"; //$NON-NLS-1$
 
+	/**
+	 * System property that controls if ScaledGraphcis are supposed to be used
+	 * instead of SWTGraphics by default.
+	 * <p>
+	 * The current default is "false".
+	 */
+	private static final String DRAW2D_SCALEDGRAPHICS_BY_DEFAULT = "draw2d.useScaledGraphicsByDefault"; //$NON-NLS-1$
+
 	private static final boolean enableAutoScale = "win32".equals(SWT.getPlatform()) //$NON-NLS-1$
 			&& Boolean.parseBoolean(System.getProperty(DRAW2D_ENABLE_AUTOSCALE, Boolean.TRUE.toString()))
 			&& SWT.getVersion() >= 4971; // SWT 2025-12 release or higher
 
+	private static final boolean useScaledGraphicsByDefault = Boolean
+			.parseBoolean(System.getProperty(DRAW2D_SCALEDGRAPHICS_BY_DEFAULT, Boolean.FALSE.toString()));
+
 	public static boolean isAutoScaleEnabled() {
 		return enableAutoScale;
+	}
+
+	public static boolean useScaledGraphicsByDefault() {
+		return useScaledGraphicsByDefault;
 	}
 
 	public static void configureForAutoscalingMode(Control control, Consumer<Double> zoomConsumer) {

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableFreeformRootEditPart.java
@@ -103,7 +103,7 @@ public class ScalableFreeformRootEditPart extends FreeformGraphicalRootEditPart 
 	 * Constructor for ScalableFreeformRootEditPart
 	 */
 	public ScalableFreeformRootEditPart() {
-		this(false);
+		this(InternalDraw2dUtils.useScaledGraphicsByDefault());
 	}
 
 	/**

--- a/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/editparts/ScalableRootEditPart.java
@@ -148,7 +148,7 @@ public class ScalableRootEditPart extends SimpleRootEditPart implements LayerCon
 	 * Constructor for ScalableRootEditPart
 	 */
 	public ScalableRootEditPart() {
-		this(false);
+		this(InternalDraw2dUtils.useScaledGraphicsByDefault());
 	}
 
 	/**


### PR DESCRIPTION
The default `Graphics` implementation to use was changed from `ScaledGraphics` to `SWTGraphics`. In order to better support the transition from using `ScaledGraphics` to `SWTGraphics`, this change makes the default Graphics implementation configurable. While the default is still changed to `SWTGraphics`, a system property is added that allows to change the default back to ScaledGraphics.

Also see the following and related comments in the `ScaledGraphics` deprecation PR:
- https://github.com/eclipse-gef/gef-classic/pull/901#issuecomment-3854316386