### PR TITLE
Call applyLayout() instead of graph.applyLayout() in inputChanged

### DIFF
--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/viewers/GraphViewer.java
@@ -125,7 +125,7 @@ public class GraphViewer extends AbstractStructuredGraphViewer implements ISelec
 		graph.setDynamicLayout(false);
 		super.inputChanged(input, oldInput);
 		graph.setDynamicLayout(dynamicLayoutEnabled);
-		graph.applyLayout();
+		applyLayout();
 	}
 
 	/**


### PR DESCRIPTION
- This allows sub-classes to over-ride applyLayout()
- See https://github.com/eclipse-gef/gef-classic/discussions/1058