### PR TITLE
Fix improper bounds calculation for RelativeLocator when zoomed in #1022

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/RelativeLocator.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/RelativeLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -112,8 +112,9 @@ public class RelativeLocator implements Locator {
 	@Override
 	public void relocate(IFigure target) {
 		IFigure reference = getReferenceFigure();
-		Rectangle targetBounds = new PrecisionRectangle(getReferenceBox().getResized(-1, -1));
+		Rectangle targetBounds = new PrecisionRectangle(getReferenceBox());
 		reference.translateToAbsolute(targetBounds);
+		targetBounds.resize(-1, -1);
 		target.translateToRelative(targetBounds);
 		targetBounds.resize(1, 1);
 

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/GEFTestSuite.java
@@ -33,7 +33,7 @@ import org.junit.platform.suite.api.Suite;
 	PaletteColorProviderTest.class,
 	SWTBotTestSuite.class,
 	DirectEditManagerTest.class,
-	MoveHandleLocatorTests.class,
+	HandleLocatorTests.class,
 	PinnablePaletteStackEditPartTests.class
 })
 public class GEFTestSuite {

--- a/org.eclipse.gef.tests/src/org/eclipse/gef/test/HandleLocatorTests.java
+++ b/org.eclipse.gef.tests/src/org/eclipse/gef/test/HandleLocatorTests.java
@@ -18,19 +18,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.IScalablePane;
-import org.eclipse.draw2d.Locator;
+import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.ScalableLayeredPane;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 import org.eclipse.gef.handles.MoveHandleLocator;
+import org.eclipse.gef.handles.RelativeHandleLocator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class MoveHandleLocatorTests {
+public class HandleLocatorTests {
 	private IScalablePane root;
 	private IFigure figure;
-	private Locator locator;
 
 	@BeforeEach
 	public void setUp() {
@@ -41,18 +41,29 @@ public class MoveHandleLocatorTests {
 		figure.setBounds(new Rectangle(10, 15, 100, 105));
 
 		root.add(figure);
-		locator = new MoveHandleLocator(figure);
 	}
 
 	@Test
-	public void testRelocateWithZoom() {
+	public void testRelocateMoveHandleLocatorWithZoom() {
 		IFigure fig = new Figure();
-		locator.relocate(fig);
+		new MoveHandleLocator(figure).relocate(fig);
 
 		Rectangle bounds = fig.getBounds();
 		assertEquals(20, bounds.x);
 		assertEquals(30, bounds.y);
 		assertEquals(200, bounds.width);
 		assertEquals(210, bounds.height);
+	}
+
+	@Test
+	public void testRelocateRelativeHandleLocatorWithZoom() {
+		IFigure fig = new Figure();
+		new RelativeHandleLocator(figure, PositionConstants.SOUTH_EAST).relocate(fig);
+
+		Rectangle bounds = fig.getBounds();
+		assertEquals(220, bounds.x);
+		assertEquals(240, bounds.y);
+		assertEquals(0, bounds.width);
+		assertEquals(0, bounds.height);
 	}
 }


### PR DESCRIPTION
This is a continuation of 4463d9d0ce13c19d10fbe769d29f28b7345a8cba, where a wrong position when relocating a figure was calculated due to an improper use of the `resize()` method.

When `translateToAbsolute()` is called after a figure has been resized, the amount by which this figure is resized may be multiplied by the current zoom. When this resizing is undone, this multiplier must be taken into consideration, or the resize be done on the absolute coordinates.

Closes https://github.com/eclipse-gef/gef-classic/issues/1022