### PR TITLE
Remove redundant call to `InternalDraw2dUtils.calculateScale(this)` #969

### DIFF
--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/FlyoutPaletteComposite.java
@@ -161,7 +161,7 @@ public class FlyoutPaletteComposite extends Composite {
 	private int cachedState = -1;
 	private int cachedLocation = -1;
 	private int cachedTitleHeight = 24; // give it a default value
-	private float scale;
+	private float scale = 1.0f;
 
 	private IPerspectiveListener perspectiveListener = new IPerspectiveListener() {
 		@Override
@@ -192,7 +192,6 @@ public class FlyoutPaletteComposite extends Composite {
 			FlyoutPreferences preferences) {
 		super(parent, style | SWT.NO_BACKGROUND | SWT.NO_REDRAW_RESIZE | SWT.DOUBLE_BUFFERED);
 		InternalDraw2dUtils.configureForAutoscalingMode(this, newScale -> scale = newScale.floatValue());
-		scale = InternalDraw2dUtils.calculateScale(this);
 		provider = pvProvider;
 		prefs = preferences;
 		sash = createSash();


### PR DESCRIPTION
This method is already called within `configureForAutoscalingMode()`, so there is no need to calculate the monitor zoom twice. Moreover, this method must only be called when Draw2D-based scaling is enabled.