### PR TITLE
Fixed index out of Bound exception on Graph Demos

### DIFF
--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/graph/GraphTests.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/graph/GraphTests.java
@@ -496,8 +496,7 @@ public class GraphTests {
 	 */
 	private static void shuffleConnections(int[] conns) {
 		for (int i = 0; i < conns.length; i += 2) {
-			int swap = (rand.nextInt() * conns.length % conns.length) / 2;
-			swap *= 2;
+			int swap = rand.nextInt(conns.length / 2) * 2;
 			int temp = conns[i];
 			conns[i] = conns[swap];
 			conns[swap] = temp;


### PR DESCRIPTION
The shuffle operation used an random number generator which could also generate negative numbers.