### PR TITLE
Replace deprecated Color constructors that take a Device parameter

### DIFF
--- a/org.eclipse.draw2d.examples/sandbox/InfoTextLayoutHitTest.java
+++ b/org.eclipse.draw2d.examples/sandbox/InfoTextLayoutHitTest.java
@@ -51,7 +51,7 @@ public class InfoTextLayoutHitTest {
 		layout = new TextLayout(display);
 		layout.setFont(font);
 		layout.setText("GEF! @ This is a test for hit testing \ufeec\ufeeb\ufeed bidi"); ////$NON-NLS-1$
-		// layout.setStyle(new TextStyle(null, new Color(null, 100, 200, 150), null),
+		// layout.setStyle(new TextStyle(null, new Color(100, 200, 150), null),
 		// 10, 13);
 
 		int width = 290;

--- a/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/CloudOptionsComposite.java
+++ b/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/CloudOptionsComposite.java
@@ -226,7 +226,7 @@ public class CloudOptionsComposite extends Composite {
 	@SuppressWarnings("static-method")
 	protected Image createImageFromColor(RGB rgb, int size) {
 		Image image;
-		Color color = new Color(Display.getDefault(), rgb);
+		Color color = new Color(rgb);
 		image = new Image(Display.getDefault(), size, size);
 		GC gc = new GC(image);
 		gc.setBackground(color);
@@ -353,7 +353,7 @@ public class CloudOptionsComposite extends Composite {
 					return;
 				}
 				Color old = viewer.getCloud().getBackground();
-				Color c = new Color(Display.getDefault(), color);
+				Color c = new Color(color);
 				viewer.getCloud().setBackground(c);
 				old.dispose();
 				viewer.getCloud().redrawTextLayerImage();
@@ -381,7 +381,7 @@ public class CloudOptionsComposite extends Composite {
 					return;
 				}
 				Color old = viewer.getCloud().getSelectionColor();
-				Color c = new Color(Display.getDefault(), color);
+				Color c = new Color(color);
 				viewer.getCloud().setSelectionColor(c);
 				old.dispose();
 				viewer.getCloud().redrawTextLayerImage();

--- a/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/TagCloud.java
+++ b/org.eclipse.zest.cloudio/src/org/eclipse/zest/cloudio/TagCloud.java
@@ -224,10 +224,10 @@ public class TagCloud extends Canvas {
 		this.accuracy = accuracy;
 		this.maxSize = maxSize;
 		cloudArea = new Rectangle(0, 0, maxSize, maxSize);
-		highlightColor = new Color(getDisplay(), Display.getDefault().getSystemColor(SWT.COLOR_RED).getRGB());
+		highlightColor = new Color(Display.getDefault().getSystemColor(SWT.COLOR_RED).getRGB());
 		gc = new GC(this);
 		layouter = new DefaultLayouter(accuracy, accuracy);
-		setBackground(new Color(getDisplay(), Display.getDefault().getSystemColor(SWT.COLOR_BLACK).getRGB()));
+		setBackground(new Color(Display.getDefault().getSystemColor(SWT.COLOR_BLACK).getRGB()));
 		initListeners();
 		textLayerImage = new Image(getDisplay(), 100, 100);
 		zoomFit();

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/ExpandGraphLabel.java
@@ -201,7 +201,7 @@ public class ExpandGraphLabel extends Figure implements ActionListener {
 		int blue = (int) (baseColor.getBlue() * 0.8 + 0.5);
 		int red = (int) (baseColor.getRed() * 0.8 + 0.5);
 		int green = (int) (baseColor.getGreen() * 0.8 + 0.5);
-		Color darkerBackground = new Color(Display.getCurrent(), new RGB(red, green, blue));
+		Color darkerBackground = new Color(new RGB(red, green, blue));
 		graphics.setForegroundColor(darkerBackground);
 		graphics.setBackgroundColor(getBackgroundColor());
 

--- a/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
+++ b/org.eclipse.zest.core/src/org/eclipse/zest/core/widgets/internal/GraphLabel.java
@@ -154,7 +154,7 @@ public class GraphLabel extends CachedLabel implements IStyleableFigure {
 		green = (int) (green - (green * 0.20));
 		green = green > 0 ? green : 0;
 
-		Color lightenColor = new Color(Display.getCurrent(), new RGB(red, green, blue));
+		Color lightenColor = new Color(new RGB(red, green, blue));
 		graphics.setForegroundColor(lightenColor);
 		graphics.setBackgroundColor(getBackgroundColor());
 

--- a/org.eclipse.zest.examples.cloudio/src/org/eclipse/zest/examples/cloudio/application/ui/TypeLabelProvider.java
+++ b/org.eclipse.zest.examples.cloudio/src/org/eclipse/zest/examples/cloudio/application/ui/TypeLabelProvider.java
@@ -135,7 +135,7 @@ public class TypeLabelProvider extends BaseLabelProvider implements IEditableClo
 		colorList.clear();
 		colors.clear();
 		for (RGB color : newColors) {
-			Color c = new Color(Display.getDefault(), color);
+			Color c = new Color(color);
 			colorList.add(c);
 		}
 	}

--- a/org.eclipse.zest.tests/src/org/eclipse/zest/tests/cloudio/TestLabelProvider.java
+++ b/org.eclipse.zest.tests/src/org/eclipse/zest/tests/cloudio/TestLabelProvider.java
@@ -23,7 +23,7 @@ public class TestLabelProvider extends BaseLabelProvider implements ICloudLabelP
 
 	public static final double WEIGHT = 0.987D;
 	public static final float ANGLE = 12.34F;
-	public static Color COLOR = new Color(Display.getDefault(), new RGB(100, 100, 100));
+	public static Color COLOR = new Color(new RGB(100, 100, 100));
 	public static FontData[] FONT_DATA = Display.getDefault().getShells()[0].getFont().getFontData();
 
 	@Override


### PR DESCRIPTION
## Summary

- Replace all usages of deprecated `Color(Device, int, int, int)`, `Color(Device, RGB)`, `Color(Device, RGBA)` and related variants with the modern device-free equivalents `Color(int, int, int)`, `Color(RGB)`, etc.
- This affects 28 files across draw2d, gef, zest core, zest cloudio, and various examples
- All modules compile successfully after the change

Follows the deprecation introduced in eclipse-platform/eclipse.platform.swt#3233.

## Test plan

- [x] All production modules compile (`org.eclipse.draw2d`, `org.eclipse.gef`, `org.eclipse.zest.core`, `org.eclipse.zest.cloudio`)
- [x] All example and test modules compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)