### PR TITLE
Remove redundant device parameter from Color constructors

### DIFF
--- a/org.eclipse.draw2d.examples/sandbox/DNDTest.java
+++ b/org.eclipse.draw2d.examples/sandbox/DNDTest.java
@@ -35,7 +35,7 @@ public class DNDTest {
 		shell.setLayout(new FillLayout());
 
 		Canvas dragCanvas = new Canvas(shell, SWT.NONE);
-		dragCanvas.setBackground(new Color(null, 255, 255, 255));
+		dragCanvas.setBackground(new Color(255, 255, 255));
 		dragCanvas.addMouseListener(new MouseListener() {
 			@Override
 			public void mouseDoubleClick(MouseEvent event) {
@@ -71,7 +71,7 @@ public class DNDTest {
 		});
 
 		Canvas dropCanvas = new Canvas(shell, SWT.NONE);
-		dropCanvas.setBackground(new Color(null, 128, 128, 128));
+		dropCanvas.setBackground(new Color(128, 128, 128));
 		DropTarget dt = new DropTarget(dropCanvas, DND.DROP_MOVE | DND.DROP_COPY | DND.DROP_LINK);
 		dt.setTransfer(TextTransfer.getInstance());
 		dt.addDropListener(new DropTargetListener() {

--- a/org.eclipse.draw2d.examples/sandbox/InfoTextLayoutHitTest.java
+++ b/org.eclipse.draw2d.examples/sandbox/InfoTextLayoutHitTest.java
@@ -40,13 +40,13 @@ public class InfoTextLayoutHitTest {
 		final Display display = Display.getDefault();
 		final Shell shell = new Shell();
 
-		wheel[0] = new Color(display, 255, 255, 100);
-		wheel[1] = new Color(display, 255, 160, 160);
-		wheel[2] = new Color(display, 255, 100, 255);
-		wheel[3] = new Color(display, 160, 160, 255);
-		wheel[4] = new Color(display, 100, 255, 255);
-		wheel[5] = new Color(display, 160, 255, 160);
-		defaultColor = new Color(display, 255, 50, 50);
+		wheel[0] = new Color(255, 255, 100);
+		wheel[1] = new Color(255, 160, 160);
+		wheel[2] = new Color(255, 100, 255);
+		wheel[3] = new Color(160, 160, 255);
+		wheel[4] = new Color(100, 255, 255);
+		wheel[5] = new Color(160, 255, 160);
+		defaultColor = new Color(255, 50, 50);
 
 		layout = new TextLayout(display);
 		layout.setFont(font);
@@ -77,7 +77,7 @@ public class InfoTextLayoutHitTest {
 				}
 			}
 		}
-		gc.setForeground(new Color(null, 0, 0, 0));
+		gc.setForeground(new Color(0, 0, 0));
 		layout.draw(gc, 20, 20);
 		gc.dispose();
 

--- a/org.eclipse.draw2d.examples/sandbox/swt/bugs/BidiMixedOrientations.java
+++ b/org.eclipse.draw2d.examples/sandbox/swt/bugs/BidiMixedOrientations.java
@@ -29,8 +29,8 @@ public class BidiMixedOrientations {
 			TextLayout tl = new TextLayout(display);
 			tl.setOrientation(SWT.RIGHT_TO_LEFT);
 			tl.setText("\u202BIBM ABC \ufeeb\ufeec\ufeec"); //$NON-NLS-1$
-			tl.setStyle(new TextStyle(null, new Color(null, 100, 200, 150), null), 2, 2);
-			tl.setStyle(new TextStyle(null, new Color(null, 100, 200, 150), null), 10, 10);
+			tl.setStyle(new TextStyle(null, new Color(100, 200, 150), null), 2, 2);
+			tl.setStyle(new TextStyle(null, new Color(100, 200, 150), null), 10, 10);
 			tl.draw(e.gc, 10, 10);
 			tl.dispose();
 		});

--- a/org.eclipse.draw2d.examples/sandbox/swt/bugs/EscapeStolen.java
+++ b/org.eclipse.draw2d.examples/sandbox/swt/bugs/EscapeStolen.java
@@ -58,7 +58,7 @@ public class EscapeStolen {
 
 			@Override
 			public void focusGained(FocusEvent e) {
-				canvas.setBackground(new Color(null, 30, 30, 255));
+				canvas.setBackground(new Color(30, 30, 255));
 			}
 
 			@Override

--- a/org.eclipse.draw2d.examples/sandbox/swt/bugs/PR_75430.java
+++ b/org.eclipse.draw2d.examples/sandbox/swt/bugs/PR_75430.java
@@ -30,7 +30,7 @@ public class PR_75430 {
 		final Canvas parent = new Canvas(shell, SWT.BORDER);
 		layout.topControl = parent;
 		Composite child = new Composite(parent, SWT.NONE);
-		child.setBackground(new Color(null, 255, 0, 0));
+		child.setBackground(new Color(255, 0, 0));
 		child.setBounds(100, 100, 50, 50);
 		shell.setSize(250, 250);
 		shell.open();
@@ -42,7 +42,7 @@ public class PR_75430 {
 				parent.scroll(0, -20, 0, 0, 250, 250, true);
 				parent.update();
 				GC gc = new GC(parent);
-				gc.setBackground(new Color(null, 200, 230, 240));
+				gc.setBackground(new Color(200, 230, 240));
 				gc.fillRectangle(0, 0, 250, 230);
 				gc.drawRectangle(0, 20, 249, 229);
 				gc.dispose();

--- a/org.eclipse.draw2d.examples/sandbox/swt/transforms/TextSize.java
+++ b/org.eclipse.draw2d.examples/sandbox/swt/transforms/TextSize.java
@@ -45,7 +45,7 @@ public class TextSize extends AbstractSWTTransform {
 	@Override
 	protected Shell createShell(Display display) {
 		Shell shell = super.createShell(display);
-		shell.setBackground(new Color(null, 60, 100, 255));
+		shell.setBackground(new Color(60, 100, 255));
 		return shell;
 	}
 }

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/CaretExample.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/text/CaretExample.java
@@ -49,7 +49,7 @@ public class CaretExample extends AbstractExample {
 		final FlowPage page = new FlowPage() {
 			@Override
 			protected void paintFigure(org.eclipse.draw2d.Graphics graphics) {
-				graphics.setBackgroundColor(new Color(null, 190, 220, 250));
+				graphics.setBackgroundColor(new Color(190, 220, 250));
 				graphics.fillRectangle(getBounds());
 			}
 		};

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/tree/PageNode.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/tree/PageNode.java
@@ -35,12 +35,12 @@ import org.eclipse.draw2d.geometry.Rectangle;
 public class PageNode extends Figure {
 
 	private boolean selected;
-	static final Color gradient1 = new Color(null, 232, 232, 240);
-	static final Color gradient2 = new Color(null, 176, 184, 216);
-	static final Color corner1 = new Color(null, 200, 208, 223);
-	static final Color corner2 = new Color(null, 160, 172, 200);
-	static final Color blue = new Color(null, 152, 168, 200);
-	static final Color shadow = new Color(null, 202, 202, 202);
+	static final Color gradient1 = new Color(232, 232, 240);
+	static final Color gradient2 = new Color(176, 184, 216);
+	static final Color corner1 = new Color(200, 208, 223);
+	static final Color corner2 = new Color(160, 172, 200);
+	static final Color blue = new Color(152, 168, 200);
+	static final Color shadow = new Color(202, 202, 202);
 
 	static final int CORNER_SIZE = 10;
 	static final Border BORDER = new CompoundBorder(new FoldedPageBorder(), new MarginBorder(4, 4, 8, 3));

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/uml/UMLClassFigure.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/uml/UMLClassFigure.java
@@ -30,7 +30,7 @@ import org.eclipse.draw2d.geometry.Insets;
 
 public class UMLClassFigure extends Figure {
 
-	static final Color BG = new Color(null, 242, 240, 255);
+	static final Color BG = new Color(242, 240, 255);
 
 	static Image classImage = new Image(null, UMLClassFigure.class.getResourceAsStream("class_obj.gif")); //$NON-NLS-1$
 

--- a/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/zoom/UMLClassFigure.java
+++ b/org.eclipse.draw2d.examples/src/org/eclipse/draw2d/examples/zoom/UMLClassFigure.java
@@ -26,7 +26,7 @@ import org.eclipse.draw2d.ToolbarLayout;
 public class UMLClassFigure extends Figure {
 
 	/** Background color of UMLFigure */
-	public static final Color CLASS_COLOR = new Color(null, 255, 255, 206);
+	public static final Color CLASS_COLOR = new Color(255, 255, 206);
 
 	/** CompartmentFigures */
 	private final CompartmentFigure attributeFigure = new CompartmentFigure();

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/BasicColorProvider.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/BasicColorProvider.java
@@ -119,11 +119,11 @@ public class BasicColorProvider implements ColorProvider {
 
 	@Override
 	public Color getListHoverBackgroundColor() {
-		return new Color(null, 252, 228, 179);
+		return new Color(252, 228, 179);
 	}
 
 	@Override
 	public Color getListSelectedBackgroundColor() {
-		return new Color(null, 207, 227, 250);
+		return new Color(207, 227, 250);
 	}
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/ColorConstants.java
@@ -151,34 +151,34 @@ public interface ColorConstants {
 	 * Misc. colors
 	 */
 	/** One of the pre-defined colors */
-	Color white = new Color(null, 255, 255, 255);
+	Color white = new Color(255, 255, 255);
 	/** One of the pre-defined colors */
-	Color lightGray = new Color(null, 192, 192, 192);
+	Color lightGray = new Color(192, 192, 192);
 	/** One of the pre-defined colors */
-	Color gray = new Color(null, 128, 128, 128);
+	Color gray = new Color(128, 128, 128);
 	/** One of the pre-defined colors */
-	Color darkGray = new Color(null, 64, 64, 64);
+	Color darkGray = new Color(64, 64, 64);
 	/** One of the pre-defined colors */
-	Color black = new Color(null, 0, 0, 0);
+	Color black = new Color(0, 0, 0);
 	/** One of the pre-defined colors */
-	Color red = new Color(null, 255, 0, 0);
+	Color red = new Color(255, 0, 0);
 	/** One of the pre-defined colors */
-	Color orange = new Color(null, 255, 196, 0);
+	Color orange = new Color(255, 196, 0);
 	/** One of the pre-defined colors */
-	Color yellow = new Color(null, 255, 255, 0);
+	Color yellow = new Color(255, 255, 0);
 	/** One of the pre-defined colors */
-	Color green = new Color(null, 0, 255, 0);
+	Color green = new Color(0, 255, 0);
 	/** One of the pre-defined colors */
-	Color lightGreen = new Color(null, 96, 255, 96);
+	Color lightGreen = new Color(96, 255, 96);
 	/** One of the pre-defined colors */
-	Color darkGreen = new Color(null, 0, 127, 0);
+	Color darkGreen = new Color(0, 127, 0);
 	/** One of the pre-defined colors */
-	Color cyan = new Color(null, 0, 255, 255);
+	Color cyan = new Color(0, 255, 255);
 	/** One of the pre-defined colors */
-	Color lightBlue = new Color(null, 127, 127, 255);
+	Color lightBlue = new Color(127, 127, 255);
 	/** One of the pre-defined colors */
-	Color blue = new Color(null, 0, 0, 255);
+	Color blue = new Color(0, 0, 255);
 	/** One of the pre-defined colors */
-	Color darkBlue = new Color(null, 0, 0, 127);
+	Color darkBlue = new Color(0, 0, 127);
 
 }

--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/FigureUtilities.java
@@ -36,7 +36,7 @@ public class FigureUtilities {
 	private static Font appliedFont;
 	private static FontMetrics metrics;
 	@Deprecated(forRemoval = true, since = "2026-06")
-	private static Color ghostFillColor = new Color(null, 31, 31, 31);
+	private static Color ghostFillColor = new Color(31, 31, 31);
 
 	/**
 	 * Returns a new Color the same as the passed color in a darker hue.
@@ -238,7 +238,7 @@ public class FigureUtilities {
 	 * @since 2.0
 	 */
 	public static Color mixColors(Color c1, Color c2, double weight) {
-		return new Color(null, (int) (c1.getRed() * weight + c2.getRed() * (1 - weight)),
+		return new Color((int) (c1.getRed() * weight + c2.getRed() * (1 - weight)),
 				(int) (c1.getGreen() * weight + c2.getGreen() * (1 - weight)),
 				(int) (c1.getBlue() * weight + c2.getBlue() * (1 - weight)));
 	}
@@ -252,7 +252,7 @@ public class FigureUtilities {
 	 * @since 2.0
 	 */
 	public static Color mixColors(Color c1, Color c2) {
-		return new Color(null, (c1.getRed() + c2.getRed()) / 2, (c1.getGreen() + c2.getGreen()) / 2,
+		return new Color((c1.getRed() + c2.getRed()) / 2, (c1.getGreen() + c2.getGreen()) / 2,
 				(c1.getBlue() + c2.getBlue()) / 2);
 	}
 

--- a/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/policies/ActivityContainerHighlightEditPolicy.java
+++ b/org.eclipse.gef.examples.flow/src/org/eclipse/gef/examples/flow/policies/ActivityContainerHighlightEditPolicy.java
@@ -27,7 +27,7 @@ import org.eclipse.gef.editpolicies.GraphicalEditPolicy;
 public class ActivityContainerHighlightEditPolicy extends GraphicalEditPolicy {
 
 	private Color revertColor;
-	private static Color highLightColor = new Color(null, 200, 200, 240);
+	private static Color highLightColor = new Color(200, 200, 240);
 
 	/**
 	 * @see org.eclipse.gef.EditPolicy#eraseTargetFeedback(org.eclipse.gef.Request)

--- a/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/figures/StyleConstants.java
+++ b/org.eclipse.gef.examples.text/src/org/eclipse/gef/examples/text/figures/StyleConstants.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 
 public class StyleConstants {
-	public static final Color CODE_FG = new Color(null, 0, 0, 32);
+	public static final Color CODE_FG = new Color(0, 0, 32);
 	public static final Font COURIER = new Font(null, "Courier New", 10, 0); //$NON-NLS-1$
 	public static final Font COURIER_BOLD = new Font(null, "Courier New", 10, SWT.BOLD); //$NON-NLS-1$
 	public static final Font COMMENT = new Font(null, "Arial", 10, 0); //$NON-NLS-1$

--- a/org.eclipse.gef.examples/src/org/eclipse/gef/examples/palette/PaletteSnippet3.java
+++ b/org.eclipse.gef.examples/src/org/eclipse/gef/examples/palette/PaletteSnippet3.java
@@ -111,7 +111,7 @@ public class PaletteSnippet3 extends ViewPart {
 			int r = Math.max(0, Math.min(color.getRed() + delta, 255));
 			int g = Math.max(0, Math.min(color.getGreen() + delta, 255));
 			int b = Math.max(0, Math.min(color.getBlue() + delta, 255));
-			return new Color(color.getDevice(), r, g, b);
+			return new Color(r, g, b);
 		}
 	}
 

--- a/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackFigure.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/internal/ui/palette/editparts/PinnablePaletteStackFigure.java
@@ -47,7 +47,7 @@ import org.eclipse.gef.ui.palette.PaletteViewerPreferences;
 public class PinnablePaletteStackFigure extends Figure {
 
 	private static final Dimension EMPTY_DIMENSION = new Dimension(0, 0);
-	private static final Color ARROW_HOVER = new Color(null, 229, 229, 219);
+	private static final Color ARROW_HOVER = new Color(229, 229, 219);
 
 	static final int ARROW_WIDTH = 9;
 

--- a/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteColorProvider.java
+++ b/org.eclipse.gef/src/org/eclipse/gef/ui/palette/PaletteColorProvider.java
@@ -37,8 +37,8 @@ import org.eclipse.gef.internal.ui.palette.editparts.PinFigure;
  * @since 3.20
  */
 public class PaletteColorProvider extends GEFColorProvider {
-	private static final Color HOVER_COLOR_HICONTRAST = new Color(null, 0, 128, 0);
-	private static final Color SELECTED_COLOR_HICONTRAST = new Color(null, 128, 0, 128);
+	private static final Color HOVER_COLOR_HICONTRAST = new Color(0, 128, 0);
+	private static final Color SELECTED_COLOR_HICONTRAST = new Color(128, 0, 128);
 	private final Map<Double, Color> mixedButtonDarker = new HashMap<>();
 	private final Map<Double, Color> mixedListBackground = new HashMap<>();
 	private Color hotspotColor;

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/Graph.java
@@ -186,11 +186,11 @@ public class Graph extends FigureCanvas implements IContainer2 {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
 		this.setBackground(ColorConstants.white);
 
-		LIGHT_BLUE = new Color(Display.getDefault(), 216, 228, 248);
-		LIGHT_BLUE_CYAN = new Color(Display.getDefault(), 213, 243, 255);
-		GREY_BLUE = new Color(Display.getDefault(), 139, 150, 171);
-		DARK_BLUE = new Color(Display.getDefault(), 1, 70, 122);
-		LIGHT_YELLOW = new Color(Display.getDefault(), 255, 255, 206);
+		LIGHT_BLUE = new Color(216, 228, 248);
+		LIGHT_BLUE_CYAN = new Color(213, 243, 255);
+		GREY_BLUE = new Color(139, 150, 171);
+		DARK_BLUE = new Color(1, 70, 122);
+		LIGHT_YELLOW = new Color(255, 255, 206);
 
 		this.getVerticalBar().addSelectionListener(new SelectionAdapter() {
 			@Override

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/custom/TriangleSubgraph.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/custom/TriangleSubgraph.java
@@ -213,7 +213,7 @@ public class TriangleSubgraph extends FigureSubgraph {
 				+ ((double) 255 - parameters.color.getGreen()) / avgNumOfChildrenInSugbraph);
 		int b = (int) (parameters.color.getBlue()
 				+ ((double) 255 - parameters.color.getBlue()) / avgNumOfChildrenInSugbraph);
-		figure.setBackgroundColor(new Color(parameters.color.getDevice(), r, g, b));
+		figure.setBackgroundColor(new Color(r, g, b));
 		figure.setForegroundColor(parameters.color);
 	}
 

--- a/org.eclipse.zest.examples.layouts/src/org/eclipse/zest/layouts/exampleUses/SimpleSWTExample.java
+++ b/org.eclipse.zest.examples.layouts/src/org/eclipse/zest/layouts/exampleUses/SimpleSWTExample.java
@@ -58,15 +58,15 @@ import org.eclipse.zest.layouts.exampleStructures.SimpleRelationship;
  */
 public class SimpleSWTExample {
 
-	private static final Color BLACK = new Color(Display.getDefault(), 0, 0, 0);
-	private static final Color NODE_NORMAL_COLOR = new Color(Display.getDefault(), 225, 225, 255);
-	private static final Color NODE_SELECTED_COLOR = new Color(Display.getDefault(), 255, 125, 125);
-	private static final Color NODE_ADJACENT_COLOR = new Color(Display.getDefault(), 255, 200, 125);
-	private static final Color BORDER_NORMAL_COLOR = new Color(Display.getDefault(), 0, 0, 0);
-	private static final Color BORDER_SELECTED_COLOR = new Color(Display.getDefault(), 255, 0, 0);
-	private static final Color BORDER_ADJACENT_COLOR = new Color(Display.getDefault(), 255, 128, 0);
-	private static final Color RELATIONSHIP_COLOR = new Color(Display.getDefault(), 192, 192, 225);
-	private static final Color RELATIONSHIP_HIGHLIGHT_COLOR = new Color(Display.getDefault(), 255, 200, 125);
+	private static final Color BLACK = new Color(0, 0, 0);
+	private static final Color NODE_NORMAL_COLOR = new Color(225, 225, 255);
+	private static final Color NODE_SELECTED_COLOR = new Color(255, 125, 125);
+	private static final Color NODE_ADJACENT_COLOR = new Color(255, 200, 125);
+	private static final Color BORDER_NORMAL_COLOR = new Color(0, 0, 0);
+	private static final Color BORDER_SELECTED_COLOR = new Color(255, 0, 0);
+	private static final Color BORDER_ADJACENT_COLOR = new Color(255, 128, 0);
+	private static final Color RELATIONSHIP_COLOR = new Color(192, 192, 225);
+	private static final Color RELATIONSHIP_HIGHLIGHT_COLOR = new Color(255, 200, 125);
 
 	@SuppressWarnings("nls")
 	private static final String[] NAMES = { "Peggy", "Rob", "Ian", "Chris", "Simon", "Wendy", "Steven", "Kim", "Neil",
@@ -195,7 +195,7 @@ public class SimpleSWTExample {
 		mainComposite.setLayoutData(mainGridData);
 		mainComposite.addPaintListener(new GraphPaintListener());
 
-		mainComposite.setBackground(new Color(Display.getCurrent(), 255, 255, 255));
+		mainComposite.setBackground(new Color(255, 255, 255));
 		mainComposite.setLayout(null);
 
 		mainComposite.addMouseMoveListener(e -> {

--- a/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/UMLExample.java
+++ b/org.eclipse.zest.examples/src/org/eclipse/zest/examples/uml/UMLExample.java
@@ -106,7 +106,7 @@ public class UMLExample {
 		Display d = shell.getDisplay();
 		shell.setLayout(new FillLayout());
 		shell.setSize(400, 400);
-		classColor = new Color(null, 255, 255, 206);
+		classColor = new Color(255, 255, 206);
 
 		Font classFont = new Font(null, "Arial", 12, SWT.BOLD);
 		Image classImage = new Image(Display.getDefault(), UMLClassFigure.class.getResourceAsStream("class_obj.gif"));


### PR DESCRIPTION
Since SWT version 3.115 it is not necessary to use the Color(Device, int, int, int) constructor

It may be that the old Color constructor will be deprecated in the near future