### PR TITLE
[Zest] Only consider monitor zoom on Windows #1055

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/AutoscaleFreeformViewport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Johannes Kepler University Linz and others.
+ * Copyright (c) 2025, 2026 Johannes Kepler University Linz and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -50,6 +50,13 @@ public class AutoscaleFreeformViewport extends FreeformViewport {
 
 	public void setScale(double scale) {
 		getAutoScaleLayerPane().setScale(scale);
+	}
+
+	/**
+	 * @return The underlying monitor zoom.
+	 */
+	public double getScale() {
+		return getAutoScaleLayerPane().getScale();
 	}
 
 	@Override

--- a/org.eclipse.zest.core/.settings/.api_filters
+++ b/org.eclipse.zest.core/.settings/.api_filters
@@ -7,6 +7,26 @@
                 <message_argument value="Graph"/>
             </message_arguments>
         </filter>
+        <filter id="640708718">
+            <message_arguments>
+                <message_argument value="AutoscaleFreeformViewport(boolean)"/>
+                <message_argument value="Graph"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AutoscaleFreeformViewport"/>
+                <message_argument value="Graph"/>
+                <message_argument value="getScale()"/>
+            </message_arguments>
+        </filter>
+        <filter id="640712815">
+            <message_arguments>
+                <message_argument value="AutoscaleFreeformViewport"/>
+                <message_argument value="Graph"/>
+                <message_argument value="setScale(double)"/>
+            </message_arguments>
+        </filter>
     </resource>
     <resource path="src/org/eclipse/zest/core/widgets/GraphConnection.java" type="org.eclipse.zest.core.widgets.GraphConnection$GraphLayoutConnection">
         <filter id="574619656">

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -55,6 +55,7 @@ import org.eclipse.zest.layouts.interfaces.ExpandCollapseManager;
 import org.eclipse.zest.layouts.interfaces.LayoutContext;
 
 import org.eclipse.draw2d.Animation;
+import org.eclipse.draw2d.AutoscaleFreeformViewport;
 import org.eclipse.draw2d.Button;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.ConnectionRouter;
@@ -70,6 +71,7 @@ import org.eclipse.draw2d.ScalableFigure;
 import org.eclipse.draw2d.ScalableFreeformLayeredPane;
 import org.eclipse.draw2d.ScrollPane;
 import org.eclipse.draw2d.TreeSearch;
+import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -181,8 +183,6 @@ public class Graph extends FigureCanvas implements IContainer2 {
 		DARK_BLUE = new Color(Display.getDefault(), 1, 70, 122);
 		LIGHT_YELLOW = new Color(Display.getDefault(), 255, 255, 206);
 
-		this.setViewport(new FreeformViewport());
-
 		this.getVerticalBar().addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
@@ -221,7 +221,9 @@ public class Graph extends FigureCanvas implements IContainer2 {
 			}
 		});
 
-		this.setContents(createLayers());
+		IFigure contents = createLayers();
+		this.setViewport(createViewport());
+		this.setContents(contents);
 		GraphDragSupport dragSupport = createGraphDragSupport();
 		this.getLightweightSystem().getRootFigure().addMouseListener(dragSupport);
 		this.getLightweightSystem().getRootFigure().addMouseMotionListener(dragSupport);
@@ -239,10 +241,6 @@ public class Graph extends FigureCanvas implements IContainer2 {
 		this.subgraphFigures = new HashSet<>();
 		this.zoomListener = new ZoomGestureListener();
 		this.rotateListener = new RotateGestureListener();
-
-		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
-			InternalDraw2dUtils.configureForAutoscalingMode(this, rootlayer::setScale);
-		}
 
 		this.addPaintListener(event -> {
 			if (shouldSheduleLayout) {
@@ -550,7 +548,10 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	public Dimension getPreferredSize() {
 		if (preferredSize.width < 0 || preferredSize.height < 0) {
 			org.eclipse.swt.graphics.Point size = getSize();
-			double scale = getZoomManager().getZoom() * InternalDraw2dUtils.calculateScale(this);
+			double scale = getZoomManager().getZoom();
+			if (getViewport() instanceof AutoscaleFreeformViewport vp) {
+				scale *= vp.getScale();
+			}
 			return new Dimension((int) (size.x / scale + 0.5), (int) (size.y / scale + 0.5));
 		}
 		return preferredSize;
@@ -697,6 +698,15 @@ public class Graph extends FigureCanvas implements IContainer2 {
 	 */
 	protected GraphDragSupport createGraphDragSupport() {
 		return new DragSupport();
+	}
+
+	/* package */ Viewport createViewport() {
+		if (InternalDraw2dUtils.isAutoScaleEnabled()) {
+			AutoscaleFreeformViewport viewport = new AutoscaleFreeformViewport(false);
+			InternalDraw2dUtils.configureForAutoscalingMode(this, viewport::setScale);
+			return viewport;
+		}
+		return new FreeformViewport();
 	}
 
 	// /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a continuation of 377f7e3475a0ee1fa61fa6afb9ff9d55504d506b where the layout bounds of the Zest graph is wrongfully scaled by the monitor zoom on MacOS, even though Draw2D-based scaling is disabled.

Instead of storing both the monitor and the editor zoom in the root figure of the Graph, we instead re-use the `AutoscaleFreeformViewport` to keep track of the monitor zoom, similar to how it's done in the GEF-based viewers. This special viewport is only used when Draw2D-based scaling is enabled (i.e. when running on Windows).