### PR TITLE
Enable advanced mode for DrawableFigureUtilities GC

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/internal/DrawableFigureUtilities.java
@@ -35,12 +35,14 @@ public class DrawableFigureUtilities {
 
 	public DrawableFigureUtilities(Control source) {
 		gc = new GC(source);
+		gc.setAdvanced(true);
 		source.addDisposeListener(e -> {
 			gc.dispose();
 		});
 		source.addListener(SWT.ZoomChanged, event -> {
 			gc.dispose();
 			gc = new GC(source);
+			gc.setAdvanced(true);
 			metrics = null;
 		});
 		appliedFont = gc.getFont();


### PR DESCRIPTION
The `GC` used in `DrawableFigureUtilities` for text extent calculation does currently not have advanced mode enabled. In most usage scenarios, however, the context that uses the extents to render text will have a `GC`with advanced mode enabled, as many `GC` operations such as applying transforms and several draw operations implicitly activate it. As a result, the extents calculated by the `DrawableFigureUtilities` will, in most cases, not return appropriate results. This is the same that has recently been detected and fixed for the plain `FigureUtilities`:
- https://github.com/eclipse-gef/gef-classic/pull/833

And the documentation of the `DrawableFigureUtilities` explicitly states:
> All GC related operations are mirrored from {`@code FigureUtilities`}

This change adapts the `DrawableFigureUtilities` to always use a `GC`in advanced mode for extent calculation. This aligns the implementation with the `FigureUtilities`.

This issue showed up for us with the usage of `DrawableFigureUtilities` in the `LightweightSystem` introduced by:
- https://github.com/eclipse-gef/gef-classic/pull/979