### PR TITLE
Remove disposal of double-buffering GC in BufferedGraphicsSource

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/BufferedGraphicsSource.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/BufferedGraphicsSource.java
@@ -66,7 +66,6 @@ class BufferedGraphicsSource implements GraphicsSource {
 		 * The imageBuffer may be null if double-buffering was not successful.
 		 */
 		if (imageBuffer != null) {
-			imageGC.dispose();
 			try {
 				// Make sure the SWT resources are properly disposed in case of an error
 				// See https://github.com/eclipse-gef/gef-classic/issues/875


### PR DESCRIPTION
The GC used for rendering the double-buffering image of a BufferedGraphicsSource is currently disposed before the rendered image is drawn back to the actual control.
The image handle for double buffering is created for a best-guess zoom, as the final context and its zoom on which it will be drawn is not known on instantiation of the image (handle). As a consequence, the image can be rendered at a wrong zoom for its final usage, which particularly happen when using Draw2D autoscaling on a non-100%-monitor on Windows. In that case, the image is first rendered at a size that includes the monitor two times. When the GC finally draws the image, that wrong size is compensated by scaling down the image while rendering it to the control again.
This does not only lead to rendering an unnecessarily large buffer image but may also lead to non-sharp results because the image has to be bitmap-scaled down.

This change removes the disposal of the double-buffering GC before the buffer image is drawn. In consequence, the image will be re-rendered for the requested target zoom, because the still-available GC contains all executed operations and re-applies them instead of relying on bitmap-scaling the image that was generated for a wrong zoom.

Contributes to https://github.com/eclipse-gef/gef-classic/issues/983

This change also leads to a performance improvement for the snippets posted in https://github.com/eclipse-gef/gef-classic/issues/983