### PR TITLE
Rename `HSLColor` to `HSL`

### DIFF
--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/Draw2dTestSuite.java
@@ -14,7 +14,7 @@
 package org.eclipse.draw2d.test;
 
 import org.eclipse.draw2d.graph.test.DirectedGraphLayoutTest;
-import org.eclipse.draw2d.test.colors.HSLColorTest;
+import org.eclipse.draw2d.test.colors.HSLTest;
 
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
@@ -65,7 +65,7 @@ import org.junit.platform.suite.api.Suite;
 	LabelTest.class,
 	PrecisionTests.class,
 	ScaledGraphicsTest.class,
-	HSLColorTest.class
+	HSLTest.class
 })
 public class Draw2dTestSuite {
 }

--- a/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/colors/HSLTest.java
+++ b/org.eclipse.draw2d.tests/src/org/eclipse/draw2d/test/colors/HSLTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.swt.graphics.RGB;
 
-import org.eclipse.draw2d.colors.HSLColor;
+import org.eclipse.draw2d.colors.HSL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,7 +28,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class HSLColorTest {
+public class HSLTest {
 
 	private static final double UNIT_EPSILON = 0.001;
 	private static final double HUE_EPSILON = 0.1;
@@ -62,7 +62,7 @@ public class HSLColorTest {
 	@MethodSource("colorProvider")
 	@SuppressWarnings("static-method")
 	void testfromRGB(int r, int g, int b, double h, double s, double l) {
-		HSLColor hsl = HSLColor.fromRGB(r, g, b);
+		HSL hsl = HSL.fromRGB(r, g, b);
 
 		assertAll(() -> assertEquals(h, hsl.h(), HUE_EPSILON, "Hue mismatch"), //$NON-NLS-1$
 				() -> assertEquals(s, hsl.s(), UNIT_EPSILON, "Saturation mismatch"), //$NON-NLS-1$
@@ -73,7 +73,7 @@ public class HSLColorTest {
 	@MethodSource("colorProvider")
 	@SuppressWarnings("static-method")
 	void testToRgb(int r, int g, int b, double h, double s, double l) {
-		HSLColor hsl = new HSLColor(h, s, l);
+		HSL hsl = new HSL(h, s, l);
 		RGB result = hsl.toRGB();
 
 		assertAll(() -> assertEquals(r, result.red, "Red mismatch"), //$NON-NLS-1$
@@ -87,7 +87,7 @@ public class HSLColorTest {
 	@SuppressWarnings("static-method")
 	void testFromRgbToRgbRoundtrip() {
 		RGB original = new RGB(255, 0, 0);
-		HSLColor hsl = HSLColor.fromRGB(original);
+		HSL hsl = HSL.fromRGB(original);
 		RGB backToRgb = hsl.toRGB();
 		assertEquals(original, backToRgb, "RGB -> HSL -> RGB should match exactly for primary colors"); //$NON-NLS-1$
 	}
@@ -95,8 +95,8 @@ public class HSLColorTest {
 	@Test
 	@SuppressWarnings("static-method")
 	void testHueWrap() {
-		HSLColor hueZero = new HSLColor(0.0, 1.0, 0.5);
-		HSLColor hueThreeSixty = new HSLColor(360.0, 1.0, 0.5);
+		HSL hueZero = new HSL(0.0, 1.0, 0.5);
+		HSL hueThreeSixty = new HSL(360.0, 1.0, 0.5);
 
 		RGB rgbZero = hueZero.toRGB();
 		RGB rgbThreeSixty = hueThreeSixty.toRGB();
@@ -112,8 +112,8 @@ public class HSLColorTest {
 	})
 	@SuppressWarnings("static-method")
 	void testLighterRelative(double initialL, double percentage, double expectedL) {
-		HSLColor color = new HSLColor(0, 1.0, initialL);
-		HSLColor lighter = color.lighter(percentage);
+		HSL color = new HSL(0, 1.0, initialL);
+		HSL lighter = color.lighter(percentage);
 
 		assertEquals(expectedL, lighter.l(), UNIT_EPSILON, "Lighter should move toward 1.0 relatively"); //$NON-NLS-1$
 	}
@@ -125,8 +125,8 @@ public class HSLColorTest {
 	})
 	@SuppressWarnings("static-method")
 	void testDarkerRelative(double initialL, double percentage, double expectedL) {
-		HSLColor color = new HSLColor(0, 1.0, initialL);
-		HSLColor darker = color.darker(percentage);
+		HSL color = new HSL(0, 1.0, initialL);
+		HSL darker = color.darker(percentage);
 
 		assertEquals(expectedL, darker.l(), UNIT_EPSILON, "Darker should scale toward 0.0"); //$NON-NLS-1$
 	}
@@ -134,9 +134,9 @@ public class HSLColorTest {
 	@Test
 	@SuppressWarnings("static-method")
 	void testHuePreservation() {
-		HSLColor color = new HSLColor(120.0, 0.8, 0.5); // A Green
-		HSLColor lighter = color.lighter(0.3);
-		HSLColor darker = color.darker(0.3);
+		HSL color = new HSL(120.0, 0.8, 0.5); // A Green
+		HSL lighter = color.lighter(0.3);
+		HSL darker = color.darker(0.3);
 
 		assertEquals(color.h(), lighter.h(), "Hue must not change when lightening"); //$NON-NLS-1$
 		assertEquals(color.h(), darker.h(), "Hue must not change when darkening"); //$NON-NLS-1$

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -22,7 +22,7 @@ import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.widgets.Shell;
 
-import org.eclipse.draw2d.colors.HSLColor;
+import org.eclipse.draw2d.colors.HSL;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.internal.InternalDraw2dUtils;
@@ -45,7 +45,7 @@ public class FigureUtilities {
 	 * @since 2.0
 	 */
 	public static Color darker(Color color) {
-		return HSLColor.fromColor(color).darker(0.4).toColor();
+		return HSL.fromColor(color).darker(0.4).toColor();
 	}
 
 	/**
@@ -209,7 +209,7 @@ public class FigureUtilities {
 	 * @since 2.0
 	 */
 	public static Color lighter(Color rgb) {
-		return HSLColor.fromColor(rgb).lighter(0.4).toColor();
+		return HSL.fromColor(rgb).lighter(0.4).toColor();
 	}
 
 	/**

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/colors/HSL.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/colors/HSL.java
@@ -22,7 +22,11 @@ import org.eclipse.pde.api.tools.annotations.NoInstantiate;
 import org.eclipse.pde.api.tools.annotations.NoReference;
 
 /**
- * Represents a color in the HSL (Hue, Saturation, Lightness) color space.
+ * Instances of this class are descriptions of colors in terms of the HSL (Hue,
+ * Saturation, Lightness) color space. A color may be described by its type
+ * (hue) on the color wheel (0° = red, 120° = green and 240° = blue), its
+ * saturation (0% = grey, 100% = full color) and its lightness (0% = black, 50%
+ * = normal, 100% = white).
  *
  * This class is currently in development its API may change.
  *
@@ -38,11 +42,11 @@ import org.eclipse.pde.api.tools.annotations.NoReference;
 @NoExtend
 @NoReference
 @NoInstantiate
-public record HSLColor(double h, double s, double l) {
+public record HSL(double h, double s, double l) {
 
 	private static final double MAX_RGB_VALUE = 255.0;
 
-	public HSLColor {
+	public HSL {
 		if (h < 0 || h > 360) {
 			SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 		}
@@ -61,9 +65,9 @@ public record HSLColor(double h, double s, double l) {
 	 *                   (0.0..1.0).
 	 * @return The lighter color
 	 */
-	public HSLColor darker(double percentage) {
+	public HSL darker(double percentage) {
 		double newL = l * (1 - Math.max(0.0, Math.min(1.0, percentage)));
-		return new HSLColor(h, s, newL);
+		return new HSL(h, s, newL);
 	}
 
 	/**
@@ -85,9 +89,9 @@ public record HSLColor(double h, double s, double l) {
 	 *                   (0.0..1.0).
 	 * @return The lighter color
 	 */
-	public HSLColor lighter(double percentage) {
+	public HSL lighter(double percentage) {
 		double newL = l + (1.0 - l) * Math.max(0.0, Math.min(1.0, percentage));
-		return new HSLColor(h, s, newL);
+		return new HSL(h, s, newL);
 	}
 
 	/**
@@ -96,7 +100,7 @@ public record HSLColor(double h, double s, double l) {
 	 * @param col The RGB color to be transformed.
 	 * @return The color in HSL space.
 	 */
-	public static HSLColor fromColor(Color col) {
+	public static HSL fromColor(Color col) {
 		return fromRGB(col.getRed(), col.getGreen(), col.getBlue());
 	}
 
@@ -106,7 +110,7 @@ public record HSLColor(double h, double s, double l) {
 	 * @param rgb The RGB color to be transformed.
 	 * @return The color in HSL space.
 	 */
-	public static HSLColor fromRGB(RGB rgb) {
+	public static HSL fromRGB(RGB rgb) {
 		return fromRGB(rgb.red, rgb.green, rgb.blue);
 	}
 
@@ -123,7 +127,7 @@ public record HSLColor(double h, double s, double l) {
 	 * @param b The blue component of the source color (0..255).
 	 * @return The color in HSL color space.
 	 */
-	public static HSLColor fromRGB(int r, int g, int b) {
+	public static HSL fromRGB(int r, int g, int b) {
 		final double rRel = r / MAX_RGB_VALUE;
 		final double gRel = g / MAX_RGB_VALUE;
 		final double bRel = b / MAX_RGB_VALUE;
@@ -157,7 +161,7 @@ public record HSLColor(double h, double s, double l) {
 				h += 360.0;
 			}
 		}
-		return new HSLColor(h, s, l);
+		return new HSL(h, s, l);
 	}
 
 	/**


### PR DESCRIPTION
This record represents a color description (similar to RGB) and not an actual color. Renaming the class avoids any confusion with the SWT `Color`.