### PR TITLE
Deprecate XOR-related methods in `Shape`

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -219,6 +219,8 @@ public class FigureUtilities {
 	 * @param s the shape
 	 * @return the ghosted shape
 	 * @since 2.0
+	 * @deprecated XOR is not fully supported on all operating systems when Advanced
+	 *             Mode is enabled.
 	 */
 	@Deprecated(forRemoval = true, since = "2026-06")
 	public static Shape makeGhostShape(Shape s) {

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Shape.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Shape.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -217,7 +217,10 @@ public abstract class Shape extends Figure {
 	 *
 	 * @param b XOR fill state
 	 * @since 2.0
+	 * @deprecated XOR is not fully supported on all operating systems when Advanced
+	 *             Mode is enabled.
 	 */
+	@Deprecated(since = "2026-06")
 	public void setFillXOR(boolean b) {
 		if (xorFill != b) {
 			xorFill = b;
@@ -243,7 +246,10 @@ public abstract class Shape extends Figure {
 	 *
 	 * @param b <code>true</code> if the outline should be XOR'ed
 	 * @since 2.0
+	 * @deprecated XOR is not fully supported on all operating systems when Advanced
+	 *             Mode is enabled.
 	 */
+	@Deprecated(since = "2026-06")
 	public void setOutlineXOR(boolean b) {
 		if (xorOutline != b) {
 			xorOutline = b;
@@ -257,7 +263,10 @@ public abstract class Shape extends Figure {
 	 *
 	 * @param b <code>true</code> if the outline and fill should be XOR'ed
 	 * @since 2.0
+	 * @deprecated XOR is not fully supported on all operating systems when Advanced
+	 *             Mode is enabled.
 	 */
+	@Deprecated(since = "2026-06")
 	public void setXOR(boolean b) {
 		xorOutline = xorFill = b;
 		repaint();

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicResizableEditPolicy.java
@@ -114,7 +114,6 @@ public class LogicResizableEditPolicy extends ResizableEditPolicy {
 			figure = new AndGateFeedbackFigure();
 		} else {
 			figure = new RectangleFigure();
-			((RectangleFigure) figure).setXOR(true);
 			((RectangleFigure) figure).setFill(true);
 			figure.setBackgroundColor(LogicEditorColors.INSTANCE.getGhostFill());
 			figure.setForegroundColor(ColorConstants.white);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicXYLayoutEditPolicy.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/LogicXYLayoutEditPolicy.java
@@ -223,7 +223,6 @@ public class LogicXYLayoutEditPolicy extends org.eclipse.gef.editpolicies.XYLayo
 			figure = new LabelFeedbackFigure();
 		} else {
 			figure = new RectangleFigure();
-			((RectangleFigure) figure).setXOR(true);
 			((RectangleFigure) figure).setFill(true);
 			figure.setBackgroundColor(LogicEditorColors.INSTANCE.getGhostFill());
 			figure.setForegroundColor(ColorConstants.white);

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/CircuitFeedbackFigure.java
@@ -18,7 +18,6 @@ public class CircuitFeedbackFigure extends RectangleFigure {
 
 	public CircuitFeedbackFigure() {
 		this.setFill(false);
-		this.setXOR(true);
 		setBorder(new CircuitFeedbackBorder());
 	}
 

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicFlowFeedbackFigure.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/LogicFlowFeedbackFigure.java
@@ -18,7 +18,6 @@ public class LogicFlowFeedbackFigure extends RectangleFigure {
 
 	public LogicFlowFeedbackFigure() {
 		this.setFill(false);
-		this.setXOR(true);
 		setBorder(new LogicFlowFeedbackBorder());
 	}
 


### PR DESCRIPTION
This is a continuation of f7a00b18852d83a98b4fb11aea0d9c6f4186cba5. XOR is unsupported on Windows when GDI+ (advanced mode) is enabled and returns a black shadow, rather than a blending of the figure and its background. Due to the support for fractional scaling (and the deprecation of `ScaledGraphics`), advanced mode is almost always active on Windows.