### PR TITLE
Fix fit to page, width and height for HiDPI case

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/zoom/AbstractZoomManager.java
@@ -26,6 +26,7 @@ import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PrecisionDimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.internal.Messages;
 
@@ -154,14 +155,18 @@ public abstract class AbstractZoomManager {
 		desired.width -= fig.getInsets().getWidth();
 		desired.height -= fig.getInsets().getHeight();
 
+		Dimension desiredAbsolute = new PrecisionDimension(desired);
+		fig.translateToAbsolute(desiredAbsolute);
+
 		while (fig != getViewport()) {
 			available.width -= fig.getInsets().getWidth();
 			available.height -= fig.getInsets().getHeight();
 			fig = fig.getParent();
 		}
 
-		double scaleX = Math.min(available.width * zoom / desired.width, getMaxZoom());
-		double scaleY = Math.min(available.height * zoom / desired.height, getMaxZoom());
+		double scaleX = Math.min(available.width * zoom / desiredAbsolute.preciseWidth(), getMaxZoom());
+		double scaleY = Math.min(available.height * zoom / desiredAbsolute.preciseHeight(), getMaxZoom());
+
 		if (which == 0) {
 			return scaleX;
 		}


### PR DESCRIPTION
In the current state, using the fit to page entry within the zoom combo box results in the following:

<img width="426" height="453" alt="image" src="https://github.com/user-attachments/assets/3946ea0c-55ca-4d1f-bae2-63e49db63feb" />


Monitor scale 100%:
<img width="2100" height="996" alt="image" src="https://github.com/user-attachments/assets/b6d8edf2-004b-4f6d-930a-ad7b308e5491" />

Monitor scale 175%:
<img width="3153" height="1469" alt="image" src="https://github.com/user-attachments/assets/c66580be-83fc-44b7-917f-3581ce6f7599" />

This fix adresses this issue with the following results:

Monitor scale 100%:
<img width="2108" height="994" alt="image" src="https://github.com/user-attachments/assets/412cdf3a-f343-4b57-9058-cbafefa755fc" />

Monitor scale 175%:
<img width="3150" height="1465" alt="image" src="https://github.com/user-attachments/assets/16bb5d25-d93c-416f-a918-55c9b56340ea" />

This also applies to the entries fit to "width" and fit to "height" to be working again within the HiDPI case. Although fit to "width" had and still has precision issues within the logic editor, this fix works fine for our products GEF based editor.



