### PR TITLE
Make sure Gate figures start and end with a straight line

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/AndGateFigure.java
@@ -26,12 +26,14 @@ public class AndGateFigure extends GateFigure {
 	private static final Path GATE_OUTLINE = new Path(null);
 
 	static {
+		GATE_OUTLINE.moveTo(4, 9.5f);
+		GATE_OUTLINE.lineTo(4, 8);
 		GATE_OUTLINE.addArc(4, 5, 6, 6, 180, -90);
 		GATE_OUTLINE.lineTo(20, 5);
 		GATE_OUTLINE.addArc(20, 5, 6, 6, 90, -90);
 		GATE_OUTLINE.lineTo(26, 11);
 		GATE_OUTLINE.addArc(4, 11, 22, 18, 0, -180);
-		GATE_OUTLINE.lineTo(4, 8);
+		GATE_OUTLINE.lineTo(4, 9.5f);
 	}
 
 	/**

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/OrGateFigure.java
@@ -26,7 +26,7 @@ public class OrGateFigure extends GateFigure {
 	private static final Path GATE_OUTLINE = new Path(null);
 
 	static {
-		GATE_OUTLINE.moveTo(5, 20);
+		GATE_OUTLINE.moveTo(5, 10);
 		GATE_OUTLINE.lineTo(5, 4);
 		GATE_OUTLINE.lineTo(9, 8);
 		GATE_OUTLINE.lineTo(13, 10);
@@ -36,6 +36,7 @@ public class OrGateFigure extends GateFigure {
 		GATE_OUTLINE.lineTo(25, 4);
 		GATE_OUTLINE.lineTo(25, 20);
 		GATE_OUTLINE.addArc(5, 11, 20, 18, 0, -180);
+		GATE_OUTLINE.lineTo(5, 10);
 	}
 
 	/**

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/XOrGateFigure.java
@@ -30,7 +30,7 @@ public class XOrGateFigure extends GateFigure {
 
 	static {
 		// setup gate outline
-		GATE_OUTLINE.moveTo(5, 20);
+		GATE_OUTLINE.moveTo(5, 10);
 		GATE_OUTLINE.lineTo(5, 8);
 		GATE_OUTLINE.lineTo(9, 12);
 		GATE_OUTLINE.lineTo(13, 14);
@@ -40,6 +40,7 @@ public class XOrGateFigure extends GateFigure {
 		GATE_OUTLINE.lineTo(25, 8);
 		GATE_OUTLINE.lineTo(25, 20);
 		GATE_OUTLINE.addArc(5, 11, 20, 18, 0, -180);
+		GATE_OUTLINE.lineTo(5, 10);
 
 		// setup top curve of gate
 		GATE_TOP.addPoint(5, 4);


### PR DESCRIPTION
Drawing arcs with GDI+ lead to visual artifacts when using fractional scaling and/or anti-alias. This is especially noticeable with the Gate figures, because the right angle that is used to imitate the round border of the figures are not painted with a perfect 90° angle.

To camouflage the problem, we need to make sure that the paint operation starts and ends with a straight line.