### PR TITLE
Reduce indirection when creating Logic figures

### DIFF
--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/CircuitEditPart.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/edit/CircuitEditPart.java
@@ -34,7 +34,6 @@ import org.eclipse.gef.editparts.ViewportMouseWheelHelper;
 import org.eclipse.gef.editpolicies.ScrollableSelectionFeedbackEditPolicy;
 
 import org.eclipse.gef.examples.logicdesigner.figures.CircuitFigure;
-import org.eclipse.gef.examples.logicdesigner.figures.FigureFactory;
 
 /**
  * Holds a circuit, which is a container capable of holding other
@@ -60,7 +59,7 @@ public class CircuitEditPart extends LogicContainerEditPart implements IScrollab
 	 */
 	@Override
 	protected IFigure createFigure() {
-		return FigureFactory.createNewCircuit();
+		return new CircuitFigure();
 	}
 
 	@Override

--- a/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
+++ b/org.eclipse.gef.examples.logic/src/org/eclipse/gef/examples/logicdesigner/figures/FigureFactory.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.gef.examples.logicdesigner.figures;
 
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PolygonDecoration;
 import org.eclipse.draw2d.PolylineConnection;
 import org.eclipse.draw2d.RoutingAnimator;
@@ -56,10 +55,6 @@ public class FigureFactory {
 		}
 		conn.setTargetDecoration(arrow);
 		return conn;
-	}
-
-	public static IFigure createNewCircuit() {
-		return new CircuitFigure();
 	}
 
 }


### PR DESCRIPTION
The `createNewCircuit()` method is only called by the `CircuitEditPart` and always return a new instance of the `CircuitFigure` For such simple figures, using a dedicated factory method is excessive, especially when its only called from one class. This method should be inlined instead.