### PR TITLE
Introduce LED Font via Eclipse Theme API

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LEDEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LEDEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,11 @@ import java.util.List;
 
 import org.eclipse.swt.accessibility.AccessibleControlEvent;
 import org.eclipse.swt.accessibility.AccessibleEvent;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
+
+import org.eclipse.jface.resource.FontDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
 
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
@@ -30,7 +34,6 @@ import org.eclipse.gef.AccessibleEditPart;
 import org.eclipse.gef.EditPolicy;
 
 import org.eclipse.gef.examples.logicdesigner.LogicMessages;
-import org.eclipse.gef.examples.logicdesigner.figures.FigureFactory;
 import org.eclipse.gef.examples.logicdesigner.figures.LEDFigure;
 import org.eclipse.gef.examples.logicdesigner.model.LED;
 
@@ -41,6 +44,7 @@ public class LEDEditPart extends LogicEditPart {
 
 	private static Image LED_SEL_PRIM_BG;
 	private static Image LED_SEL_SECD_BG;
+	private static FontDescriptor ledDisplayFontDescriptor = null;
 
 	private static Image createImage(String name) {
 		try (InputStream stream = LEDFigure.class.getResourceAsStream(name)) {
@@ -80,7 +84,9 @@ public class LEDEditPart extends LogicEditPart {
 	 */
 	@Override
 	protected IFigure createFigure() {
-		return FigureFactory.createNewLED();
+		IFigure ledFigure = new LEDFigure();
+		ledFigure.setFont(getLEDDisplayFont());
+		return ledFigure;
 	}
 
 	@Override
@@ -123,13 +129,20 @@ public class LEDEditPart extends LogicEditPart {
 		return null;
 	}
 
-	/**
-	 * Returns the Figure of this as a LEDFigure.
-	 *
-	 * @return LEDFigure of this.
-	 */
-	public LEDFigure getLEDFigure() {
-		return (LEDFigure) getFigure();
+	@Override
+	public LEDFigure getFigure() {
+		return (LEDFigure) super.getFigure();
+	}
+
+	private Font getLEDDisplayFont() {
+		return getViewer().getResourceManager().create(getLEDDisplayFontDescriptor());
+	}
+
+	private static FontDescriptor getLEDDisplayFontDescriptor() {
+		if (ledDisplayFontDescriptor == null) {
+			ledDisplayFontDescriptor = JFaceResources.getTextFontDescriptor().setHeight(24);
+		}
+		return ledDisplayFontDescriptor;
 	}
 
 	/**
@@ -156,7 +169,7 @@ public class LEDEditPart extends LogicEditPart {
 	 */
 	@Override
 	public void refreshVisuals() {
-		getLEDFigure().setValue(getLEDModel().getValue());
+		getFigure().setValue(getLEDModel().getValue());
 		super.refreshVisuals();
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
@@ -58,10 +58,6 @@ public class FigureFactory {
 		return conn;
 	}
 
-	public static IFigure createNewLED() {
-		return new LEDFigure();
-	}
-
 	public static IFigure createNewCircuit() {
 		return new CircuitFigure();
 	}

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFeedbackFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LEDFigure.java
@@ -14,9 +14,6 @@ package org.eclipse.gef.examples.logicdesigner.figures;
 
 import static org.eclipse.draw2d.FigureUtilities.getTextExtents;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
-
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Dimension;
@@ -35,7 +32,6 @@ import org.eclipse.gef.examples.logicdesigner.model.LED;
 public class LEDFigure extends NodeFigure implements HandleBounds {
 
 	public static final Dimension SIZE = new Dimension(92, 71);
-	protected static final Font DISPLAY_FONT = new Font(null, "DialogInput", 24, SWT.NORMAL); //$NON-NLS-1$
 	protected static PointList connector = new PointList();
 	protected static PointList bottomConnector = new PointList();
 	protected static Rectangle displayRectangle = new Rectangle(14, 17, 65, 38);
@@ -43,7 +39,6 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 	protected static Rectangle displayHighlight = new Rectangle(14, 17, 66, 39);
 	protected static Point valuePoint = new Point(24, 15);
 	private static final int HORIZONTAL_PADDING = 3;
-	private static final int VERTICAL_OFFSET = -1;
 	private static final int CORNER_RADIUS = 6;
 
 	static {
@@ -109,7 +104,6 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 		c.topDown = false;
 		connectionAnchors.put(LED.TERMINAL_4_OUT, c);
 		outputConnectionAnchors.add(c);
-
 	}
 
 	/**
@@ -172,16 +166,15 @@ public class LEDFigure extends NodeFigure implements HandleBounds {
 	}
 
 	private void drawModernText(Graphics g) {
-		// Calculate centered position within display inlcuding padding
-		Dimension textExtents = getTextExtents(value, DISPLAY_FONT);
+		// Calculate centered position within display including padding
+		Dimension textExtents = getTextExtents(value, getFont());
 		int x = displayRectangle.x + HORIZONTAL_PADDING
 				+ ((displayRectangle.width - 2 * HORIZONTAL_PADDING) - textExtents.width) / 2;
-		int y = displayRectangle.y + (displayRectangle.height - textExtents.height) / 2 + VERTICAL_OFFSET;
+		int y = displayRectangle.y + (displayRectangle.height - textExtents.height) / 2;
 
 		// Draw the value
-		g.setFont(DISPLAY_FONT);
 		g.setForegroundColor(LogicColorConstants.displayTextLED);
-		g.drawText(value, new Point(x, y));
+		g.drawText(value, x, y);
 	}
 
 	/**


### PR DESCRIPTION
In order to have a defined font on all supported OSes an own logic editor theme font for the font to used by the LED figure is introduced. The values are based on the JFace text editor. We cannot directly use the text colors as text editor zooming is changing the values and the default colors have the wrong size.

@ptziegler during the work on this PR I noticed that there are images for the numbers to be displayed by the LED figure in: https://github.com/eclipse-gef/gef-classic/tree/master/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/icons

I also checked the history and noticed that these where used before switching to the font. Now with SVG images in place we could reconsider switching back to the images. As the logic editor is for me a bit a show of of best practices and features of GEF Classic both would fine. WDYT?
