### PR TITLE
Fix IllegalArgumentException in TextEditor when opened twice #886

### DIFF
--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/TextEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -233,6 +233,8 @@ public class TextEditor extends GraphicalEditor {
 		getGraphicalViewer().setEditPartFactory(new TextEditorEditPartFactory());
 
 		getGraphicalViewer().setContents(doc);
+		// Initial layout is required for Caret calculation
+		getGraphicalViewer().flush();
 	}
 
 	/**


### PR DESCRIPTION
When opening the Text editor, the caret is moved to the first character of the first word. But in order to calculate this location, the layout has to be applied, because it internally creates the text fragments of the underlying `TextFlow`.

This step is required because the Caret location is determined by the call to `getNextVisibleOffset()` in `TextFlow`, which returns -1, if no fragments exist. When the Caret is refreshed in the `TextTool`, this value is then passed via the `TextFlowPart` to the `TextFlow` which then throws the `IllegalArgumentException`.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/886