### PR TITLE
Provide finer control of Palette colors

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/DrawerFigure.java
@@ -317,7 +317,7 @@ public class DrawerFigure extends Figure {
 		scrollpane.setLayoutManager(new OverlayScrollPaneLayout());
 		scrollpane.setContents(new Figure());
 		scrollpane.getContents().setOpaque(true);
-		scrollpane.getContents().setBackgroundColor(colorProvider.getListBackground());
+		scrollpane.getContents().setBackgroundColor(colorProvider.getDrawerEditPartBackground());
 	}
 
 	@SuppressWarnings("static-method")

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/GroupEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/GroupEditPart.java
@@ -44,7 +44,7 @@ public class GroupEditPart extends PaletteEditPart {
 	public IFigure createFigure() {
 		Figure figure = new Figure();
 		figure.setOpaque(true);
-		figure.setBackgroundColor(getColorProvider().getListBackground());
+		figure.setBackgroundColor(getColorProvider().getGroupEditPartBackground());
 		return figure;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SliderPaletteEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/SliderPaletteEditPart.java
@@ -32,7 +32,7 @@ public class SliderPaletteEditPart extends PaletteEditPart {
 		Figure figure = new Figure();
 		figure.setOpaque(true);
 		figure.setForegroundColor(getColorProvider().getListForeground());
-		figure.setBackgroundColor(getColorProvider().getListBackground());
+		figure.setBackgroundColor(getColorProvider().getSliderPaletteEditPartBackground());
 		return figure;
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolbarEditPart.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/ToolbarEditPart.java
@@ -58,7 +58,7 @@ public class ToolbarEditPart extends GroupEditPart {
 
 		};
 		figure.setOpaque(true);
-		figure.setBackgroundColor(getColorProvider().getButton());
+		figure.setBackgroundColor(getColorProvider().getToolbarEditPartBackground());
 		figure.setBorder(new MarginBorder(2, 1, 1, 1));
 
 		return figure;

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -1158,8 +1158,8 @@ public class FlyoutPaletteComposite extends Composite {
 			graphics.pushState();
 			org.eclipse.draw2d.geometry.Rectangle r = org.eclipse.draw2d.geometry.Rectangle.SINGLETON;
 			r.setBounds(getBounds());
-			graphics.setForegroundColor(getColorProvider().getListBackground());
-			graphics.setBackgroundColor(getColorProvider().getButton());
+			graphics.setForegroundColor(getColorProvider().getTitleForeground());
+			graphics.setBackgroundColor(getColorProvider().getTitleBackground());
 			graphics.fillGradient(r, true);
 
 			// draw bottom border
@@ -1316,8 +1316,8 @@ public class FlyoutPaletteComposite extends Composite {
 				graphics.pushState();
 				org.eclipse.draw2d.geometry.Rectangle r = org.eclipse.draw2d.geometry.Rectangle.SINGLETON;
 				r.setBounds(getBounds());
-				graphics.setForegroundColor(getColorProvider().getListBackground());
-				graphics.setBackgroundColor(getColorProvider().getButton());
+				graphics.setForegroundColor(getColorProvider().getTitleForeground());
+				graphics.setBackgroundColor(getColorProvider().getTitleBackground());
 				graphics.fillGradient(r, true);
 				graphics.popState();
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteColorProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteColorProvider.java
@@ -100,6 +100,32 @@ public class PaletteColorProvider extends GEFColorProvider {
 		return ColorConstants.listForeground;
 	}
 
+	@Override
+	public Color getTitleForeground() {
+		return getListBackground();
+	}
+
+	@Override
+	public Color getTitleBackground() {
+		return getButton();
+	}
+
+	public Color getToolbarEditPartBackground() {
+		return getButton();
+	}
+
+	public Color getGroupEditPartBackground() {
+		return getListBackground();
+	}
+
+	public Color getSliderPaletteEditPartBackground() {
+		return getListBackground();
+	}
+
+	public Color getDrawerEditPartBackground() {
+		return getListBackground();
+	}
+
 	/**
 	 * Returns the mix of {@link #getButton()} with {@link #getButtonDarker()} with
 	 * weight {@code weight}. This weight must be within the interval [0, 1].


### PR DESCRIPTION
This is not intended to be merged. It's a proof of concept of providing finer control over the Palette's colors when using different themes.

I have an extended `PaletteColorProvider` where I want to use a different background color for the Palette. The only thing I can implement is `getListBackground()` but this affects other parts of the Palette such as the title label area. In Archi using my old fork of GEF I hard-coded some hooks into these points.

There are other places where the Palette part colors could be provided.

Do you think this is something that could be implemented? I can provide a more fleshed out PR if needed.